### PR TITLE
Debounce brightness sliders to avoid flooding ESP32

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -244,7 +244,7 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
     <div class="section-body">
       <label for="bright">Brightness: <span id="brightVal">%BRIGHT%</span></label>
       <input type="range" id="bright" min="10" max="255" value="%BRIGHT%"
-             oninput="document.getElementById('brightVal').textContent=this.value;fetch('/brightness?val='+this.value)">
+             oninput="document.getElementById('brightVal').textContent=this.value;sendBrightness(this.value)">
 
       <div style="margin-top:12px">
         <div class="check-row">
@@ -264,7 +264,7 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
           </div>
           <label for="nbright" style="font-size:12px">Night brightness: <span id="nbrightVal">%NBRIGHT%</span></label>
           <input type="range" id="nbright" min="0" max="255" step="5" value="%NBRIGHT%"
-                 oninput="document.getElementById('nbrightVal').textContent=this.value;fetch('/brightness?val='+this.value)">
+                 oninput="document.getElementById('nbrightVal').textContent=this.value;sendBrightness(this.value)">
           <p style="font-size:11px;color:#8B949E;margin-top:4px">Recommended: 20-50 for night use. Requires NTP time sync.</p>
         </div>
       </div>
@@ -290,7 +290,7 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
       <div id="ssbrightWrap" style="display:%CLOCKDISP%">
         <label for="ssbright" style="margin-top:12px;font-size:12px">Screensaver brightness: <span id="ssbrightVal">%SSBRIGHT%</span></label>
         <input type="range" id="ssbright" min="0" max="255" step="5" value="%SSBRIGHT%"
-               oninput="document.getElementById('ssbrightVal').textContent=this.value;fetch('/brightness?val='+this.value)">
+               oninput="document.getElementById('ssbrightVal').textContent=this.value;sendBrightness(this.value)">
         <p style="font-size:11px;color:#8B949E;margin-top:4px">Brightness when clock/screensaver is active. Set to 0 to turn off backlight.</p>
       </div>
       <div class="check-row">
@@ -553,6 +553,10 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
 <script>
 // --- HTML escape helper ---
 function esc(s){var d=document.createElement('div');d.appendChild(document.createTextNode(s));return d.innerHTML;}
+
+// --- Debounced brightness send ---
+var _brightTimer=null;
+function sendBrightness(val){clearTimeout(_brightTimer);_brightTimer=setTimeout(function(){fetch('/brightness?val='+val);},150);}
 
 // --- Polling timers (started/stopped when sections open/close) ---
 var diagTimer=null,statsTimer=null;


### PR DESCRIPTION
## Summary

- Add 150ms debounce to all three brightness sliders (main, night, screensaver)
- Only the final value is sent to `/brightness` after the user stops dragging

## Context

The brightness sliders fired a fetch request on every `oninput` event. Dragging the slider rapidly could send dozens of HTTP requests per second to the ESP32, potentially overwhelming it. Now a shared `sendBrightness()` helper coalesces rapid inputs with a 150ms debounce timer.

## Test plan

- Built and flashed to device via OTA
- Verified brightness slider still adjusts display brightness
- Confirmed page loads without console errors