### PR TITLE
Add pinout for using ESP32-C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Use a **passive buzzer** and connect it like this:
 | `-` / `GND` | `GND` | `GND` |
 
 > **Note:** The firmware default buzzer pin is `GPIO 5` on both ESP32-S3 and ESP32-C3. The table above shows the **recommended wiring**. If you wire an ESP32-C3 buzzer to `GPIO 3`, you must change the buzzer pin to `GPIO 3` in the web interface after the first boot.
+> **Note:** The firmware default buzzer pin is `GPIO 5` on both ESP32-S3 and ESP32-C3. The table above shows the **recommended wiring**. If you wire an ESP32-C3 buzzer to `GPIO 3`, you must change the buzzer pin to `GPIO 3` in the web interface after the first boot.
 You can change the buzzer GPIO later in the web interface under **Buzzer**. The buzzer can be used for print-finished, connected, and error notifications.
 
 ![wiring](img/wiring.png)


### PR DESCRIPTION
Updated readme.md to include pinout for C3 variant of ESP32. Added the same chart for the optional button.