### PR TITLE
Fix buzzer default pin conflict with backlight on C3

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -113,6 +113,12 @@
 // =============================================================================
 //  Buzzer (optional passive buzzer)
 // =============================================================================
-#define BUZZER_DEFAULT_PIN    5       // default GPIO for buzzer
+#if defined(BOARD_IS_C3)
+#define BUZZER_DEFAULT_PIN    3       // C3: GPIO 3 (GPIO 5 is backlight)
+#elif defined(DISPLAY_CYD) || defined(DISPLAY_240x320)
+#define BUZZER_DEFAULT_PIN    26      // CYD: GPIO 26
+#else
+#define BUZZER_DEFAULT_PIN    5       // S3: GPIO 5
+#endif
 
 #endif // CONFIG_H

--- a/src/buzzer.cpp
+++ b/src/buzzer.cpp
@@ -1,7 +1,18 @@
 #include "buzzer.h"
 #include "buzzer_backend.h"
 #include "settings.h"
+#include "config.h"
 #include <time.h>
+
+void sanitizeBuzzerPin() {
+  if (buzzerSettings.pin == 0) return;
+#if defined(BACKLIGHT_PIN)
+  if (buzzerSettings.pin == BACKLIGHT_PIN) {
+    Serial.printf("Buzzer: pin %d conflicts with backlight, disabling\n", buzzerSettings.pin);
+    buzzerSettings.pin = 0;
+  }
+#endif
+}
 
 // ---------------------------------------------------------------------------
 //  Tone patterns (frequency Hz, duration ms) - 0 freq = pause

--- a/src/buzzer.h
+++ b/src/buzzer.h
@@ -15,5 +15,6 @@ void buzzerPlay(BuzzerEvent event);
 void buzzerPlayClick();  // short click, ignores quiet hours and playing state
 void buzzerTick();  // call from loop() for non-blocking playback
 bool buzzerIsQuietHour();
+void sanitizeBuzzerPin();  // zero pin in RAM if it conflicts with BACKLIGHT_PIN
 
 #endif // BUZZER_H

--- a/src/buzzer_backend_gpio.cpp
+++ b/src/buzzer_backend_gpio.cpp
@@ -32,7 +32,6 @@ void buzzerBackendTick() {
 }
 
 void buzzerBackendShutdown() {
-  sanitizeBuzzerPin();
   buzzerBackendStop();
 }
 

--- a/src/buzzer_backend_gpio.cpp
+++ b/src/buzzer_backend_gpio.cpp
@@ -1,18 +1,8 @@
 #include "buzzer_backend.h"
+#include "buzzer.h"
 #include "settings.h"
-#include "config.h"
 
 #if !defined(BOARD_HAS_ES8311_AUDIO)
-
-static void sanitizeBuzzerPin() {
-  if (buzzerSettings.pin == 0) return;
-#if defined(BACKLIGHT_PIN)
-  if (buzzerSettings.pin == BACKLIGHT_PIN) {
-    Serial.printf("Buzzer: pin %d conflicts with backlight, disabling\n", buzzerSettings.pin);
-    buzzerSettings.pin = 0;
-  }
-#endif
-}
 
 void buzzerBackendInit() {
   sanitizeBuzzerPin();

--- a/src/buzzer_backend_gpio.cpp
+++ b/src/buzzer_backend_gpio.cpp
@@ -1,9 +1,21 @@
 #include "buzzer_backend.h"
 #include "settings.h"
+#include "config.h"
 
 #if !defined(BOARD_HAS_ES8311_AUDIO)
 
+static void sanitizeBuzzerPin() {
+  if (buzzerSettings.pin == 0) return;
+#if defined(BACKLIGHT_PIN)
+  if (buzzerSettings.pin == BACKLIGHT_PIN) {
+    Serial.printf("Buzzer: pin %d conflicts with backlight, disabling\n", buzzerSettings.pin);
+    buzzerSettings.pin = 0;
+  }
+#endif
+}
+
 void buzzerBackendInit() {
+  sanitizeBuzzerPin();
   if (buzzerSettings.pin == 0) return;
   pinMode(buzzerSettings.pin, OUTPUT);
   digitalWrite(buzzerSettings.pin, LOW);
@@ -20,6 +32,7 @@ void buzzerBackendApplyStep(uint16_t freq) {
 }
 
 void buzzerBackendStop() {
+  sanitizeBuzzerPin();
   if (buzzerSettings.pin == 0) return;
   noTone(buzzerSettings.pin);
   digitalWrite(buzzerSettings.pin, LOW);
@@ -29,6 +42,7 @@ void buzzerBackendTick() {
 }
 
 void buzzerBackendShutdown() {
+  sanitizeBuzzerPin();
   buzzerBackendStop();
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,5 +1,6 @@
 #include "settings.h"
 #include "config.h"
+#include "buzzer.h"
 #include "timezones.h"
 #include <Preferences.h>
 
@@ -474,6 +475,7 @@ void saveButtonSettings() {
 }
 
 void saveBuzzerSettings() {
+  sanitizeBuzzerPin();
   prefs.begin(NVS_NAMESPACE, false);
   prefs.putBool("buz_on", buzzerSettings.enabled);
   prefs.putUChar("buz_pin", buzzerSettings.pin);


### PR DESCRIPTION
## Summary
- BUZZER_DEFAULT_PIN was hardcoded to GPIO 5 for all boards
- On C3, GPIO 5 is the backlight pin — initBuzzer() turns the backlight off
- Display appears completely black after boot (backlight killed, not SPI issue)
- Set board-specific defaults: S3=GPIO 5, C3=GPIO 3, CYD=GPIO 26
- Add runtime safety check: if buzzer pin matches BACKLIGHT_PIN, disable buzzer

## Root cause
Introduced by commit 044190a (ES8311 speaker support) which refactored buzzer into backend abstraction. The new `buzzerBackendInit()` calls `pinMode(pin, OUTPUT)` + `digitalWrite(pin, LOW)` on the default pin, which on C3 is the backlight.

## Test plan
- [ ] All three environments build clean (esp32s3, cyd, esp32c3)
- [ ] Flashed C3 via serial — display stays visible through all screen states
- [ ] S3 and CYD unaffected (different backlight pins)