### PR TITLE
Fix display going blank when applying settings in clock/screensaver mode

### DIFF
--- a/src/clock_mode.cpp
+++ b/src/clock_mode.cpp
@@ -13,7 +13,14 @@ void resetClock() {
 
 void drawClock() {
   struct tm now;
-  if (!getLocalTime(&now, 0)) return;
+  if (!getLocalTime(&now, 0)) {
+    // getLocalTime() fails when SNTP sync status is reset (e.g., after a
+    // timezone change). Fall back to the raw system clock, which remains
+    // valid even without a completed NTP sync.
+    time_t t = time(nullptr);
+    if (t < 1600000000UL) return;  // sanity: before Sep 2020 = clock not set
+    localtime_r(&t, &now);
+  }
 
   // Only redraw when minute changes (resetClock() forces redraw)
   if (now.tm_min == prevMinute) return;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -82,10 +82,13 @@ static bool tickGaugeSmooth(const BambuState& s, bool snap) {
 // ---------------------------------------------------------------------------
 //  Backlight
 // ---------------------------------------------------------------------------
+static uint8_t lastAppliedBrightness = 0;
+
 void setBacklight(uint8_t level) {
 #if defined(BACKLIGHT_PIN) && BACKLIGHT_PIN >= 0
   analogWrite(BACKLIGHT_PIN, level);
 #endif
+  lastAppliedBrightness = level;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,6 +147,12 @@ void applyDisplaySettings() {
   tft.setRotation(dispSettings.rotation);
   tft.fillScreen(dispSettings.bgColor);
   forceRedraw = true;
+  lastDisplayUpdate = 0;  // bypass throttle so redraw is immediate after fillScreen
+  // Reset clock/pong so they redraw fully after fillScreen cleared everything
+  if (currentScreen == SCREEN_CLOCK) {
+    if (dispSettings.pongClock) resetPongClock();
+    else resetClock();
+  }
 }
 
 void triggerDisplayTransition() {
@@ -1263,7 +1272,7 @@ static void drawFinished() {
 //  Night mode — scheduled brightness dimming
 // ---------------------------------------------------------------------------
 static unsigned long lastNightCheck = 0;
-static uint8_t lastAppliedBrightness = 0;
+// lastAppliedBrightness declared near setBacklight() above
 
 static bool isNightHour() {
   struct tm now;

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1257,16 +1257,15 @@ static void readGaugeColorsFromForm(const char* prefix, GaugeColors& gc) {
 //  Read display settings from form args
 // ---------------------------------------------------------------------------
 static void readDisplayFromForm() {
-  if (server.hasArg("bright")) {
-    brightness = server.arg("bright").toInt();
-    setBacklight(getEffectiveBrightness());
-  }
+  if (server.hasArg("bright")) brightness = server.arg("bright").toInt();
   // Night mode
   dpSettings.nightModeEnabled = server.hasArg("nighten");
   if (server.hasArg("nstart")) dpSettings.nightStartHour = server.arg("nstart").toInt();
   if (server.hasArg("nend"))   dpSettings.nightEndHour = server.arg("nend").toInt();
   if (server.hasArg("nbright")) dpSettings.nightBrightness = server.arg("nbright").toInt();
   if (server.hasArg("ssbright")) dpSettings.screensaverBrightness = server.arg("ssbright").toInt();
+  // Apply brightness after all brightness-related values are parsed
+  setBacklight(getEffectiveBrightness());
 
   if (server.hasArg("rotation")) {
     uint8_t rot = server.arg("rotation").toInt();
@@ -1425,21 +1424,32 @@ static void handleSaveWifi() {
 }
 
 // Live brightness preview (no save, just PWM update)
+// Only applies when the main display is active — during clock/screensaver
+// the screensaverBrightness governs the backlight, not the main slider.
 static void handleBrightnessPreview() {
   if (server.hasArg("val")) {
     uint8_t val = server.arg("val").toInt();
-    setBacklight(val);
+    ScreenState scr = getScreenState();
+    if (scr != SCREEN_CLOCK && scr != SCREEN_OFF) {
+      setBacklight(val);
+    }
   }
   server.send(200, "text/plain", "OK");
 }
 
 // Apply display settings live (no restart)
 static void handleApply() {
+  // Snapshot timezone before parsing — only re-init NTP if it changes.
+  // configTzTime() resets the SNTP sync status, which causes getLocalTime()
+  // to return false for up to 60s, blanking the clock screen unnecessarily.
+  char prevTz[sizeof(netSettings.timezoneStr)];
+  strlcpy(prevTz, netSettings.timezoneStr, sizeof(prevTz));
   readDisplayFromForm();
   saveSettings();
   applyDisplaySettings();
-  // Re-apply NTP if timezone changed
-  configTzTime(netSettings.timezoneStr, "pool.ntp.org", "time.nist.gov");
+  if (strcmp(netSettings.timezoneStr, prevTz) != 0) {
+    configTzTime(netSettings.timezoneStr, "pool.ntp.org", "time.nist.gov");
+  }
   server.send(200, "text/plain", "OK");
 }
 


### PR DESCRIPTION
## Problem

When the device was in clock/screensaver mode and the user clicked **Apply Display Settings**, the display would go completely dark for up to 60 seconds before the clock reappeared. This happened 100% of the time, even when only changing brightness — nothing to do with timezone.

## Root cause (three layers deep)

### 1. `configTzTime()` was called unconditionally on every Apply

`handleApply()` always called `configTzTime(...)` at the end, regardless of whether the timezone had actually changed. This is the **primary cause**.

`configTzTime()` reinitialises the SNTP stack, which resets the sync status to `SNTP_SYNC_STATUS_RESET`. The ESP32 Arduino implementation of `getLocalTime()` checks this status flag:

```cpp
// ESP32 Arduino internals (simplified)
bool getLocalTime(struct tm* info, uint32_t ms) {
    uint32_t count = ms / 10;
    while (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET && count--) {
        vTaskDelay(10 / portTICK_PERIOD_MS);
    }
    if (sntp_get_sync_status() == SNTP_SYNC_STATUS_RESET) return false;
    // ... fill struct tm ...
}
```

With the timeout we use (`0`), it returns `false` immediately whenever the sync status is reset — even though the hardware RTC still has the correct time. `drawClock()` returns on the very first line when this happens, so after `applyDisplaySettings()` blanks the screen with `fillScreen()`, nothing redraws it until NTP re-syncs (typically 15–60 seconds later).

**Fix:** snapshot `netSettings.timezoneStr` before parsing the form and only call `configTzTime()` if it actually changed.

### 2. No fallback when `getLocalTime()` fails

Even with fix #1, a genuine timezone change still resets SNTP. `drawClock()` had no recovery path — it would return immediately and leave a black screen until NTP caught up.

**Fix:** fall back to `time(nullptr)` + `localtime_r()` when `getLocalTime()` fails. This reads the hardware RTC directly, bypassing the SNTP sync-status check. A sanity check (`t < 1600000000`) guards against the clock being genuinely unset.

### 3. 250 ms display throttle caused a visible flash

`applyDisplaySettings()` clears the screen with `fillScreen()`, but `updateDisplay()` is throttled to run at most every `DISPLAY_UPDATE_MS` (250 ms). If the throttle timer hadn't expired yet, the first redraw was delayed, producing a brief black flash.

**Fix:** reset `lastDisplayUpdate = 0` inside `applyDisplaySettings()` so the throttle is bypassed and the redraw happens on the very next `loop()` iteration.

---

## Changes

| File | Change |
|------|--------|
| `src/web_server.cpp` | Only call `configTzTime()` when timezone string actually changed; call `setBacklight()` after all brightness fields are parsed; skip brightness preview during `SCREEN_CLOCK`/`SCREEN_OFF` |
| `src/clock_mode.cpp` | Fallback to `time()` + `localtime_r()` when `getLocalTime()` returns false |
| `src/display_ui.cpp` | Reset display throttle timer in `applyDisplaySettings()`; `setBacklight()` keeps `lastAppliedBrightness` in sync; call `resetClock()`/`resetPongClock()` on apply so clock redraws immediately |

## Testing

- Verified on device (ESP32-S3 Super Mini, ST7789 240×240)
- Applied display settings while in clock mode → clock stays visible, no blank screen
- Changed timezone → clock updates correctly after NTP re-sync, no blank screen in the meantime
- Adjusted brightness while in clock mode → backlight updates immediately, clock stays on
- Brightness preview slider no longer tramples screensaver brightness while clock is active