### PR TITLE
Add printer model selection and related functionality

### DIFF
--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -4,6 +4,32 @@
 #include <Arduino.h>
 #include "config.h"
 
+// ---------------------------------------------------------------------------
+//  Printer model enum
+// ---------------------------------------------------------------------------
+enum PrinterModel : uint8_t {
+  MODEL_P1S = 0,
+  MODEL_P1P,
+  MODEL_X1C,
+  MODEL_A1,
+  MODEL_A1_MINI
+};
+
+inline bool hasEnclosure(PrinterModel m) {
+  return (m == MODEL_P1S || m == MODEL_X1C);
+}
+
+inline const char* defaultModelName(PrinterModel m) {
+  switch (m) {
+    case MODEL_P1S:     return "Bambu P1S";
+    case MODEL_P1P:     return "Bambu P1P";
+    case MODEL_X1C:     return "Bambu X1C";
+    case MODEL_A1:      return "Bambu A1";
+    case MODEL_A1_MINI: return "Bambu A1 Mini";
+    default:            return "Bambu Printer";
+  }
+}
+
 struct BambuState {
   bool connected;
   bool printing;
@@ -29,6 +55,7 @@ struct BambuState {
 
 struct PrinterConfig {
   bool enabled;
+  PrinterModel model;         // printer model (determines fan gauge)
   char ip[16];
   char serial[20];
   char accessCode[12];

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -290,7 +290,7 @@ static void drawIdle() {
   // Printer name
   tft.setTextColor(CLR_GREEN, CLR_BG);
   tft.setTextFont(4);
-  const char* name = (p.config.name[0] != '\0') ? p.config.name : "Bambu P1S";
+  const char* name = (p.config.name[0] != '\0') ? p.config.name : defaultModelName(p.config.model);
   tft.drawString(name, SCREEN_W / 2, 30);
 
   // Status badge
@@ -349,7 +349,8 @@ static void drawPrinting() {
   bool fansChanged = forceRedraw ||
                      (s.coolingFanPct != prevState.coolingFanPct) ||
                      (s.auxFanPct != prevState.auxFanPct) ||
-                     (s.chamberFanPct != prevState.chamberFanPct);
+                     (s.chamberFanPct != prevState.chamberFanPct) ||
+                     (s.heatbreakFanPct != prevState.heatbreakFanPct);
   bool stateChanged = forceRedraw ||
                       (strcmp(s.gcodeState, prevState.gcodeState) != 0);
 
@@ -376,7 +377,7 @@ static void drawPrinting() {
     tft.setTextDatum(ML_DATUM);
     tft.setTextFont(2);
     tft.setTextColor(CLR_TEXT, hdrBg);
-    const char* name = (p.config.name[0] != '\0') ? p.config.name : "Bambu P1S";
+    const char* name = (p.config.name[0] != '\0') ? p.config.name : defaultModelName(p.config.model);
     tft.drawString(name, 6, 17);
 
     // State badge (right)
@@ -424,8 +425,11 @@ static void drawPrinting() {
                  s.auxFanPct, dispSettings.auxFan.arc, "Aux", forceRedraw,
                  &dispSettings.auxFan);
 
+    bool enclosed = hasEnclosure(p.config.model);
     drawFanGauge(tft, col3, row2Y, gR,
-                 s.chamberFanPct, dispSettings.chamberFan.arc, "Chamber", forceRedraw,
+                 enclosed ? s.chamberFanPct : s.heatbreakFanPct,
+                 dispSettings.chamberFan.arc,
+                 enclosed ? "Chamber" : "Heatbrk", forceRedraw,
                  &dispSettings.chamberFan);
   }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -101,6 +101,9 @@ void loadSettings() {
     snprintf(key, sizeof(key), "p%d_on", i);
     cfg.enabled = prefs.getBool(key, false);
 
+    snprintf(key, sizeof(key), "p%d_mdl", i);
+    cfg.model = (PrinterModel)prefs.getUChar(key, MODEL_P1S);
+
     snprintf(key, sizeof(key), "p%d_ip", i);
     strlcpy(cfg.ip, prefs.getString(key, "").c_str(), sizeof(cfg.ip));
 
@@ -204,6 +207,9 @@ void savePrinterConfig(uint8_t index) {
 
   snprintf(key, sizeof(key), "p%d_on", index);
   prefs.putBool(key, cfg.enabled);
+
+  snprintf(key, sizeof(key), "p%d_mdl", index);
+  prefs.putUChar(key, cfg.model);
 
   snprintf(key, sizeof(key), "p%d_ip", index);
   prefs.putString(key, cfg.ip);

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -168,8 +168,16 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
     <input type="checkbox" name="enabled" id="enabled" value="1" %ENABLED%>
     <label for="enabled">Enable Monitoring</label>
   </div>
+  <label for="pmodel">Printer Model</label>
+  <select name="pmodel" id="pmodel" onchange="updateFanLabel()">
+    <option value="0" %MDL0%>Bambu Lab P1S</option>
+    <option value="1" %MDL1%>Bambu Lab P1P</option>
+    <option value="2" %MDL2%>Bambu Lab X1C</option>
+    <option value="3" %MDL3%>Bambu Lab A1</option>
+    <option value="4" %MDL4%>Bambu Lab A1 Mini</option>
+  </select>
   <label for="pname">Printer Name</label>
-  <input type="text" name="pname" id="pname" value="%PNAME%" placeholder="My P1S" maxlength="23">
+  <input type="text" name="pname" id="pname" value="%PNAME%" placeholder="My Printer" maxlength="23">
   <label for="ip">Printer IP Address</label>
   <input type="text" name="ip" id="ip" value="%IP%" placeholder="192.168.1.xxx">
   <label for="serial">Serial Number</label>
@@ -272,7 +280,7 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
   </div>
 
   <div class="gauge-section">
-    <h3>Chamber Fan</h3>
+    <h3 id="cfnLabel">Chamber Fan</h3>
     <div class="color-row">
       <label>Arc</label><input type="color" name="cfn_a" id="cfn_a" value="%CFN_A%">
       <label>Label</label><input type="color" name="cfn_l" id="cfn_l" value="%CFN_L%">
@@ -301,6 +309,13 @@ function toggleStatic(){
   document.getElementById('staticFields').style.display=(m==='static')?'block':'none';
 }
 toggleStatic();
+
+function updateFanLabel(){
+  var mdl=parseInt(document.getElementById('pmodel').value);
+  var enclosed=(mdl===0||mdl===2);
+  document.getElementById('cfnLabel').textContent=enclosed?'Chamber Fan':'Heatbreak Fan';
+}
+updateFanLabel();
 
 var themes={
   default:{bg:'#081018',track:'#182028',
@@ -456,6 +471,14 @@ static String processTemplate(const String& html) {
   page.replace("%SSID%", wifiSSID);
   page.replace("%PASS%", wifiPass);
   page.replace("%ENABLED%", cfg.enabled ? "checked" : "");
+
+  // Model dropdown
+  for (uint8_t m = 0; m <= 4; m++) {
+    char ph[8];
+    snprintf(ph, sizeof(ph), "%%MDL%d%%", m);
+    page.replace(ph, cfg.model == m ? "selected" : "");
+  }
+
   page.replace("%PNAME%", cfg.name);
   page.replace("%IP%", cfg.ip);
   page.replace("%SERIAL%", cfg.serial);
@@ -586,6 +609,10 @@ static void handleSave() {
 
   PrinterConfig& cfg = printers[0].config;
   cfg.enabled = server.hasArg("enabled");
+  if (server.hasArg("pmodel")) {
+    uint8_t mdl = server.arg("pmodel").toInt();
+    if (mdl <= MODEL_A1_MINI) cfg.model = (PrinterModel)mdl;
+  }
 
   // Network settings
   netSettings.useDHCP = (!server.hasArg("netmode") || server.arg("netmode") == "dhcp");


### PR DESCRIPTION
This pull request adds support for multiple Bambu Lab printer models, improving how the application handles model-specific behavior and display. The changes introduce a new `PrinterModel` enum, update configuration and UI to allow model selection, and adjust the display logic to show the correct default model name and fan label depending on the selected printer model.

**Printer model support and configuration:**
- Added a `PrinterModel` enum and helper functions (`hasEnclosure`, `defaultModelName`) to `bambu_state.h` for identifying printer models and their characteristics.
- Updated the `PrinterConfig` struct to include a `model` field, and modified settings load/save logic to persist the selected model. [[1]](diffhunk://#diff-a674ce837a6403bb10047711fb1bc936a74dd38f736ba7f70ed040e49f421b46R58) [[2]](diffhunk://#diff-c044ba02ccf7862f1e2f56436d5b92baa7bb35601791846655fb07ac253a8697R104-R106) [[3]](diffhunk://#diff-c044ba02ccf7862f1e2f56436d5b92baa7bb35601791846655fb07ac253a8697R211-R213)

**Display and UI updates:**
- Changed display logic in `drawIdle` and `drawPrinting` to show the default model name if no custom name is set, using the selected printer model. [[1]](diffhunk://#diff-861ef4916bb97a8c0f249fd68f1e7f9c9b7215f2f754592b7e475bfddebcd77cL293-R293) [[2]](diffhunk://#diff-861ef4916bb97a8c0f249fd68f1e7f9c9b7215f2f754592b7e475bfddebcd77cL379-R380)
- Adjusted fan gauge logic in `drawPrinting` to display "Chamber Fan" or "Heatbreak Fan" and use the appropriate sensor value based on whether the selected model has an enclosure.
- Added a printer model dropdown to the web UI, updated the template processor to handle model selection, and implemented dynamic fan label switching in JavaScript based on the selected model. [[1]](diffhunk://#diff-5907a7d9ec23bc8064ec283555cfb47da92bab8e6cc031b557ae9ecf69d31f43R171-R180) [[2]](diffhunk://#diff-5907a7d9ec23bc8064ec283555cfb47da92bab8e6cc031b557ae9ecf69d31f43L275-R283) [[3]](diffhunk://#diff-5907a7d9ec23bc8064ec283555cfb47da92bab8e6cc031b557ae9ecf69d31f43R313-R319) [[4]](diffhunk://#diff-5907a7d9ec23bc8064ec283555cfb47da92bab8e6cc031b557ae9ecf69d31f43R474-R481) [[5]](diffhunk://#diff-5907a7d9ec23bc8064ec283555cfb47da92bab8e6cc031b557ae9ecf69d31f43R612-R615)

**Fan change detection:**
- Included the `heatbreakFanPct` field in the fan change detection logic to ensure updates are triggered appropriately for models without enclosures.