### PR TITLE
Limit CYD/C3 to single printer (BOARD_LOW_RAM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ When using Bambu Cloud, BambuHelper connects through Bambu Lab's cloud MQTT serv
 - **Auto AP mode** - creates WiFi hotspot on first boot or when WiFi is lost
 - **Smart redraw** - only redraws changed UI elements for smooth performance
 - **Customizable gauge colors** - per-gauge arc/label/value colors with preset themes
-- **Multi-printer support** - monitor up to 2 printers simultaneously with auto-rotating display
+- **Multi-printer support** - monitor up to 2 printers simultaneously with auto-rotating display (ESP32-S3 only - CYD/C3 limited to 1 printer due to RAM)
 - **Smart rotation** - automatically shows the printing printer; cycles between both when both are printing
 - **Physical button** - optional push button or TTP223 touch sensor to cycle printers and wake display
 - **Optional buzzer** - passive buzzer notifications for print finished, connected, and error events
@@ -318,6 +318,8 @@ tools/
 ## Multi-Printer Monitoring
 
 BambuHelper supports monitoring up to 2 printers simultaneously via dual MQTT connections.
+
+> **CYD and ESP32-C3 boards are limited to 1 printer.** Each MQTT connection requires ~85 KB of RAM (TLS session + message buffer), and the classic ESP32 / C3 do not have enough free heap for two simultaneous connections. The web interface on these boards hides the second printer tab and shows a notice. Use an ESP32-S3 board if you need two printers.
 
 ### Rotation Modes
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,6 +92,7 @@ build_flags =
     ; --- Layout profile ---
     -D DISPLAY_CYD=1
     -D BOARD_VARIANT=\"cyd\"
+    -D BOARD_LOW_RAM=1
 
 ; =============================================================================
 ;  ESP32-C3 Super Mini + ST7789 240x240
@@ -122,3 +123,4 @@ build_flags =
     -D TFT_BL=5
     -D BOARD_VARIANT=\"esp32c3\"
     -D ENABLE_OTA_AUTO=1
+    -D BOARD_LOW_RAM=1

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -189,12 +189,24 @@ static const char PAGE_HTML[] PROGMEM = R"rawliteral(
   </div>
   <div class="section-content" id="sec-printer">
     <div class="section-body">
+)rawliteral"
+#ifdef BOARD_LOW_RAM
+R"rawliteral(
+      <div style="padding:10px;margin-bottom:12px;background:#0D1117;border:1px solid #30363D;border-radius:6px;font-size:12px;color:#8B949E">
+        &#9432; This board supports one printer. Use ESP32-S3 for two printers.
+      </div>
+)rawliteral"
+#else
+R"rawliteral(
       <div style="display:flex;gap:8px;margin-bottom:12px">
         <button class="tab-btn" id="tab0" onclick="selectPrinterTab(0)"
                 style="flex:1;padding:8px;border:1px solid #30363D;border-radius:6px;background:#238636;color:#fff;cursor:pointer;font-weight:600">Printer 1</button>
         <button class="tab-btn" id="tab1" onclick="selectPrinterTab(1)"
                 style="flex:1;padding:8px;border:1px solid #30363D;border-radius:6px;background:#0D1117;color:#8B949E;cursor:pointer">Printer 2</button>
       </div>
+)rawliteral"
+#endif
+R"rawliteral(
       <div id="printerStatus" class="%STATUS_CLASS%">%STATUS_TEXT%</div>
       <label for="connmode">Connection Mode</label>
       <select id="connmode" onchange="toggleConnMode()">
@@ -1579,6 +1591,14 @@ static void handleSavePrinter() {
   uint8_t slot = 0;
   if (server.hasArg("slot")) slot = server.arg("slot").toInt();
   if (slot >= MAX_ACTIVE_PRINTERS) slot = 0;
+
+#ifdef BOARD_LOW_RAM
+  if (slot > 0) {
+    server.send(200, "application/json",
+      "{\"status\":\"error\",\"message\":\"This board supports only one printer due to RAM limits. Use ESP32-S3 for two printers.\"}");
+    return;
+  }
+#endif
 
   PrinterConfig& cfg = printers[slot].config;
   if (server.hasArg("connmode")) {


### PR DESCRIPTION
## Summary
- Add BOARD_LOW_RAM=1 build flag to [env:cyd] and [env:esp32c3] in platformio.ini
- Hide Printer 2 tab on low-RAM boards, show info banner instead
- Block saving second printer slot on backend with JSON error
- Update README with single-printer limitation note

Closes #52

## Test plan
- [x] Build env:cyd - compiles without errors
- [x] Build env:esp32c3 - compiles without errors
- [x] Build env:esp32s3 - compiles without errors, both printer tabs still visible
- [x] Flash CYD - web UI shows info banner, no Printer 2 tab
- [x] Flash S3 - web UI unchanged, both tabs work