### PR TITLE
Add WiFi RSSI to /debug endpoint

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1499,6 +1499,7 @@ static void handleDebug() {
 
   doc["heap"] = ESP.getFreeHeap();
   doc["uptime"] = millis() / 1000;
+  doc["rssi"] = WiFi.RSSI();
   doc["debug_log"] = mqttDebugLog;
 
   String json;


### PR DESCRIPTION
## Summary

Adds `rssi` (dBm) to the `GET /debug` JSON response alongside the existing `heap` and `uptime` fields, making it easy to check signal strength without a serial connection.

## Example response

```json
{
  "printers": [...],
  "heap": 236552,
  "uptime": 13,
  "rssi": -71,
  "debug_log": false
}
```

## Test plan

- [x] Flash firmware, open `http://<device>/debug`, verify `rssi` field is present with a reasonable dBm value (typically -30 to -90)