### PR TITLE
Fix memory safety issues across multiple subsystems

### DIFF
--- a/src/bambu_cloud.cpp
+++ b/src/bambu_cloud.cpp
@@ -52,7 +52,7 @@ static int httpsRequestWith(WiFiClientSecure& tls, const char* method,
                             const char* url, const char* body,
                             const char* authToken, String& response) {
   HTTPClient http;
-  if (!http.begin(tls, url)) return -1;
+  if (!http.begin(tls, url)) { http.end(); return -1; }
 
   setSlicerHeaders(http);
   if (authToken && strlen(authToken) > 0) {

--- a/src/bambu_mqtt.cpp
+++ b/src/bambu_mqtt.cpp
@@ -267,7 +267,8 @@ static void parseMqttPayload(byte* payload, unsigned int length,
       while (v < payloadEnd && (*v == ' ' || *v == '\n' || *v == '\r' || *v == '\t')) v++;
       if (v < payloadEnd && *v == '{') { amsObj = v; break; }
       search = f + 6;
-      rem = length - (search - (const char*)payload);
+      size_t consumed = (size_t)(search - (const char*)payload);
+      rem = (consumed < length) ? (length - consumed) : 0;
     }
 
     if (amsObj) {

--- a/src/clock_pong.cpp
+++ b/src/clock_pong.cpp
@@ -41,14 +41,18 @@ extern TFT_eSPI tft;
 #define ARK_MAX_FRAGS     20
 #define ARK_TIME_OVERRIDE_MS 60000
 
-// Brick colors per row (classic Arcanoid rainbow)
-static const uint16_t brickColors[ARK_BRICK_ROWS] = {
+// Brick colors per row (classic Arcanoid rainbow).
+// BRICK_COLOR_COUNT is the authoritative size; ARK_BRICK_ROWS must not exceed it.
+#define BRICK_COLOR_COUNT 5
+static const uint16_t brickColors[BRICK_COLOR_COUNT] = {
   0xF800,  // Red
   0xFD20,  // Orange
   0xFFE0,  // Yellow
   0x07E0,  // Green
   0x001F,  // Blue
 };
+static_assert(ARK_BRICK_ROWS <= BRICK_COLOR_COUNT,
+              "ARK_BRICK_ROWS exceeds brickColors array size");
 
 // ========== Fragment struct ==========
 struct PongFragment {
@@ -322,7 +326,7 @@ static void updateFragments() {
       frags[i].active = false;
       continue;
     }
-    tft.fillRect((int)frags[i].x, (int)frags[i].y, 3, 3, brickColors[random(0, ARK_BRICK_ROWS)]);
+    tft.fillRect((int)frags[i].x, (int)frags[i].y, 3, 3, brickColors[random(0, BRICK_COLOR_COUNT)]);
   }
   if (fragTimer == 0) {
     for (int i = 0; i < ARK_MAX_FRAGS; i++) {

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -172,7 +172,8 @@ struct GaugeTextCache {
 static GaugeTextCache gCache[GAUGE_CACHE_SLOTS];
 static uint8_t gCacheCount = 0;
 
-// Find or create cache slot for gauge at (cx, cy)
+// Find or create cache slot for gauge at (cx, cy).
+// If the cache is full, evict the oldest entry (slot 0) to make room.
 static GaugeTextCache* gaugeCache(int16_t cx, int16_t cy) {
   for (uint8_t i = 0; i < gCacheCount; i++) {
     if (gCache[i].cx == cx && gCache[i].cy == cy) return &gCache[i];
@@ -183,7 +184,12 @@ static GaugeTextCache* gaugeCache(int16_t cx, int16_t cy) {
     c->main[0] = '\0'; c->sub[0] = '\0';
     return c;
   }
-  return nullptr;
+  // Cache full: evict oldest slot (index 0), shift remaining entries down
+  memmove(&gCache[0], &gCache[1], (GAUGE_CACHE_SLOTS - 1) * sizeof(GaugeTextCache));
+  GaugeTextCache* c = &gCache[GAUGE_CACHE_SLOTS - 1];
+  c->cx = cx; c->cy = cy;
+  c->main[0] = '\0'; c->sub[0] = '\0';
+  return c;
 }
 
 // Check if text changed; update cache. Returns true if redraw needed.

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -25,6 +25,7 @@ static Preferences prefs;
 //  RGB565 <-> HTML hex conversion
 // ---------------------------------------------------------------------------
 uint16_t htmlToRgb565(const char* hex) {
+  if (!hex || hex[0] == '\0') return 0;
   // Skip '#' if present
   if (hex[0] == '#') hex++;
   uint32_t rgb = strtoul(hex, nullptr, 16);

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -26,6 +26,14 @@ String getAPSSID() {
   return apSSID;
 }
 
+static void stopAP() {
+  if (dnsServer) {
+    dnsServer->stop();
+    delete dnsServer;
+    dnsServer = nullptr;
+  }
+}
+
 static void startAP() {
   // Build SSID from MAC
   uint32_t mac = (uint32_t)(ESP.getEfuseMac() & 0xFFFF);
@@ -90,6 +98,7 @@ void initWiFi() {
     if (WiFi.status() == WL_CONNECTED) {
       Serial.printf("WiFi connected! IP: %s\n",
                     WiFi.localIP().toString().c_str());
+      stopAP();
       apMode = false;
       disconnectTime = 0;
 


### PR DESCRIPTION
## Summary

A handful of low-level memory safety problems found while auditing the firmware:

- **bambu_cloud**: `http.end()` was not called on the early-return path in `httpsRequestWith`, leaking the HTTP client resource.
- **bambu_mqtt**: The AMS search loop computed `rem` with an unchecked unsigned subtraction, which could wrap around to a huge value and cause an out-of-bounds read.
- **clock_pong**: `brickColors` has 5 entries but was indexed with `random(0, ARK_BRICK_ROWS)` — if `ARK_BRICK_ROWS` ever exceeds 5 the result is an out-of-bounds read. Added a `BRICK_COLOR_COUNT` constant and a `static_assert` to make that contract explicit and compiler-enforced.
- **display_gauges**: `gaugeCache()` returned `nullptr` when the fixed-size cache was full, but callers did not check for null — a guaranteed null-pointer dereference on screens with more than `GAUGE_CACHE_SLOTS` gauges. Replaced the null return with an LRU-style eviction (shift remaining entries down, reclaim the last slot).
- **settings**: `htmlToRgb565` dereferenced its argument before checking for null or empty string.
- **wifi_manager**: On successful STA connect the AP DNS server object was abandoned without calling `stop()` or `delete`, leaking heap memory. Extracted a `stopAP()` helper and call it during the connect transition.

## Test plan

- Built cleanly for both `esp32s3` and `cyd` environments with no new warnings
- Flashed to test device; display, MQTT, and web config portal all behave normally
- Verified AP shuts down cleanly after STA connect (no lingering DNS traffic)