### PR TITLE
Add separate brightness setting for screensaver/clock screen

### DIFF
--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1172,6 +1172,13 @@ static bool isNightHour() {
 }
 
 uint8_t getEffectiveBrightness() {
+  if (currentScreen == SCREEN_CLOCK) {
+    // During night hours, use the dimmer of the two
+    if (dpSettings.nightModeEnabled && isNightHour()) {
+      return min(dpSettings.screensaverBrightness, dpSettings.nightBrightness);
+    }
+    return dpSettings.screensaverBrightness;
+  }
   if (dpSettings.nightModeEnabled && isNightHour()) {
     return dpSettings.nightBrightness;
   }
@@ -1215,8 +1222,9 @@ void updateDisplay() {
 
   // Detect screen change
   if (currentScreen != prevScreen) {
-    // Restore backlight when leaving SCREEN_OFF
-    if (prevScreen == SCREEN_OFF && currentScreen != SCREEN_OFF) {
+    // Restore backlight when leaving SCREEN_OFF or SCREEN_CLOCK
+    if ((prevScreen == SCREEN_OFF || prevScreen == SCREEN_CLOCK) &&
+        currentScreen != SCREEN_OFF && currentScreen != SCREEN_CLOCK) {
       setBacklight(getEffectiveBrightness());
     }
     // Reset text size in case Pong clock left it scaled up
@@ -1229,6 +1237,7 @@ void updateDisplay() {
     if (currentScreen == SCREEN_CLOCK) {
       if (dispSettings.pongClock) resetPongClock();
       else resetClock();
+      setBacklight(getEffectiveBrightness());  // dim for screensaver
     }
     prevScreen = currentScreen;
   }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -262,6 +262,7 @@ void loadSettings() {
   dpSettings.nightStartHour = prefs.getUChar("dp_nstart", 22);
   dpSettings.nightEndHour = prefs.getUChar("dp_nend", 7);
   dpSettings.nightBrightness = prefs.getUChar("dp_nbright", 30);
+  dpSettings.screensaverBrightness = prefs.getUChar("dp_ssbright", 30);
 
   // Rotation settings (multi-printer)
   rotState.mode = (RotateMode)prefs.getUChar("rot_mode", ROTATE_SMART);
@@ -342,6 +343,7 @@ void saveSettings() {
   prefs.putUChar("dp_nstart", dpSettings.nightStartHour);
   prefs.putUChar("dp_nend", dpSettings.nightEndHour);
   prefs.putUChar("dp_nbright", dpSettings.nightBrightness);
+  prefs.putUChar("dp_ssbright", dpSettings.screensaverBrightness);
 
   prefs.end();
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -52,6 +52,8 @@ struct DisplayPowerSettings {
   uint8_t nightStartHour;      // dim start hour (0-23)
   uint8_t nightEndHour;        // dim end hour (0-23)
   uint8_t nightBrightness;     // brightness during night (0-255)
+  // Screensaver dimming (idle/clock screen)
+  uint8_t screensaverBrightness; // brightness when clock/screensaver is active (0-255)
 };
 
 // Button type

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -284,8 +284,14 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
         <label for="keepon">Keep display always on (override timeout)</label>
       </div>
       <div class="check-row">
-        <input type="checkbox" id="clock" value="1" %CLOCK% onchange="toggleSetting('clock',this.checked)">
+        <input type="checkbox" id="clock" value="1" %CLOCK%>
         <label for="clock">Show clock after print (instead of screen off)</label>
+      </div>
+      <div id="ssbrightWrap" style="display:%CLOCKDISP%">
+        <label for="ssbright" style="margin-top:12px;font-size:12px">Screensaver brightness: <span id="ssbrightVal">%SSBRIGHT%</span></label>
+        <input type="range" id="ssbright" min="0" max="255" step="5" value="%SSBRIGHT%"
+               oninput="document.getElementById('ssbrightVal').textContent=this.value;fetch('/brightness?val='+this.value)">
+        <p style="font-size:11px;color:#8B949E;margin-top:4px">Brightness when clock/screensaver is active. Set to 0 to turn off backlight.</p>
       </div>
       <div class="check-row">
         <input type="checkbox" id="dack" value="1" %DACK% onchange="toggleSetting('dack',this.checked)">
@@ -762,6 +768,7 @@ function applyDisplay(){
   p.append('nstart',document.getElementById('nstart').value);
   p.append('nend',document.getElementById('nend').value);
   p.append('nbright',document.getElementById('nbright').value);
+  p.append('ssbright',document.getElementById('ssbright').value);
   p.append('rotation',document.getElementById('rotation').value);
   p.append('fmins',document.getElementById('fmins').value);
   if(document.getElementById('keepon').checked) p.append('keepon','1');
@@ -931,11 +938,13 @@ function startOta(){
   var clk=document.getElementById('clock');
   var pong=document.getElementById('pong');
   var row=document.getElementById('pong-row');
+  var ssw=document.getElementById('ssbrightWrap');
   function upd(){
     pong.disabled=!clk.checked;
     row.style.opacity=clk.checked?'1':'0.4';
+    if(ssw) ssw.style.display=clk.checked?'block':'none';
   }
-  clk.onchange=upd;
+  clk.addEventListener('change',function(){toggleSetting('clock',clk.checked);upd();});
   upd();
 })();
 </script>
@@ -995,6 +1004,7 @@ static void processTemplate(String& page) {
   page.replace("%NIGHTEN%", dpSettings.nightModeEnabled ? "checked" : "");
   page.replace("%NIGHTDISP%", dpSettings.nightModeEnabled ? "block" : "none");
   page.replace("%NBRIGHT%", String(dpSettings.nightBrightness));
+  page.replace("%SSBRIGHT%", String(dpSettings.screensaverBrightness));
   {
     String startOpts, endOpts;
     for (uint8_t h = 0; h < 24; h++) {
@@ -1047,6 +1057,7 @@ static void processTemplate(String& page) {
   // Display power
   page.replace("%FMINS%", String(dpSettings.finishDisplayMins));
   page.replace("%KEEPON%", dpSettings.keepDisplayOn ? "checked" : "");
+  page.replace("%CLOCKDISP%", dpSettings.showClockAfterFinish ? "block" : "none");
   page.replace("%CLOCK%", dpSettings.showClockAfterFinish ? "checked" : "");
   page.replace("%DACK%", dpSettings.doorAckEnabled ? "checked" : "");
   page.replace("%ABAR%", dispSettings.animatedBar ? "checked" : "");
@@ -1135,6 +1146,7 @@ static void readDisplayFromForm() {
   if (server.hasArg("nstart")) dpSettings.nightStartHour = server.arg("nstart").toInt();
   if (server.hasArg("nend"))   dpSettings.nightEndHour = server.arg("nend").toInt();
   if (server.hasArg("nbright")) dpSettings.nightBrightness = server.arg("nbright").toInt();
+  if (server.hasArg("ssbright")) dpSettings.screensaverBrightness = server.arg("ssbright").toInt();
 
   if (server.hasArg("rotation")) {
     uint8_t rot = server.arg("rotation").toInt();
@@ -1545,6 +1557,7 @@ static void handleSettingsExport() {
   dp["nightStartHour"] = dpSettings.nightStartHour;
   dp["nightEndHour"] = dpSettings.nightEndHour;
   dp["nightBrightness"] = dpSettings.nightBrightness;
+  dp["screensaverBrightness"] = dpSettings.screensaverBrightness;
 
   // Network
   JsonObject net = doc["network"].to<JsonObject>();
@@ -1677,6 +1690,7 @@ static void handleSettingsImportFinish() {
     if (dp["nightStartHour"].is<uint8_t>())     dpSettings.nightStartHour = dp["nightStartHour"].as<uint8_t>();
     if (dp["nightEndHour"].is<uint8_t>())       dpSettings.nightEndHour = dp["nightEndHour"].as<uint8_t>();
     if (dp["nightBrightness"].is<uint8_t>())    dpSettings.nightBrightness = dp["nightBrightness"].as<uint8_t>();
+    if (dp["screensaverBrightness"].is<uint8_t>()) dpSettings.screensaverBrightness = dp["screensaverBrightness"].as<uint8_t>();
   }
 
   // Network


### PR DESCRIPTION
## Summary
- Adds a configurable brightness level for the clock/screensaver screen, so the display can automatically dim when idle without affecting brightness during active use
- Slider appears in the web UI under "Show clock after print" (hidden when clock is disabled)
- Respects night mode: during night hours, uses whichever is dimmer (screensaver or night brightness)
- Included in settings export/import; backwards-compatible with existing configs

## Changes
- `settings.h` — new `screensaverBrightness` field
- `settings.cpp` — NVS load/save
- `display_ui.cpp` — brightness logic + screen transitions
- `web_server.cpp` — slider UI, form handling, JSON export/import

## Test plan
- [ ] Set screensaver brightness lower than normal brightness, verify display dims when clock activates
- [ ] Set screensaver brightness higher than night brightness, verify night mode wins during night hours
- [ ] Toggle "Show clock after print" off, verify slider hides
- [ ] Click "Apply Display Settings", reboot, verify value persists
- [ ] Export/import settings, verify screensaver brightness is included
- [ ] Tested on ESP32-S3
- [ ] Test on CYD builds