### PR TITLE
Add firmware size and checksum validation to OTA updates

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -13,6 +13,7 @@
 #include <WebServer.h>
 #include <ArduinoJson.h>
 #include <Update.h>
+#include "esp_ota_ops.h"
 #ifdef ENABLE_OTA_AUTO
 #include <HTTPUpdate.h>
 #include <WiFiClientSecure.h>
@@ -2251,10 +2252,28 @@ static void handleOtaUpload() {
 
     disconnectBambuMqtt();
 
-    if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
-      otaError = Update.errorString();
+    const esp_partition_t* partition = esp_ota_get_next_update_partition(NULL);
+    if (!partition) {
+      otaError = "No OTA partition found";
+      Serial.println("OTA: no OTA partition found");
+      otaInProgress = false;
+      return;
+    }
+    Serial.printf("OTA: firmware upload started, partition size: %u bytes\n", partition->size);
+
+    if (!Update.begin(partition->size)) {
+      otaError = "OTA begin failed: " + String(Update.errorString());
       Serial.printf("OTA: begin failed: %s\n", otaError.c_str());
       otaInProgress = false;
+      return;
+    }
+
+    if (server.hasHeader("X-MD5")) {
+      String md5 = server.header("X-MD5");
+      if (md5.length() == 32) {
+        Update.setMD5(md5.c_str());
+        Serial.printf("OTA: MD5 checksum set: %s\n", md5.c_str());
+      }
     }
 
   } else if (upload.status == UPLOAD_FILE_WRITE) {
@@ -2362,6 +2381,8 @@ void initWebServer() {
   server.on("/ota/status", HTTP_GET,  handleOtaStatus);
 #endif
   server.onNotFound(handleNotFound);
+  const char* otaHeaders[] = {"X-MD5"};
+  server.collectHeaders(otaHeaders, 1);
   server.begin();
   Serial.println("Web server started on port 80");
 }


### PR DESCRIPTION
OTA handler used UPDATE_SIZE_UNKNOWN and only checked the ESP32 magic byte. An oversized firmware could potentially corrupt the SPIFFS partition or bootloader.

**Changes:**
- Replaced UPDATE_SIZE_UNKNOWN with actual OTA partition size via esp_ota_get_next_update_partition()
- The ESP32 Update library now rejects uploads exceeding the partition boundary
- Added optional MD5 checksum verification via X-MD5 HTTP header — when provided, Update.end() verifies the hash
- Added partition size logging on upload start
- Clients that don't send X-MD5 are unaffected (backward compatible)

Usage with checksum: `curl -H "X-MD5:<hash>" -F "firmware=@firmware.bin" http://device/ota/upload`

Tested on device — OTA upload with the new validation code works correctly, device boots and serves web UI.