### PR TITLE
Replace strcmp state checks with GcodeState enum

### DIFF
--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -4,6 +4,19 @@
 #include <Arduino.h>
 #include "config.h"
 
+// ── Gcode state machine ─────────────────────────────────────────────────────
+enum GcodeState : uint8_t {
+  STATE_UNKNOWN, STATE_IDLE, STATE_RUNNING,
+  STATE_PAUSE, STATE_PREPARE, STATE_FINISH, STATE_FAILED
+};
+
+GcodeState  parseGcodeState(const char* raw);
+const char* gcodeStateLabel(GcodeState state);
+
+extern const char* const DAYS_SHORT[7];
+extern const char* const MONTHS_SHORT[12];
+
+// ── Connection modes ────────────────────────────────────────────────────────
 enum ConnMode : uint8_t { CONN_LOCAL = 0, CONN_CLOUD = 1, CONN_CLOUD_ALL = 2 };
 enum CloudRegion : uint8_t { REGION_US = 0, REGION_EU = 1, REGION_CN = 2 };
 
@@ -33,7 +46,8 @@ struct AmsState {
 struct BambuState {
   bool connected;
   bool printing;
-  char gcodeState[16];        // RUNNING, PAUSE, FINISH, IDLE, FAILED, PREPARE
+  char gcodeState[16];        // raw MQTT value (kept for web API compat)
+  GcodeState gcodeStateEnum;  // parsed enum — use this for all comparisons
   uint8_t progress;           // 0-100%
   uint16_t remainingMinutes;
   float nozzleTemp;

--- a/src/bambu_mqtt.cpp
+++ b/src/bambu_mqtt.cpp
@@ -384,10 +384,11 @@ static void parseMqttPayload(byte* payload, unsigned int length,
     const char* state = print["gcode_state"];
     strncpy(s.gcodeState, state, 15);
     s.gcodeState[15] = '\0';
+    s.gcodeStateEnum = parseGcodeState(state);
     bool wasActive = s.printing;
-    s.printing = (strcmp(state, "RUNNING") == 0 ||
-                  strcmp(state, "PAUSE") == 0 ||
-                  strcmp(state, "PREPARE") == 0);
+    s.printing = (s.gcodeStateEnum == STATE_RUNNING ||
+                  s.gcodeStateEnum == STATE_PAUSE ||
+                  s.gcodeStateEnum == STATE_PREPARE);
     if (s.printing) {
       idleSince = 0;
     } else if (wasActive || idleSince == 0) {
@@ -752,6 +753,7 @@ static void handleConn(MqttConn& c) {
         // Also reset gcodeState — otherwise state machine shows SCREEN_IDLE
         // with "RUNNING" text (2 gauges) instead of SCREEN_PRINTING (6 gauges)
         strlcpy(s.gcodeState, "IDLE", sizeof(s.gcodeState));
+        s.gcodeStateEnum = STATE_IDLE;
         c.stalePushallSentMs = 0;
       }
     }
@@ -837,6 +839,7 @@ void initBambuMqtt() {
     BambuState& s = printers[i].state;
     memset(&s, 0, sizeof(BambuState));
     strlcpy(s.gcodeState, "UNKNOWN", sizeof(s.gcodeState));
+    s.gcodeStateEnum = STATE_UNKNOWN;
 
     if (isPrinterConfigured(i)) {
       c.active = true;

--- a/src/clock_mode.cpp
+++ b/src/clock_mode.cpp
@@ -1,5 +1,6 @@
 #include "clock_mode.h"
 #include "display_ui.h"
+#include "bambu_state.h"
 #include "settings.h"
 #include "config.h"
 #include "layout.h"
@@ -53,17 +54,16 @@ void drawClock() {
   }
 
   // Date — smaller font below
-  const char* days[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-  const char* months[] = {"Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"};
+  // Shared string arrays from gcode_state.cpp
   char dateBuf[24];
   int day = now.tm_mday, mon = now.tm_mon + 1, year = now.tm_year + 1900;
   switch (netSettings.dateFormat) {
-    case 1:  snprintf(dateBuf, sizeof(dateBuf), "%s  %02d-%02d-%04d", days[now.tm_wday], day, mon, year); break;
-    case 2:  snprintf(dateBuf, sizeof(dateBuf), "%s  %02d/%02d/%04d", days[now.tm_wday], mon, day, year); break;
-    case 3:  snprintf(dateBuf, sizeof(dateBuf), "%s  %04d-%02d-%02d", days[now.tm_wday], year, mon, day); break;
-    case 4:  snprintf(dateBuf, sizeof(dateBuf), "%s  %d %s %04d", days[now.tm_wday], day, months[now.tm_mon], year); break;
-    case 5:  snprintf(dateBuf, sizeof(dateBuf), "%s  %s %d, %04d", days[now.tm_wday], months[now.tm_mon], day, year); break;
-    default: snprintf(dateBuf, sizeof(dateBuf), "%s  %02d.%02d.%04d", days[now.tm_wday], day, mon, year); break;
+    case 1:  snprintf(dateBuf, sizeof(dateBuf), "%s  %02d-%02d-%04d", DAYS_SHORT[now.tm_wday], day, mon, year); break;
+    case 2:  snprintf(dateBuf, sizeof(dateBuf), "%s  %02d/%02d/%04d", DAYS_SHORT[now.tm_wday], mon, day, year); break;
+    case 3:  snprintf(dateBuf, sizeof(dateBuf), "%s  %04d-%02d-%02d", DAYS_SHORT[now.tm_wday], year, mon, day); break;
+    case 4:  snprintf(dateBuf, sizeof(dateBuf), "%s  %d %s %04d", DAYS_SHORT[now.tm_wday], day, MONTHS_SHORT[now.tm_mon], year); break;
+    case 5:  snprintf(dateBuf, sizeof(dateBuf), "%s  %s %d, %04d", DAYS_SHORT[now.tm_wday], MONTHS_SHORT[now.tm_mon], day, year); break;
+    default: snprintf(dateBuf, sizeof(dateBuf), "%s  %02d.%02d.%04d", DAYS_SHORT[now.tm_wday], day, mon, year); break;
   }
   tft.setTextFont(4);
   tft.setTextColor(CLR_TEXT_DIM, bg);

--- a/src/clock_pong.cpp
+++ b/src/clock_pong.cpp
@@ -11,6 +11,7 @@
 #include "layout.h"
 #include "settings.h"
 #include "display_ui.h"
+#include "bambu_state.h"
 #include <TFT_eSPI.h>
 #include <time.h>
 
@@ -530,14 +531,13 @@ void tickPongClock() {
   // Draw text on top (repairs any ball/paddle damage via cache invalidation)
   // Date (Font 2, smooth)
   {
-    const char* days[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
     char dateStr[20];
     if (netSettings.use24h)
       snprintf(dateStr, sizeof(dateStr), "%s %02d.%02d.%04d",
-               days[now.tm_wday], now.tm_mday, now.tm_mon + 1, now.tm_year + 1900);
+               DAYS_SHORT[now.tm_wday], now.tm_mday, now.tm_mon + 1, now.tm_year + 1900);
     else
       snprintf(dateStr, sizeof(dateStr), "%s %02d/%02d/%04d",
-               days[now.tm_wday], now.tm_mon + 1, now.tm_mday, now.tm_year + 1900);
+               DAYS_SHORT[now.tm_wday], now.tm_mon + 1, now.tm_mday, now.tm_year + 1900);
     if (strcmp(dateStr, prevDateStr) != 0) {
       tft.setTextFont(2);
       tft.setTextSize(1);

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -465,7 +465,7 @@ static void drawIdle() {
 
   bool animating = tickGaugeSmooth(s, forceRedraw);
   gaugesAnimating = animating;
-  bool stateChanged = forceRedraw || (strcmp(s.gcodeState, prevState.gcodeState) != 0);
+  bool stateChanged = forceRedraw || (s.gcodeStateEnum != prevState.gcodeStateEnum);
   bool tempChanged = forceRedraw || animating ||
                      (s.nozzleTemp != prevState.nozzleTemp) ||
                      (s.nozzleTarget != prevState.nozzleTarget) ||
@@ -488,16 +488,9 @@ static void drawIdle() {
   if (stateChanged) {
     tft.setTextFont(2);
     uint16_t stateColor = CLR_TEXT_DIM;
-    const char* stateStr = s.gcodeState;
-    if (strcmp(s.gcodeState, "IDLE") == 0) {
-      stateColor = CLR_GREEN;
-      stateStr = "Ready";
-    } else if (strcmp(s.gcodeState, "FAILED") == 0) {
-      stateColor = CLR_RED;
-      stateStr = "ERROR";
-    } else if (strcmp(s.gcodeState, "UNKNOWN") == 0 || s.gcodeState[0] == '\0') {
-      stateStr = "Waiting...";
-    }
+    if (s.gcodeStateEnum == STATE_IDLE)   stateColor = CLR_GREEN;
+    if (s.gcodeStateEnum == STATE_FAILED) stateColor = CLR_RED;
+    const char* stateStr = gcodeStateLabel(s.gcodeStateEnum);
     tft.fillRect(0, LY_IDLE_STATE_Y, scrW, LY_IDLE_STATE_H, CLR_BG);
     tft.setTextColor(stateColor, CLR_BG);
     tft.drawString(stateStr, cx, LY_IDLE_STATE_TY);
@@ -852,7 +845,7 @@ static void drawPrinting() {
                      (s.auxFanPct != prevState.auxFanPct) ||
                      (s.chamberFanPct != prevState.chamberFanPct);
   bool stateChanged = forceRedraw ||
-                      (strcmp(s.gcodeState, prevState.gcodeState) != 0);
+                      (s.gcodeStateEnum != prevState.gcodeStateEnum);
 
   // 2x3 gauge grid constants (from layout profile)
   const int16_t gR = LY_GAUGE_R;
@@ -915,16 +908,17 @@ static void drawPrinting() {
 
     // State badge (right)
     uint16_t badgeColor = CLR_TEXT_DIM;
-    if (strcmp(s.gcodeState, "RUNNING") == 0) badgeColor = CLR_GREEN;
-    else if (strcmp(s.gcodeState, "PAUSE") == 0) badgeColor = CLR_YELLOW;
-    else if (strcmp(s.gcodeState, "FAILED") == 0) badgeColor = CLR_RED;
-    else if (strcmp(s.gcodeState, "PREPARE") == 0) badgeColor = CLR_BLUE;
+    if (s.gcodeStateEnum == STATE_RUNNING) badgeColor = CLR_GREEN;
+    else if (s.gcodeStateEnum == STATE_PAUSE)   badgeColor = CLR_YELLOW;
+    else if (s.gcodeStateEnum == STATE_FAILED)  badgeColor = CLR_RED;
+    else if (s.gcodeStateEnum == STATE_PREPARE) badgeColor = CLR_BLUE;
 
+    const char* badgeLabel = gcodeStateLabel(s.gcodeStateEnum);
     tft.setTextDatum(MR_DATUM);
     tft.setTextColor(badgeColor, hdrBg);
     tft.setTextFont(2);
-    tft.fillCircle(SCREEN_W - LY_HDR_BADGE_RX - tft.textWidth(s.gcodeState) - 10, LY_HDR_CY, 4, badgeColor);
-    tft.drawString(s.gcodeState, SCREEN_W - LY_HDR_BADGE_RX, LY_HDR_CY);
+    tft.fillCircle(SCREEN_W - LY_HDR_BADGE_RX - tft.textWidth(badgeLabel) - 10, LY_HDR_CY, 4, badgeColor);
+    tft.drawString(badgeLabel, SCREEN_W - LY_HDR_BADGE_RX, LY_HDR_CY);
 
     // Printer indicator dots (multi-printer)
     if (getActiveConnCount() > 1) {
@@ -1001,14 +995,14 @@ static void drawPrinting() {
     tft.fillRect(0, eff_etaY, SCREEN_W, eff_etaH, CLR_BG);
     tft.setTextDatum(MC_DATUM);
 
-    if (strcmp(s.gcodeState, "PAUSE") == 0) {
+    if (s.gcodeStateEnum == STATE_PAUSE) {
       tft.setTextFont(4);
       tft.setTextColor(CLR_YELLOW, CLR_BG);
-      tft.drawString("PAUSED", SCREEN_W / 2, eff_etaTextY);
-    } else if (strcmp(s.gcodeState, "FAILED") == 0) {
+      tft.drawString(gcodeStateLabel(STATE_PAUSE), SCREEN_W / 2, eff_etaTextY);
+    } else if (s.gcodeStateEnum == STATE_FAILED) {
       tft.setTextFont(4);
       tft.setTextColor(CLR_RED, CLR_BG);
-      tft.drawString("ERROR!", SCREEN_W / 2, eff_etaTextY);
+      tft.drawString(gcodeStateLabel(STATE_FAILED), SCREEN_W / 2, eff_etaTextY);
     } else if (s.remainingMinutes > 0) {
       // Use time() directly - avoids getLocalTime() race condition with timeout 0.
       // Once NTP syncs the RTC keeps running; ntpSynced latches true forever.
@@ -1242,12 +1236,12 @@ static void drawFinished() {
                   &dispSettings.bed, smoothBedTemp);
   }
 
-  // === "Print Complete!" status ===
+  // === Print complete status ===
   if (forceRedraw) {
     tft.setTextDatum(MC_DATUM);
     tft.setTextColor(CLR_GREEN, CLR_BG);
     tft.setTextFont(4);
-    tft.drawString("Print Complete!", cx, LY_FIN_TEXT_Y);
+    tft.drawString("Print complete", cx, LY_FIN_TEXT_Y);
   }
 
   // === File name ===

--- a/src/gcode_state.cpp
+++ b/src/gcode_state.cpp
@@ -1,0 +1,29 @@
+#include "bambu_state.h"
+#include <string.h>
+
+GcodeState parseGcodeState(const char* raw) {
+    if (!raw || !raw[0])                  return STATE_UNKNOWN;
+    if (strcmp(raw, "RUNNING") == 0)       return STATE_RUNNING;
+    if (strcmp(raw, "PAUSE")   == 0)       return STATE_PAUSE;
+    if (strcmp(raw, "FINISH")  == 0)       return STATE_FINISH;
+    if (strcmp(raw, "IDLE")    == 0)       return STATE_IDLE;
+    if (strcmp(raw, "FAILED")  == 0)       return STATE_FAILED;
+    if (strcmp(raw, "PREPARE") == 0)       return STATE_PREPARE;
+    return STATE_UNKNOWN;
+}
+
+const char* gcodeStateLabel(GcodeState s) {
+    switch (s) {
+        case STATE_IDLE:    return "Ready";
+        case STATE_RUNNING: return "Running";
+        case STATE_PAUSE:   return "Paused";
+        case STATE_PREPARE: return "Preparing";
+        case STATE_FINISH:  return "Finished";
+        case STATE_FAILED:  return "Error";
+        default:            return "Waiting...";
+    }
+}
+
+const char* const DAYS_SHORT[7]   = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+const char* const MONTHS_SHORT[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ static unsigned long finishScreenStart = 0;
 static bool finishActive = false;          // guards finishScreenStart against millis() wrap
 static unsigned long idleClockStart = 0;  // when all printers became idle
 static bool idleClockActive = false;      // guards idleClockStart against millis() wrap
-static char prevGcodeState[MAX_ACTIVE_PRINTERS][16] = {{0}};
+static GcodeState prevGcodeStateEnum[MAX_ACTIVE_PRINTERS] = {STATE_UNKNOWN};
 
 // ---------------------------------------------------------------------------
 //  Display rotation logic (multi-printer)
@@ -182,7 +182,7 @@ void loop() {
       s.finishBuzzerPlayed = false;  // reset for next finish event
       s.doorAcknowledged = false;    // reset door ack for next finish
     } else if (s.connected && !s.printing &&
-               strcmp(s.gcodeState, "FINISH") == 0) {
+               s.gcodeStateEnum == STATE_FINISH) {
       if (current != SCREEN_FINISHED && current != SCREEN_OFF && current != SCREEN_CLOCK) {
         if (tasmotaSettings.enabled &&
             (tasmotaSettings.assignedSlot == 255 ||
@@ -236,7 +236,7 @@ void loop() {
         }
       }
     } else if (s.connected && !s.printing &&
-               strcmp(s.gcodeState, "FINISH") != 0) {
+               s.gcodeStateEnum != STATE_FINISH) {
       // SCREEN_CLOCK and SCREEN_OFF are sticky — only button press or
       // new print (s.printing → SCREEN_PRINTING) exits them
       if (current == SCREEN_CLOCK || current == SCREEN_OFF) {
@@ -284,12 +284,12 @@ void loop() {
   for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
     if (!isPrinterConfigured(i)) continue;
     BambuState& ps = printers[i].state;
-    if (strcmp(ps.gcodeState, "FAILED") == 0 &&
-        strcmp(prevGcodeState[i], "FAILED") != 0 &&
-        prevGcodeState[i][0] != '\0') {
+    if (ps.gcodeStateEnum == STATE_FAILED &&
+        prevGcodeStateEnum[i] != STATE_FAILED &&
+        prevGcodeStateEnum[i] != STATE_UNKNOWN) {
       buzzerPlay(BUZZ_ERROR);
     }
-    strlcpy(prevGcodeState[i], ps.gcodeState, sizeof(prevGcodeState[i]));
+    prevGcodeStateEnum[i] = ps.gcodeStateEnum;
   }
 
   buzzerTick();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -190,6 +190,7 @@ void loadSettings() {
     // Zero out state
     memset(&printers[i].state, 0, sizeof(BambuState));
     strlcpy(printers[i].state.gcodeState, "UNKNOWN", sizeof(printers[i].state.gcodeState));
+    printers[i].state.gcodeStateEnum = STATE_UNKNOWN;
   }
 
   // Display settings

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1690,6 +1690,7 @@ static void handleStatus() {
   doc["connected"] = st.connected;
   doc["configured"] = isPrinterConfigured(slot);
   doc["state"] = st.gcodeState;
+  doc["stateLabel"] = gcodeStateLabel(st.gcodeStateEnum);
   doc["progress"] = st.progress;
   doc["nozzle"] = (int)st.nozzleTemp;
   doc["nozzle_t"] = (int)st.nozzleTarget;


### PR DESCRIPTION
## Summary
- Introduce `GcodeState` enum parsed once in MQTT handler, replacing 18 `strcmp()` calls across 3 files with compile-time safe enum comparisons
- Add `gcodeStateLabel()` for consistent human-readable display text: "Ready", "Running", "Paused", "Preparing", "Finished", "Error"
- Fix inconsistent display labels: "PAUSED" → "Paused", "ERROR!" → "Error", "Print Complete!" → "Print complete"
- Add `stateLabel` field to `/status` JSON API (backward compatible — `state` still returns raw MQTT value)
- Deduplicate `days[]` and `months[]` arrays into shared `DAYS_SHORT`/`MONTHS_SHORT` constants

## Test plan
- [x] All three environments build clean (esp32s3 67%, cyd 69%, esp32c3 68%)
- [x] Flashed and verified on S3 — finish screen shows "Print complete", API returns stateLabel
- [ ] Verify idle screen shows "Ready" (not "IDLE")
- [ ] Verify printing badge shows "Running"/"Paused" (not "RUNNING"/"PAUSE")
- [ ] Verify error buzzer still triggers on FAILED transition
- [x] Verify clock screens show correct day-of-week from shared arrays