### PR TITLE
Add invert display colors option for CYD

### DIFF
--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -109,6 +109,9 @@ void initDisplay() {
   tft.fillScreen(TFT_BLACK);
 #endif
   tft.setRotation(dispSettings.rotation);
+#if defined(DISPLAY_CYD)
+  if (dispSettings.invertColors) tft.invertDisplay(false);
+#endif
   Serial.println("Display: setRotation done");
   tft.fillScreen(CLR_BG);
   Serial.println("Display: fillScreen done");
@@ -145,6 +148,9 @@ void applyDisplaySettings() {
   tft.fillScreen(TFT_BLACK);
 #endif
   tft.setRotation(dispSettings.rotation);
+#if defined(DISPLAY_CYD)
+  tft.invertDisplay(dispSettings.invertColors ? false : true);
+#endif
   tft.fillScreen(dispSettings.bgColor);
   forceRedraw = true;
   lastDisplayUpdate = 0;  // bypass throttle so redraw is immediate after fillScreen

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -107,6 +107,7 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.animatedBar = true;
   ds.pongClock = false;
   ds.smallLabels = false;
+  ds.invertColors = false;
   ds.cydExtraMode = 0;
 
   // Progress: green arc, green label, white value
@@ -204,6 +205,7 @@ void loadSettings() {
   dispSettings.animatedBar = prefs.getBool("dsp_abar", def.animatedBar);
   dispSettings.pongClock = prefs.getBool("dsp_pong", def.pongClock);
   dispSettings.smallLabels = prefs.getBool("dsp_slbl", def.smallLabels);
+  dispSettings.invertColors = prefs.getBool("dsp_inv", def.invertColors);
   dispSettings.cydExtraMode = prefs.getUChar("dsp_cydex", 0);
   dispSettings.cydExtraMode = 0;  // temporary: force AMS-only on CYD
 
@@ -334,6 +336,7 @@ void saveSettings() {
   prefs.putBool("dsp_abar", dispSettings.animatedBar);
   prefs.putBool("dsp_pong", dispSettings.pongClock);
   prefs.putBool("dsp_slbl", dispSettings.smallLabels);
+  prefs.putBool("dsp_inv", dispSettings.invertColors);
   prefs.putUChar("dsp_cydex", dispSettings.cydExtraMode);
 
   saveGaugeColors("gc_prg", dispSettings.progress);

--- a/src/settings.h
+++ b/src/settings.h
@@ -19,6 +19,7 @@ struct DisplaySettings {
   bool     animatedBar;    // shimmer effect on progress bar
   bool     pongClock;      // Pong/Breakout animated clock
   bool     smallLabels;    // use smaller gauge labels (Font 1 instead of Font 2)
+  bool     invertColors;   // invert display colors (fixes white-bg on some panels)
   uint8_t  cydExtraMode;   // CYD extra area: 0=AMS, 1=Extra Gauges
   GaugeColors progress;
   GaugeColors nozzle;

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -333,6 +333,7 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
           <input type="checkbox" id="slbl" value="1" %SLBL% onchange="toggleSetting('slbl',this.checked)">
           <label for="slbl">Smaller gauge labels</label>
         </div>
+%INVCOL_ROW%
       </div>
 
       <div style="margin-top:16px;padding-top:12px;border-top:1px solid #30363D">
@@ -1378,6 +1379,19 @@ static void processTemplate(String& page) {
   page.replace("%ABAR%", dispSettings.animatedBar ? "checked" : "");
   page.replace("%PONG%", dispSettings.pongClock ? "checked" : "");
   page.replace("%SLBL%", dispSettings.smallLabels ? "checked" : "");
+#if defined(DISPLAY_CYD)
+  {
+    String row = "<div class=\"check-row\">"
+      "<input type=\"checkbox\" id=\"invcol\" value=\"1\" ";
+    row += dispSettings.invertColors ? "checked" : "";
+    row += " onchange=\"toggleSetting('invcol',this.checked)\">"
+      "<label for=\"invcol\">Invert display colors (fix white background)</label>"
+      "</div>";
+    page.replace("%INVCOL_ROW%", row);
+  }
+#else
+  page.replace("%INVCOL_ROW%", "");
+#endif
 
   // Global colors
   char buf[8];
@@ -1770,6 +1784,7 @@ static void handleToggleSetting() {
   else if (key == "abar")    dispSettings.animatedBar = on;
   else if (key == "pong")    dispSettings.pongClock = on;
   else if (key == "slbl")    dispSettings.smallLabels = on;
+  else if (key == "invcol")  dispSettings.invertColors = on;
   else if (key == "nighten") dpSettings.nightModeEnabled = on;
   else if (key == "use24h")  netSettings.use24h = on;
   else {
@@ -1778,6 +1793,7 @@ static void handleToggleSetting() {
   }
 
   saveSettings();
+  if (key == "invcol") applyDisplaySettings();
   server.send(200, "text/plain", "OK");
 }
 


### PR DESCRIPTION
Adds a checkbox in web UI to invert display colors. Fixes white background issue on some CYD panels.