### PR TITLE
Fix NVS timezone migration race condition on power loss

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -150,7 +150,9 @@ static void loadGaugeColors(const char* prefix, GaugeColors& gc, const GaugeColo
 //  Load settings
 // ---------------------------------------------------------------------------
 void loadSettings() {
-  prefs.begin(NVS_NAMESPACE, true);  // read-only
+  // Open read-write from the start: we may need to write a migration flag.
+  // This is safe and avoids closing/reopening the partition mid-load.
+  prefs.begin(NVS_NAMESPACE, false);
 
   // WiFi credentials
   strlcpy(wifiSSID, prefs.getString("wifiSSID", "").c_str(), sizeof(wifiSSID));
@@ -219,49 +221,48 @@ void loadSettings() {
   strlcpy(netSettings.subnet, prefs.getString("net_sn", "255.255.255.0").c_str(), sizeof(netSettings.subnet));
   strlcpy(netSettings.dns, prefs.getString("net_dns", "").c_str(), sizeof(netSettings.dns));
   netSettings.showIPAtStartup = prefs.getBool("net_showip", true);
-  // Timezone: load new POSIX format, migrate from old gmtOffsetMin if needed
+
+  // Timezone: load POSIX string, migrating from legacy gmtOffsetMin if needed.
+  // All reads and any migration writes happen in the same open transaction to
+  // prevent incomplete state if power is lost mid-migration.
+  bool tzMigrated = prefs.getBool("tz_migrated", false);
   String tzStr = prefs.getString("net_tzstr", "");
-  if (tzStr.length() > 0) {
-    strlcpy(netSettings.timezoneStr, tzStr.c_str(), sizeof(netSettings.timezoneStr));
-    // Re-resolve index from TZ string (handles database reordering across updates)
-    size_t cnt;
-    const TimezoneRegion* tz = getSupportedTimezones(&cnt);
-    netSettings.timezoneIndex = 14; // default: CET (Amsterdam, Berlin, Rome)
-    for (size_t i = 0; i < cnt; i++) {
-      if (strcmp(tz[i].posixString, netSettings.timezoneStr) == 0) {
-        netSettings.timezoneIndex = (uint8_t)i;
-        break;
-      }
-    }
-  } else {
-    // Migration: convert old gmtOffsetMin to POSIX string
+  if (tzStr.isEmpty() && !tzMigrated) {
+    // Legacy migration: convert old integer offset to POSIX timezone string.
     int16_t oldOffset = prefs.getShort("net_tz", 60);
     const char* migrated = getDefaultTimezoneForOffset(oldOffset);
     if (migrated) {
-      strlcpy(netSettings.timezoneStr, migrated, sizeof(netSettings.timezoneStr));
+      tzStr = migrated;
     } else {
-      strlcpy(netSettings.timezoneStr, "CET-1CEST,M3.5.0/02:00,M10.5.0/03:00", sizeof(netSettings.timezoneStr));
+      tzStr = "CET-1CEST,M3.5.0/02:00,M10.5.0/03:00";
     }
-    // Find matching index in database
-    size_t count;
-    const TimezoneRegion* regions = getSupportedTimezones(&count);
-    netSettings.timezoneIndex = 14; // default: CET (Amsterdam, Berlin, Rome)
-    for (size_t i = 0; i < count; i++) {
+    // Write both the migrated value and the completion flag in the same
+    // transaction so a power loss cannot leave migration half-done.
+    prefs.putString("net_tzstr", tzStr);
+    prefs.putBool("tz_migrated", true);
+    Serial.printf("[SETTINGS] Migrated timezone: offset %d -> %s\n", oldOffset, tzStr.c_str());
+  } else if (!tzStr.isEmpty() && !tzMigrated) {
+    // Recovery: net_tzstr already exists but flag is absent — this device ran
+    // the old migration code and lost power before it could be marked done.
+    // Stamp the flag now so future boots skip migration entirely.
+    prefs.putBool("tz_migrated", true);
+  }
+  strlcpy(netSettings.timezoneStr, tzStr.c_str(), sizeof(netSettings.timezoneStr));
+
+  // Re-resolve the index from the POSIX string (handles database reordering
+  // across firmware updates without relying on a stored index value).
+  {
+    size_t cnt;
+    const TimezoneRegion* regions = getSupportedTimezones(&cnt);
+    netSettings.timezoneIndex = 14;  // default: CET (Amsterdam, Berlin, Rome)
+    for (size_t i = 0; i < cnt; i++) {
       if (strcmp(regions[i].posixString, netSettings.timezoneStr) == 0) {
         netSettings.timezoneIndex = (uint8_t)i;
         break;
       }
     }
-    // Save new format so migration only happens once.
-    // prefs is open read-only here, so reopen in write mode for migration.
-    prefs.end();
-    prefs.begin(NVS_NAMESPACE, false);
-    prefs.putString("net_tzstr", netSettings.timezoneStr);
-    prefs.putUChar("net_tzidx", netSettings.timezoneIndex);
-    prefs.end();
-    prefs.begin(NVS_NAMESPACE, true);  // back to read-only for remaining loads
-    Serial.printf("Timezone migrated from offset %d -> %s\n", oldOffset, netSettings.timezoneStr);
   }
+
   netSettings.use24h = prefs.getBool("net_24h", true);
   netSettings.dateFormat = prefs.getUChar("net_datefmt", 0);
 


### PR DESCRIPTION
Timezone migration in loadSettings() did 3 separate NVS open/close cycles. If power was lost between prefs.end() and the next prefs.begin(), migration could be left in an incomplete state.

**Changes:**
- Consolidated to a single NVS transaction: open read-write once at the start, close once at the end
- Added tz_migrated flag written atomically alongside the migrated timezone string
- On subsequent boots, the flag short-circuits migration entirely
- Added recovery path: if net_tzstr exists but flag is missing (partial migration from old code), the flag is stamped

Tested on device via OTA — settings load correctly, timezone displays properly.