### PR TITLE
Fix buzzer quiet hour bounds check and blocking delay() in web handlers

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -22,6 +22,15 @@ extern const uint8_t rootca_crt_bundle_start[] asm("_binary_x509_crt_bundle_star
 static WebServer server(80);
 
 // ---------------------------------------------------------------------------
+//  Deferred restart — avoids blocking delay() before ESP.restart()
+// ---------------------------------------------------------------------------
+static unsigned long pendingRestartAt = 0;
+
+static void scheduleRestart(unsigned long delayMs = 1000) {
+  pendingRestartAt = millis() + delayMs;
+}
+
+// ---------------------------------------------------------------------------
 //  AP-mode page (minimal WiFi setup only)
 // ---------------------------------------------------------------------------
 static const char PAGE_AP_HTML[] PROGMEM = R"rawliteral(
@@ -1645,8 +1654,7 @@ static void handleSaveWifi() {
   saveSettings();
 
   server.send(200, "application/json", "{\"status\":\"ok\"}");
-  delay(1000);
-  ESP.restart();
+  scheduleRestart();
 }
 
 // Live brightness preview (no save, just PWM update)
@@ -1710,8 +1718,7 @@ static void handleReset() {
     "<html><body style='background:#0D1117;color:#E6EDF3;text-align:center;padding-top:80px;font-family:sans-serif'>"
     "<h2 style='color:#F85149'>Factory Reset</h2>"
     "<p>Restarting...</p></body></html>");
-  delay(1000);
-  resetSettings();
+  resetSettings();  // clears NVS and calls ESP.restart()
 }
 
 static void handleDebug() {
@@ -1847,8 +1854,14 @@ static void handleSaveRotation() {
     uint8_t bp = server.arg("buzpin").toInt();
     if (bp > 0 && bp <= 48) buzzerSettings.pin = bp;
   }
-  if (server.hasArg("buzqs")) buzzerSettings.quietStartHour = server.arg("buzqs").toInt();
-  if (server.hasArg("buzqe")) buzzerSettings.quietEndHour = server.arg("buzqe").toInt();
+  if (server.hasArg("buzqs")) {
+    int qs = server.arg("buzqs").toInt();
+    if (qs >= 0 && qs <= 23) buzzerSettings.quietStartHour = qs;
+  }
+  if (server.hasArg("buzqe")) {
+    int qe = server.arg("buzqe").toInt();
+    if (qe >= 0 && qe <= 23) buzzerSettings.quietEndHour = qe;
+  }
   saveBuzzerSettings();
   initBuzzer();
 
@@ -2124,8 +2137,14 @@ static void handleSettingsImportFinish() {
   if (buz) {
     if (buz["enabled"].is<bool>())    buzzerSettings.enabled = buz["enabled"].as<bool>();
     if (buz["pin"].is<uint8_t>())     buzzerSettings.pin = buz["pin"].as<uint8_t>();
-    if (buz["quietStart"].is<uint8_t>()) buzzerSettings.quietStartHour = buz["quietStart"].as<uint8_t>();
-    if (buz["quietEnd"].is<uint8_t>())   buzzerSettings.quietEndHour = buz["quietEnd"].as<uint8_t>();
+    if (buz["quietStart"].is<uint8_t>()) {
+      uint8_t qs = buz["quietStart"].as<uint8_t>();
+      if (qs <= 23) buzzerSettings.quietStartHour = qs;
+    }
+    if (buz["quietEnd"].is<uint8_t>()) {
+      uint8_t qe = buz["quietEnd"].as<uint8_t>();
+      if (qe <= 23) buzzerSettings.quietEndHour = qe;
+    }
   }
 
   // Save everything to NVS
@@ -2135,8 +2154,7 @@ static void handleSettingsImportFinish() {
   saveBuzzerSettings();
 
   server.send(200, "application/json", "{\"status\":\"ok\",\"message\":\"Settings imported. Restarting...\"}");
-  delay(1000);
-  ESP.restart();
+  scheduleRestart();
 }
 
 // ---------------------------------------------------------------------------
@@ -2167,9 +2185,8 @@ static void otaAutoTaskFn(void* param) {
     case HTTP_UPDATE_OK:
       otaAutoProgress = 100;
       otaAutoStatus = "done";
-      Serial.println("OTA auto: success, restarting in 4s");
-      delay(4000);   // long enough for JS poller to detect "done" before reboot
-      ESP.restart();
+      Serial.println("OTA auto: success, scheduling restart");
+      scheduleRestart(4000);  // let JS poller detect "done" before reboot
       break;
     case HTTP_UPDATE_NO_UPDATES:
       otaAutoStatus = "already_current";
@@ -2185,8 +2202,7 @@ static void otaAutoTaskFn(void* param) {
         if (ret == HTTP_UPDATE_OK) {
           otaAutoProgress = 100;
           otaAutoStatus = "done";
-          delay(4000);
-          ESP.restart();
+          scheduleRestart(4000);
           break;
         }
       }
@@ -2304,8 +2320,7 @@ static void handleOtaFinish() {
   }
   server.send(200, "application/json",
     "{\"status\":\"ok\",\"message\":\"Update successful. Restarting...\"}");
-  delay(1500);
-  ESP.restart();
+  scheduleRestart(1500);
 }
 
 // Captive portal: redirect any unknown request to root
@@ -2368,4 +2383,8 @@ void initWebServer() {
 
 void handleWebServer() {
   server.handleClient();
+  if (pendingRestartAt && millis() >= pendingRestartAt) {
+    Serial.println("Deferred restart triggered");
+    ESP.restart();
+  }
 }


### PR DESCRIPTION
## Summary

- Add 0–23 bounds validation on buzzer quiet hour inputs in both the form handler and the JSON settings import path — previously any int was accepted, causing incorrect quiet hour calculations
- Replace all blocking `delay()` + `ESP.restart()` patterns in web handlers with a non-blocking `scheduleRestart()` mechanism polled in `handleWebServer()`, preventing watchdog resets and missed MQTT heartbeats during restart

## What changed

**Buzzer bounds check:**
- Form handler (`/save-buzzer`): validates `buzqs`/`buzqe` args are 0–23 before storing
- Import handler (`/import`): validates `quietStart`/`quietEnd` JSON values are ≤ 23

**Deferred restart:**
- New `scheduleRestart(delayMs)` sets a `pendingRestartAt` timestamp
- `handleWebServer()` checks the timestamp each loop iteration and calls `ESP.restart()` when due
- Replaces 5 blocking `delay()` calls: WiFi save, settings import, OTA auto (×2), OTA upload

## Test plan

- [x] All 4 build envs pass (esp32s3, cyd, esp32c3, esp32c3-headless)
- [x] OTA upload on S3 test device — response received, device restarted cleanly
- [x] Settings page loads after restart