### PR TITLE
Add SenseCAP Indicator board support (ST7701S 480x480 RGB display + FT5X06 touch)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -102,6 +102,8 @@
 // =============================================================================
 #ifdef DISPLAY_240x320
 #define BUTTON_DEFAULT_PIN    0       // CYD: GPIO4 is RGB LED, not usable
+#elif defined(BOARD_IS_SENSECAP)
+#define BUTTON_DEFAULT_PIN    38      // SenseCAP Indicator: GPIO38 (inverted, normally HIGH)
 #else
 #define BUTTON_DEFAULT_PIN    4       // default GPIO for physical button
 #endif
@@ -119,6 +121,8 @@
 #define BUZZER_DEFAULT_PIN    3       // C3: GPIO 3 (GPIO 5 is backlight)
 #elif defined(DISPLAY_CYD) || defined(DISPLAY_240x320)
 #define BUZZER_DEFAULT_PIN    26      // CYD: GPIO 26
+#elif defined(BOARD_IS_SENSECAP)
+#define BUZZER_DEFAULT_PIN    255     // SenseCAP Indicator: no built-in buzzer (255 = disabled)
 #else
 #define BUZZER_DEFAULT_PIN    5       // S3: GPIO 5
 #endif

--- a/include/config.h
+++ b/include/config.h
@@ -111,7 +111,11 @@
 // =============================================================================
 //  Display refresh
 // =============================================================================
+#if defined(BOARD_IS_SENSECAP)
+#define DISPLAY_UPDATE_MS          100    // ~10 Hz refresh (PSRAM framebuffer can handle it)
+#else
 #define DISPLAY_UPDATE_MS          250    // ~4 Hz refresh rate
+#endif
 #define DISPLAY_STATE_TIMEOUT_MS   60000  // 60s timeout for intermediate display states
 
 // =============================================================================

--- a/include/layout.h
+++ b/include/layout.h
@@ -6,7 +6,9 @@
 // gauge positions, text positions, etc.
 // To add a new display: create layout_xxx.h and add an #elif here.
 
-#if defined(DISPLAY_240x320)
+#if defined(DISPLAY_480x480)
+  #include "layout_480x480.h"    // SenseCAP Indicator: ST7701S 480x480
+#elif defined(DISPLAY_240x320)
   #include "layout_240x320.h"   // 240x320 portrait (CYD, Waveshare)
 #else
   #include "layout_default.h"   // ESP32-S3 Mini: ST7789 240x240

--- a/include/layout_480x480.h
+++ b/include/layout_480x480.h
@@ -1,0 +1,110 @@
+#ifndef LAYOUT_480x480_H
+#define LAYOUT_480x480_H
+
+// Layout profile: SenseCAP Indicator ST7701S 480x480
+// Scaled 2x from the 240x240 default layout for crisp rendering on
+// the high-resolution display.
+
+// --- Screen dimensions ---
+#define LY_W    480
+#define LY_H    480
+
+// --- LED progress bar (top, y=0) ---
+#define LY_BAR_W   472
+#define LY_BAR_H   10
+
+// --- Header bar ---
+#define LY_HDR_Y        14
+#define LY_HDR_H        40
+#define LY_HDR_NAME_X   12
+#define LY_HDR_CY       34
+#define LY_HDR_BADGE_RX 16
+#define LY_HDR_DOT_CY   20
+
+// --- Printing: 2x3 gauge grid (2x of 240x240) ---
+#define LY_GAUGE_R   64
+#define LY_GAUGE_T   12
+#define LY_COL1      84
+#define LY_COL2      240
+#define LY_COL3      396
+#define LY_ROW1      120
+#define LY_ROW2      296
+
+// --- Printing: ETA / info zone ---
+#define LY_ETA_Y        380
+#define LY_ETA_H        60
+#define LY_ETA_TEXT_Y   410
+
+// --- Printing: bottom status bar ---
+#define LY_BOT_Y    444
+#define LY_BOT_H    36
+#define LY_BOT_CY   462
+
+// --- Printing: WiFi signal indicator ---
+#define LY_WIFI_X    8
+#define LY_WIFI_Y    462
+
+// --- Idle screen (with printer) ---
+#define LY_IDLE_NAME_Y      60
+#define LY_IDLE_STATE_Y      100
+#define LY_IDLE_STATE_H      40
+#define LY_IDLE_STATE_TY     120
+#define LY_IDLE_DOT_Y        170
+#define LY_IDLE_GAUGE_R      60
+#define LY_IDLE_GAUGE_Y      280
+#define LY_IDLE_G_OFFSET      110
+
+// --- Idle screen (no printer) ---
+#define LY_IDLE_NP_TITLE_Y  80
+#define LY_IDLE_NP_WIFI_Y   160
+#define LY_IDLE_NP_DOT_Y    210
+#define LY_IDLE_NP_MSG_Y    280
+#define LY_IDLE_NP_OPEN_Y   330
+#define LY_IDLE_NP_IP_Y    400
+
+// --- Finished screen ---
+#define LY_FIN_GAUGE_R   64
+#define LY_FIN_GL        144
+#define LY_FIN_GR        336
+#define LY_FIN_GY        160
+#define LY_FIN_TEXT_Y    296
+#define LY_FIN_FILE_Y    356
+#define LY_FIN_BOT_Y    440
+#define LY_FIN_BOT_H    40
+#define LY_FIN_WIFI_Y   462
+
+// --- AP mode screen ---
+#define LY_AP_TITLE_Y     80
+#define LY_AP_SSID_LBL_Y 160
+#define LY_AP_SSID_Y     220
+#define LY_AP_PASS_LBL_Y 280
+#define LY_AP_PASS_Y      316
+#define LY_AP_OPEN_Y      370
+#define LY_AP_IP_Y        420
+
+// --- Simple clock ---
+#define LY_CLK_CLEAR_Y   100
+#define LY_CLK_CLEAR_H   280
+#define LY_CLK_TIME_Y    200
+#define LY_CLK_AMPM_Y    270
+#define LY_CLK_DATE_Y    310
+
+// --- Pong/Breakout clock ---
+#define LY_ARK_BRICK_ROWS   5
+#define LY_ARK_COLS          10
+#define LY_ARK_BRICK_W      44
+#define LY_ARK_BRICK_H      16
+#define LY_ARK_BRICK_GAP    4
+#define LY_ARK_START_X      6
+#define LY_ARK_START_Y      56
+#define LY_ARK_PADDLE_Y     448
+#define LY_ARK_PADDLE_W     60
+#define LY_ARK_TIME_Y       260
+#define LY_ARK_DATE_Y       16
+#define LY_ARK_DIGIT_W      64
+#define LY_ARK_DIGIT_H      96
+#define LY_ARK_COLON_W      24
+#define LY_ARK_DATE_CLR_X   80
+#define LY_ARK_DATE_CLR_W   320
+
+#endif // LAYOUT_480x480_H

--- a/partitions_8mb.csv
+++ b/partitions_8mb.csv
@@ -1,0 +1,11 @@
+# Partition table for 8 MB flash (SenseCAP Indicator - ESP32-S3)
+# Dual OTA slots of 3 MB each, leaving room for NVS and FAT filesystem.
+# NOTE: changing the partition table requires a full USB flash; OTA cannot update it.
+#
+# Name,    Type,  SubType,  Offset,    Size,
+nvs,       data,  nvs,      0x9000,    0x5000,
+otadata,   data,  ota,      0xe000,    0x2000,
+phy_init,  data,  phy,      0x10000,    0x1000,
+ota_0,     app,   ota_0,    0x20000,    0x300000,
+ota_1,     app,   ota_1,    0x320000,   0x300000,
+ffat,      data,  fat,      0x620000,   0x1E0000,

--- a/platformio.ini
+++ b/platformio.ini
@@ -146,3 +146,36 @@ build_flags =
     ; --- USB Serial (C3 native USB CDC) ---
     -D ARDUINO_USB_CDC_ON_BOOT=1
     -D BOARD_LOW_RAM=1
+
+; =============================================================================
+;  SenseCAP Indicator (Seeed INDICATOR RP2040) + ST7701S 480x480 RGB
+;  ESP32-S3 + RP2040 dual-MCU, 8MB flash, octal PSRAM
+;  ST7701S display via SPI init + LCD_CAM RGB, FT5X06 touch, PCA9535PW IO expander
+; =============================================================================
+[env:sensecap_indicator]
+platform = espressif32
+board = seeed_sensecap_indicator
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = partitions_8mb.csv
+board_build.arduino.memory_type = qio_opi
+platform_packages =
+    ; Custom arduino-esp32 fork with TCA9535 IO expander support (based on 2.0.16)
+    ; Required for SenseCAP Indicator — display CS/RST are on the TCA9535 expander
+    platformio/framework-arduinoespressif32 @ https://github.com/mverch67/arduino-esp32/archive/aef7fef6de3329ed6f75512d46d63bba12b09bb5.zip
+lib_deps =
+    https://github.com/mverch67/LovyanGFX/archive/4c76238c1344162a234ae917b27651af146d6fb2.zip
+    knolleary/PubSubClient@^2.8
+    bblanchon/ArduinoJson@^7.0
+build_flags =
+    -D BOARD_VARIANT=\"sensecap_indicator\"
+    -D BOARD_IS_SENSECAP=1
+    -D DISPLAY_480x480=1
+    -D ENABLE_OTA_AUTO=1
+    -D BACKLIGHT_PIN=45
+    -D IO_EXPANDER=0x40
+    -D USE_ARDUINO_HAL_GPIO
+    -D USE_FT5X06
+    -D TOUCH_SLAVE_ADDRESS=0x48
+    -D BOARD_BTN_1=38
+    -D ARDUINO_USB_CDC_ON_BOOT=0

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -27,6 +27,28 @@
     value = Wire.read();
     return true;
   }
+#elif defined(USE_FT5X06)
+  #include <Wire.h>
+  #ifndef TOUCH_SLAVE_ADDRESS
+    #define TOUCH_SLAVE_ADDRESS 0x38
+  #endif
+  #define FT5X06_TOUCH_POINTS_REG 0x02  // TD_STATUS register
+  static bool ft5x06BusReady = false;
+  static bool ft5x06Seen = false;
+
+  static bool ft5x06Probe() {
+    Wire.beginTransmission(TOUCH_SLAVE_ADDRESS);
+    return Wire.endTransmission(true) == 0;
+  }
+
+  static bool ft5x06ReadReg(uint8_t reg, uint8_t& value) {
+    Wire.beginTransmission(TOUCH_SLAVE_ADDRESS);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom((uint8_t)TOUCH_SLAVE_ADDRESS, (uint8_t)1) != 1) return false;
+    value = Wire.read();
+    return true;
+  }
 #elif defined(TOUCH_CS)
   #include "display_ui.h"  // extern tft for getTouch()
 #endif
@@ -75,6 +97,30 @@ void initButton() {
     }
     return;
   }
+#elif defined(USE_FT5X06)
+  if (buttonType == BTN_TOUCHSCREEN) {
+    // FT5X06 uses same I2C bus as PCA9535PW IO expander (SDA=39, SCL=40)
+    // Touch RST is handled via PCA9535 pin 7 during display init
+    Wire.begin(39, 40);
+    Wire.setClock(400000);
+    ft5x06BusReady = true;
+    delay(50);  // Wait for touch controller to be ready after RST release
+    if (ft5x06Probe()) {
+      uint8_t touchPoints = 0;
+      if (ft5x06ReadReg(FT5X06_TOUCH_POINTS_REG, touchPoints)) {
+        Serial.printf("FT5X06 touch initialized (I2C addr 0x%02X, touchPoints=%d)\n",
+                      TOUCH_SLAVE_ADDRESS, touchPoints);
+        ft5x06Seen = true;
+      } else {
+        Serial.printf("FT5X06 detected on I2C addr 0x%02X, but register reads failed\n",
+                      TOUCH_SLAVE_ADDRESS);
+      }
+    } else {
+      Serial.printf("FT5X06 touch did not answer at init (addr 0x%02X); will keep retrying at runtime\n",
+                    TOUCH_SLAVE_ADDRESS);
+    }
+    return;
+  }
 #endif
   if (buttonType == BTN_TOUCHSCREEN) return;
   if (buttonPin == 0) return;
@@ -105,6 +151,15 @@ bool wasButtonPressed() {
       cst816Seen = true;
     }
     raw = (touchNum > 0);
+#elif defined(USE_FT5X06)
+    if (!ft5x06BusReady) return false;
+    uint8_t touchPoints = 0;
+    if (!ft5x06ReadReg(FT5X06_TOUCH_POINTS_REG, touchPoints)) return false;
+    if (!ft5x06Seen) {
+      Serial.printf("FT5X06 touch became responsive at runtime (addr 0x%02X)\n", TOUCH_SLAVE_ADDRESS);
+      ft5x06Seen = true;
+    }
+    raw = (touchPoints > 0);
 #elif defined(TOUCH_CS)
     uint16_t tx, ty;
     raw = tft.getTouch(&tx, &ty);

--- a/src/clock_mode.cpp
+++ b/src/clock_mode.cpp
@@ -50,6 +50,9 @@ void drawClock() {
   uint16_t timeClr = dispSettings.clockTimeColor;
   uint16_t dateClr = dispSettings.clockDateColor;
 
+  // Text size: scale up on high-res displays (480x480 uses 2x layout constants)
+  const int clkTextSize = (SCREEN_W >= 480) ? 2 : 1;
+
   // --- Colon blink (every call, ~250ms) ---
   bool colonOn = (millis() % 1000) < 500;
   if (colonOn != prevColon) {
@@ -58,7 +61,7 @@ void drawClock() {
     tft.fillRect(cx, cy, CLK_COLON_W, CLK_DIGIT_H, bg);
     if (colonOn) {
       tft.setTextFont(7);
-      tft.setTextSize(1);
+      tft.setTextSize(clkTextSize);
       tft.setTextColor(timeClr, bg);
       tft.drawChar(':', cx, cy, 7);
     }
@@ -86,7 +89,7 @@ void drawClock() {
 
   // Draw only changed digits
   tft.setTextFont(7);
-  tft.setTextSize(1);
+  tft.setTextSize(clkTextSize);
   tft.setTextColor(timeClr, bg);
 
   int dy = LY_CLK_TIME_Y - CLK_DIGIT_H / 2;  // top-left Y (MC_DATUM centers at LY_CLK_TIME_Y)
@@ -109,24 +112,27 @@ void drawClock() {
   }
 
   // --- AM/PM (12h mode) / clear stale AM/PM when switching to 24h ---
+  const int ampmFontH = clkTextSize * 12;  // approx height of Font 4 at scaled size
   if (!netSettings.use24h) {
     const char* ampm = now.tm_hour < 12 ? "AM" : "PM";
     if (strcmp(ampm, prevAmPm) != 0) {
       tft.setTextDatum(MC_DATUM);
       tft.setTextFont(4);
+      tft.setTextSize(clkTextSize);
       tft.setTextColor(dateClr, bg);
       int ampmW = tft.textWidth("PM");
       const int sw = clkScrW();
-      tft.fillRect(sw / 2 - ampmW / 2 - 2, LY_CLK_AMPM_Y - 12, ampmW + 4, 24, bg);
+      tft.fillRect(sw / 2 - ampmW / 2 - 2, LY_CLK_AMPM_Y - ampmFontH, ampmW + 4, ampmFontH * 2, bg);
       tft.drawString(ampm, sw / 2, LY_CLK_AMPM_Y);
       strlcpy(prevAmPm, ampm, sizeof(prevAmPm));
     }
   } else if (prevAmPm[0] != '\0') {
     tft.setTextDatum(MC_DATUM);
     tft.setTextFont(4);
+    tft.setTextSize(clkTextSize);
     int ampmW = tft.textWidth("PM");
     const int sw = clkScrW();
-    tft.fillRect(sw / 2 - ampmW / 2 - 2, LY_CLK_AMPM_Y - 12, ampmW + 4, 24, bg);
+    tft.fillRect(sw / 2 - ampmW / 2 - 2, LY_CLK_AMPM_Y - ampmFontH, ampmW + 4, ampmFontH * 2, bg);
     prevAmPm[0] = '\0';
   }
 
@@ -147,13 +153,15 @@ void drawClock() {
   if (strcmp(dateBuf, prevDateBuf) != 0) {
     tft.setTextDatum(MC_DATUM);
     tft.setTextFont(4);
+    tft.setTextSize(clkTextSize);
     tft.setTextColor(dateClr, bg);
     // Clear previous date, draw new
+    const int dateFontH = clkTextSize * 12;
     int dateW = tft.textWidth(prevDateBuf[0] ? prevDateBuf : dateBuf);
     int newW = tft.textWidth(dateBuf);
     int clearW = (dateW > newW) ? dateW : newW;
     const int sw = clkScrW();
-    tft.fillRect(sw / 2 - clearW / 2 - 2, LY_CLK_DATE_Y - 12, clearW + 4, 24, bg);
+    tft.fillRect(sw / 2 - clearW / 2 - 2, LY_CLK_DATE_Y - dateFontH, clearW + 4, dateFontH * 2, bg);
     tft.drawString(dateBuf, sw / 2, LY_CLK_DATE_Y);
     strlcpy(prevDateBuf, dateBuf, sizeof(prevDateBuf));
   }

--- a/src/clock_pong.cpp
+++ b/src/clock_pong.cpp
@@ -33,8 +33,11 @@
 #define ARK_LAND_BRICK_COLS 13
 
 // ========== Gameplay constants (not layout-dependent) ==========
-#define ARK_BALL_SIZE     4
-#define ARK_PADDLE_H      4
+// Logical ball size scales with display — bigger screen needs bigger ball for visibility
+#define ARK_BALL_SIZE_BASE 4
+#define ARK_BALL_SIZE      (SCREEN_W >= 480 ? ARK_BALL_SIZE_BASE * 2 : ARK_BALL_SIZE_BASE)
+#define ARK_PADDLE_H_BASE  4
+#define ARK_PADDLE_H      (SCREEN_W >= 480 ? ARK_PADDLE_H_BASE * 2 : ARK_PADDLE_H_BASE)
 #define ARK_BALL_SPEED    3.0f
 #define ARK_PADDLE_SPEED  4
 #define ARK_UPDATE_MS     20    // ~50fps
@@ -183,6 +186,9 @@ static void refreshPongLayout() {
   pongLayout = next;
 }
 
+// Text size: scale up on high-res displays (480x480 uses 2x layout constants)
+static const int pongTextSize = (SCREEN_W >= 480) ? 2 : 1;
+
 // ========== Digit bounce (inlined) ==========
 static void triggerBounce(int i) {
   if (i >= 0 && i < 5) digitVelocity[i] = -6.0f;
@@ -329,8 +335,9 @@ static bool overlapsText(int bx, int by) {
     int tRight = digitX(4) + DIGIT_W + 4;
     if (bx2 > tLeft && bx < tRight) return true;
   }
-  // Date zone (centered text clear width, scaled to the active screen width)
-  if (by2 > layout.dateY && by < layout.dateY + 16) {
+  // Date zone (centered text clear width, scaled with textSize)
+  int dateFontH = pongTextSize * 16;
+  if (by2 > layout.dateY && by < layout.dateY + dateFontH) {
     int dateLeft = (layout.screenW - LY_ARK_DATE_CLR_W) / 2;
     int dateRight = dateLeft + LY_ARK_DATE_CLR_W;
     if (bx2 > dateLeft && bx < dateRight) return true;
@@ -339,18 +346,14 @@ static bool overlapsText(int bx, int by) {
 }
 
 static void drawBall() {
+  // Erase old position, then draw new — both in the same function to prevent
+  // visible black holes between erase and redraw.  Text uses setTextColor(fg,bg)
+  // so it redraws atomically each frame, covering any ball erase overlap from
+  // the previous frame.
   if (prevBallX >= 0) {
-    // Ball passes behind text — no erase needed, no damage to repair
-    if (overlapsText(prevBallX, prevBallY)) {
-      // skip — ball was never drawn here
-    } else {
-      tft.fillRect(prevBallX, prevBallY, ARK_BALL_SIZE, ARK_BALL_SIZE, TFT_BLACK);
-    }
+    tft.fillRect(prevBallX, prevBallY, ARK_BALL_SIZE, ARK_BALL_SIZE, TFT_BLACK);
   }
-  // Don't draw ball over time digits — it passes behind
-  if (!overlapsText((int)ballX, (int)ballY)) {
-    tft.fillRect((int)ballX, (int)ballY, ARK_BALL_SIZE, ARK_BALL_SIZE, TFT_WHITE);
-  }
+  tft.fillRect((int)ballX, (int)ballY, ARK_BALL_SIZE, ARK_BALL_SIZE, TFT_WHITE);
   prevBallX = (int)ballX;
   prevBallY = (int)ballY;
 }
@@ -551,7 +554,7 @@ static int digitX(int i) {
 
 static void drawTime() {
   const PongLayout& layout = pongLayout;
-  tft.setTextSize(1);  // no scaling, Font 7 is already 48px
+  tft.setTextSize(pongTextSize);  // no scaling on 240px, 2x on 480px
   char digits[5];
   if (netSettings.use24h) {
     digits[0] = '0' + (dispHour / 10);
@@ -568,50 +571,52 @@ static void drawTime() {
 
   bool colon = showColon();
 
-  // Draw digits - only redraw changed ones
   tft.setTextFont(7);
-  tft.setTextSize(1);
+  tft.setTextSize(pongTextSize);
+  // Background fill mode: drawChar fills a black rect behind each glyph atomically,
+  // eliminating the flicker caused by separate fillRect + drawChar sequence.
   tft.setTextColor(dispSettings.clockTimeColor, TFT_BLACK);
 
+  // Always redraw every frame — text covers ball erase area each frame.
   for (int i = 0; i < 5; i++) {
     if (i == 2) continue;  // skip colon slot, handled separately
 
     int x = digitX(i);
     int y = layout.timeY + (int)digitOffsetY[i];
-    bool bouncing = (digitOffsetY[i] != 0 || digitVelocity[i] != 0);
-    bool changed = (digits[i] != prevDigits[i]) || bouncing || (prevDigitY[i] != y);
 
-    if (changed) {
-      // Clear previous and current position
-      int clearW = DIGIT_W + 2;  // +2 margin for font rendering
-      if (prevDigitY[i] != 0)
-        tft.fillRect(x, prevDigitY[i], clearW, DIGIT_H, TFT_BLACK);
-      if (prevDigitY[i] != y)
-        tft.fillRect(x, y, clearW, DIGIT_H, TFT_BLACK);
-
-      tft.drawChar(digits[i], x, y, 7);
-      prevDigits[i] = digits[i];
-      prevDigitY[i] = y;
+    // Clear previous position if digit moved (bounce animation)
+    if (prevDigitY[i] != 0 && prevDigitY[i] != y) {
+      tft.fillRect(x, prevDigitY[i], DIGIT_W + 2, DIGIT_H, TFT_BLACK);
     }
+
+    // Redraw with background — no separate fillRect needed, drawChar fills atomically
+    tft.drawChar(digits[i], x, y, 7);
+    prevDigits[i] = digits[i];
+    prevDigitY[i] = y;
   }
 
-  // Colon - blinks, draw only when state changes
-  if (colon != prevColon) {
+  // Colon — always redraw (ball may erase it)
+  {
     int cx = digitX(2);
-    tft.fillRect(cx, layout.timeY, COLON_W, DIGIT_H, TFT_BLACK);
+    // Background fill included in drawChar via setTextColor(fg, TFT_BLACK)
     if (colon) {
       tft.drawChar(':', cx, layout.timeY, 7);
+    } else {
+      tft.fillRect(cx, layout.timeY, COLON_W, DIGIT_H, TFT_BLACK);
     }
     prevColon = colon;
   }
 
-  // AM/PM for 12h mode
+  // AM/PM for 12h mode — always redraw (ball may erase it)
   if (!netSettings.use24h) {
+    bool am = (dispHour < 12);
     tft.setTextFont(2);
+    tft.setTextSize(pongTextSize);
     tft.setTextColor(dispSettings.clockDateColor, TFT_BLACK);
     int ampmX = digitX(4) + DIGIT_W + 2;
-    tft.setCursor(ampmX, layout.timeY + DIGIT_H - 16);
-    tft.print(dispHour < 12 ? "AM" : "PM");
+    int ampmY = layout.timeY + DIGIT_H - pongTextSize * 16;
+    tft.setCursor(ampmX, ampmY);
+    tft.print(am ? "AM" : "PM");
   }
 }
 
@@ -656,6 +661,7 @@ void tickPongClock() {
     memset(prevDigits, 0, sizeof(prevDigits));
     prevColon = false;
     prevBallX = -1;
+    prevBallY = -1;
     ballStuckToPaddle = false;
     ballStickyUntilMs = 0;
     ballStickyHit = 0.5f;
@@ -707,11 +713,14 @@ void tickPongClock() {
   updatePaddle();
   updateBounce();
 
-  // Draw ball and paddle first (they erase and may damage text)
-  drawBall();
-  drawPaddle();
+  // Hold the SPI bus for the entire frame draw — prevents other tasks from
+  // interleaving display operations that cause flicker.
+  tft.startWrite();
 
-  // Draw text on top (repairs any ball/paddle damage via cache invalidation)
+  // Draw text — always redraw every frame since the ball may erase digits.
+  // setTextWcolor(fg, bg) draws per-glyph backgrounds atomically, so no
+  // separate fillRect(black) clear is needed — eliminates the visible black
+  // flash between clear and redraw that caused flicker.
   // Date (Font 2, smooth)
   {
     const char* days[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
@@ -726,18 +735,25 @@ void tickPongClock() {
       case 5:  snprintf(dateStr, sizeof(dateStr), "%s %s %d, %04d", days[now.tm_wday], months[now.tm_mon], day, year); break;
       default: snprintf(dateStr, sizeof(dateStr), "%s %02d.%02d.%04d", days[now.tm_wday], day, mon, year); break;
     }
-    if (strcmp(dateStr, prevDateStr) != 0) {
-      tft.setTextFont(2);
-      tft.setTextSize(1);
-      tft.setTextDatum(TC_DATUM);
-      tft.setTextColor(dispSettings.clockDateColor, TFT_BLACK);
-      tft.fillRect(pongLayout.dateClearX, pongLayout.dateY, pongLayout.dateClearW, 16, TFT_BLACK);
-      tft.drawString(dateStr, pongLayout.screenW / 2, pongLayout.dateY);
-      tft.setTextDatum(TL_DATUM);
-      strlcpy(prevDateStr, dateStr, sizeof(prevDateStr));
-    }
+    tft.setTextFont(2);
+    tft.setTextSize(pongTextSize);
+    tft.setTextDatum(TC_DATUM);
+    // setTextColor(fg, bg) draws a black background behind each glyph atomically —
+    // no visible intermediate state, no flicker from a separate fillRect+drawString sequence.
+    tft.setTextColor(dispSettings.clockDateColor, TFT_BLACK);
+    tft.drawString(dateStr, pongLayout.screenW / 2, pongLayout.dateY);
+    tft.setTextDatum(TL_DATUM);
   }
 
-  // Time (Font 7, on top of everything)
+  // Time (Font 7, on top of date but below ball)
   drawTime();
+
+  // 3) Draw paddle (may erase ball if overlapping, but ball is redrawn next)
+  drawPaddle();
+
+  // 4) Draw ball on top of everything (so it's always visible, including on top of paddle)
+  drawBall();
+
+  // Release SPI bus — frame draw complete
+  tft.endWrite();
 }

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -14,6 +14,21 @@ static inline uint16_t alphaBlend565(uint8_t alpha, uint16_t fg, uint16_t bg) {
   return (r << 11) | (g << 5) | b;
 }
 
+// Return white or black text color that contrasts well against a given RGB565 background.
+// Uses perceived luminance (ITU-R BT.601 weights) to decide.
+static inline uint16_t contrastTextColor565(uint16_t bgColor) {
+  uint8_t r5 = (bgColor >> 11) & 0x1F;
+  uint8_t g6 = (bgColor >>  5) & 0x3F;
+  uint8_t b5 =  bgColor        & 0x1F;
+  // Scale to 0-255 for luminance calculation
+  uint8_t r8 = r5 * 255 / 31;
+  uint8_t g8 = g6 * 255 / 63;
+  uint8_t b8 = b5 * 255 / 31;
+  // ITU-R BT.601 perceived luminance
+  uint16_t lum = (uint16_t)(r8 * 77 + g8 * 150 + b8 * 29) / 256;
+  return (lum < 128) ? 0xFFFF : 0x0000;  // white on dark, black on light
+}
+
 // Holds the SPI bus for an entire gauge update. Without this, each primitive
 // (fillArc, fillCircle, drawString) opens+closes its own transaction and the
 // scheduler can interleave between them — producing visible intermediate
@@ -823,5 +838,314 @@ void drawClockWidget(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radiu
     tft.setTextFont(sm ? 1 : 2);
     tft.setTextColor(CLR_TEXT_DIM, bg);
     tft.drawString("Clock", cx, cy + radius + (sm ? 3 : -1));
+  }
+}
+
+// -----------------------------------------------------------------------------
+//  Filament type shorthand mapping
+// -----------------------------------------------------------------------------
+const char* getFilamentTypeLabel(const char* fullType) {
+  if (!fullType || !fullType[0]) return "---";
+  // Match Bambu-specific type codes to shorthand
+  if (strstr(fullType, "GFL99") || strstr(fullType, "PLA")) return "PLA";
+  if (strstr(fullType, "GFG99") || strstr(fullType, "PETG")) return "PETG";
+  if (strstr(fullType, "GFCR") || strstr(fullType, "CF") || strstr(fullType, "Carbon")) return "CF";
+  if (strstr(fullType, "GFT99") || strstr(fullType, "TPU")) return "TPU";
+  if (strstr(fullType, "GFAB") || strstr(fullType, "ABS")) return "ABS";
+  if (strstr(fullType, "GFPA") || strstr(fullType, "PA")) return "PA";
+  if (strstr(fullType, "GFPA-CF") || strstr(fullType, "PA-CF")) return "PA-CF";
+  if (strstr(fullType, "GFSG") || strstr(fullType, "SG")) return "SG";
+  if (strstr(fullType, "GFPEI") || strstr(fullType, "PEI")) return "PEI";
+  if (strstr(fullType, "PVB")) return "PVB";
+  if (strstr(fullType, "HPCS")) return "HPCS";
+  if (strstr(fullType, "PVA")) return "PVA";
+  if (strstr(fullType, "ECO")) return "ECO";
+  // Generic fallback: extract first 4 chars
+  static char buf[5];
+  strlcpy(buf, fullType, sizeof(buf));
+  return buf;
+}
+
+// -----------------------------------------------------------------------------
+//  AMS Filament gauge - shows active tray color swatch + type label
+// -----------------------------------------------------------------------------
+void drawAmsFilamentGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                          int16_t thickness, const AmsState& ams,
+                          bool forceRedraw) {
+  ScopedWrite sw(tft);
+  uint16_t bg = dispSettings.bgColor;
+
+  if (forceRedraw) {
+    tft.fillCircle(cx, cy, radius + 2, bg);
+  }
+
+  // Find active tray
+  uint8_t activeTray = ams.activeTray;
+  const AmsTray* tray = nullptr;
+  if (ams.present && activeTray < AMS_MAX_TRAYS) {
+    tray = &ams.trays[activeTray];
+  }
+
+  // Build label: type + remain%
+  char mainText[12];
+  char subText[12];
+  uint16_t swatchColor = CLR_TEXT_DIM;
+
+  if (tray && tray->present) {
+    strlcpy(mainText, getFilamentTypeLabel(tray->type), sizeof(mainText));
+    swatchColor = tray->colorRgb565;
+    if (tray->remain >= 0) {
+      snprintf(subText, sizeof(subText), "%d%%", tray->remain);
+    } else {
+      subText[0] = '\0';
+    }
+  } else if (ams.present && ams.unitCount > 0) {
+    // AMS is connected but no active tray selected — show AMS status
+    strlcpy(mainText, "AMS OK", sizeof(mainText));
+    swatchColor = CLR_TEXT_DIM;
+    subText[0] = '\0';
+  } else {
+    strlcpy(mainText, "No AMS", sizeof(mainText));
+    subText[0] = '\0';
+  }
+
+  // Only redraw if text changed
+  if (!gaugeTextChanged(cx, cy, mainText, subText, forceRedraw)) return;
+
+  tft.fillCircle(cx, cy, radius - 1, bg);
+
+  // Draw color swatch circle in center
+  int16_t swatchR = radius * 5 / 12;  // ~42% of gauge radius
+  if (swatchR < 4) swatchR = 4;
+  tft.fillCircle(cx, cy, swatchR, swatchColor);
+
+  // White border on swatch for visibility
+  uint16_t swatchBorder = alphaBlend565(100, 0xFFFF, swatchColor);
+  tft.drawCircle(cx, cy, swatchR + 1, swatchBorder);
+
+  // Draw type label below swatch
+  tft.setTextDatum(MC_DATUM);
+  tft.setTextFont(2);
+  tft.setTextColor(CLR_TEXT, bg);
+  tft.drawString(mainText, cx, cy + radius * 4 / 10);
+
+  // Draw remain % as subtitle if present
+  if (subText[0]) {
+    tft.setTextFont(1);
+    tft.setTextColor(CLR_TEXT_DIM, bg);
+    tft.drawString(subText, cx, cy + radius * 6 / 10);
+  }
+
+  // Draw "AMS" label at bottom
+  bool sm = dispSettings.smallLabels;
+  tft.setTextFont(sm ? 1 : 2);
+  tft.setTextColor(CLR_TEXT_DIM, bg);
+  tft.drawString("AMS", cx, cy + radius + (sm ? 3 : -1));
+}
+
+// -----------------------------------------------------------------------------
+//  AMS Filament All gauge - circular gauge divided into 4 quadrants
+//  Top-Left=Slot1, Top-Right=Slot2, Bottom-Right=Slot3, Bottom-Left=Slot4
+//  Separator lines: solid left half of horizontal, dotted elsewhere.
+//  Each quadrant: filament color bg + type label + % remaining.
+//  Humidity "H{n}" shown in a tiny circle at the center of the gauge.
+// -----------------------------------------------------------------------------
+void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                             int16_t thickness, const struct AmsState& ams,
+                             bool forceRedraw) {
+  ScopedWrite sw(tft);
+  uint16_t bg = dispSettings.bgColor;
+  uint16_t dim = CLR_TEXT_DIM;
+
+  if (forceRedraw) {
+    tft.fillCircle(cx, cy, radius + 2, bg);
+  }
+
+  const int16_t innerR = radius - 2;
+
+  // Fill circle background
+  tft.fillCircle(cx, cy, innerR, bg);
+
+  // Humidity color scale: 0=dry (green) to 5=wet (red)
+  static const uint16_t humidColors[6] = {
+    0x07E0,  // 0 - green
+    0xAFE5,  // 1 - light green
+    0xFFE0,  // 2 - yellow
+    0xFC80,  // 3 - orange
+    0xF800,  // 4 - red
+    0x7800   // 5 - dark red
+  };
+
+  uint8_t humidLevel = 0;
+  if (ams.present && ams.unitCount > 0) {
+    humidLevel = ams.units[0].humidity;
+    if (humidLevel > 5) humidLevel = 5;
+  }
+  uint16_t hColor = humidColors[humidLevel];
+
+  // Quadrant slot mapping: TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4
+  // trays[0]=Slot1, trays[1]=Slot2, trays[2]=Slot3, trays[3]=Slot4
+  static const int8_t qSlotX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
+  static const int8_t qSlotY[4] = {-1, -1, 1, 1};
+  const int16_t halfR = innerR;
+  // Inset text toward center so it doesn't touch the circle edge
+  const int16_t textInset = 5;
+  const int16_t qCX = halfR / 2;  // quadrant center X offset
+  const int16_t qCY = halfR / 2;  // quadrant center Y offset
+
+  for (int qi = 0; qi < 4; qi++) {
+    const AmsTray& tray = ams.trays[qi];
+    int16_t qCenterX = cx + qSlotX[qi] * qCX;
+    int16_t qCenterY = cy + qSlotY[qi] * qCY;
+
+    // Quadrant fill rectangle
+    int16_t fx, fy, fw, fh;
+    if (qi == 0) {        // Top-Left
+      fx = cx - halfR;  fy = cy - halfR;  fw = halfR;  fh = halfR;
+    } else if (qi == 1) { // Top-Right
+      fx = cx;           fy = cy - halfR;  fw = halfR;  fh = halfR;
+    } else if (qi == 2) { // Bottom-Right
+      fx = cx;           fy = cy;          fw = halfR;  fh = halfR;
+    } else {              // Bottom-Left
+      fx = cx - halfR;  fy = cy;          fw = halfR;  fh = halfR;
+    }
+
+    if (tray.present) {
+      uint16_t swatchColor = tray.colorRgb565;
+
+      // Fill quadrant with filament color
+      tft.fillRect(fx + 1, fy + 1, fw - 2, fh - 2, swatchColor);
+
+      // Contrast border around quadrant
+      uint16_t borderCol = alphaBlend565(60, 0xFFFF, swatchColor);
+      tft.drawRoundRect(fx + 1, fy + 1, fw - 2, fh - 2, 2, borderCol);
+
+      // Pick text color that contrasts well against the filament color
+      uint16_t txtColor = contrastTextColor565(swatchColor);
+
+      // Inset text toward center of circle to avoid touching the edges
+      int16_t tCX = qCenterX - qSlotX[qi] * textInset;
+      int16_t tCY = qCenterY - qSlotY[qi] * textInset;
+
+      // Type label (Font 2)
+      const char* typeLabel = getFilamentTypeLabel(tray.type);
+      tft.setTextDatum(MC_DATUM);
+      tft.setTextFont(2);
+      tft.setTextColor(txtColor, swatchColor);
+      tft.drawString(typeLabel, tCX, tCY - 8);
+
+      // Remaining % (Font 2)
+      char remainBuf[8];
+      if (tray.remain >= 0) {
+        snprintf(remainBuf, sizeof(remainBuf), "%d%%", tray.remain);
+      } else {
+        strlcpy(remainBuf, "--%", sizeof(remainBuf));
+      }
+      tft.setTextFont(2);
+      tft.setTextColor(txtColor, swatchColor);
+      tft.drawString(remainBuf, tCX, tCY + 10);
+    } else {
+      // Empty slot — inset toward center
+      int16_t tCX = qCenterX - qSlotX[qi] * textInset;
+      int16_t tCY = qCenterY - qSlotY[qi] * textInset;
+      tft.setTextDatum(MC_DATUM);
+      tft.setTextFont(2);
+      tft.setTextColor(dim, bg);
+      tft.drawString("--", tCX, tCY);
+    }
+  }
+
+  // Clip quadrant fill rectangles to the circle:
+  // Erase the 4 corner areas outside the circle by drawing bg-colored
+  // fast horizontal lines from the bounding square edges to the chord.
+  for (int16_t y = cy - innerR; y <= cy + innerR; y++) {
+    int16_t dy = y - cy;
+    int32_t d2 = (int32_t)dy * dy;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 >= r2) continue;
+    int16_t halfChord = (int16_t)sqrtf((float)(r2 - d2));
+    // Erase left side: from bounding square left edge to circle left edge
+    tft.drawFastHLine(cx - innerR, y, innerR - halfChord, bg);
+    // Erase right side: from circle right edge to bounding square right edge
+    tft.drawFastHLine(cx + halfChord, y, innerR - halfChord, bg);
+  }
+  // Erase rows above and below the circle entirely
+  tft.fillRect(cx - innerR, cy - innerR - 1, innerR * 2 + 1, 2, bg);
+  tft.fillRect(cx - innerR, cy + innerR, innerR * 2 + 1, 2, bg);
+
+  // Redraw circle boundary ring
+  uint16_t ringColor = alphaBlend565(80, 0xFFFF, bg);
+  tft.drawCircle(cx, cy, innerR, ringColor);
+
+  // Separator lines: all dotted except the TL↔BL (left vertical) segment.
+  //
+  //   Slot1 (TL)  ·  Slot2 (TR)
+  //       ·  ┃  ·
+  //   Slot4 (BL)  ·  Slot3 (BR)
+  //
+  // Left half of horizontal (between TL & BL) = SOLID
+  // Everything else = dotted
+
+  // Solid left-half of horizontal line (between TL/Slot1 and BL/Slot4)
+  {
+    int16_t startX = cx - innerR + 2;
+    int16_t endX = cx;
+    for (int16_t x = startX; x < endX; x++) {
+      int16_t dx = x - cx;
+      int32_t d2 = (int32_t)dx * dx;
+      int32_t r2 = (int32_t)innerR * innerR;
+      if (d2 < r2) {
+        tft.drawPixel(x, cy, dim);
+      }
+    }
+  }
+
+  // Dotted right-half of horizontal line (between TR/Slot2 and BR/Slot3)
+  for (int16_t dx = 1; dx < innerR - 2; dx += 3) {
+    int32_t d2 = (int32_t)dx * dx;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 < r2) {
+      tft.drawPixel(cx + dx, cy, dim);
+    }
+  }
+
+  // Dotted vertical line — both top half (TL↔TR) and bottom half (BL↔BR)
+  for (int16_t dy = -innerR + 3; dy < innerR - 2; dy += 3) {
+    int32_t d2 = (int32_t)dy * dy;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 < r2) {
+      tft.drawPixel(cx, cy + dy, dim);
+    }
+  }
+
+  // Slot number labels at the corners outside the circle
+  // Placed diagonally outside the circle boundary, near each quadrant
+  static const int8_t sNumX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
+  static const int8_t sNumY[4] = {-1, -1, 1, 1};
+  static const char* sNumLabel[4] = {"1", "2", "3", "4"};
+  // 45-degree offset: place labels along diagonal outside the circle
+  // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
+  int16_t diagOff = (int16_t)(radius * 0.71f) + 4;  // just outside the circle edge
+  tft.setTextDatum(MC_DATUM);
+  tft.setTextFont(1);
+  for (int i = 0; i < 4; i++) {
+    int16_t nx = cx + sNumX[i] * diagOff;
+    int16_t ny = cy + sNumY[i] * diagOff;
+    tft.setTextColor(dim, bg);
+    tft.drawString(sNumLabel[i], nx, ny);
+  }
+
+  // Humidity indicator: tiny circle at the center of the gauge
+  // Draw a small filled circle with bg color to clear the center, then outline + text
+  const int16_t humCircleR = 10;
+  tft.fillCircle(cx, cy, humCircleR, bg);
+  tft.drawCircle(cx, cy, humCircleR, dim);
+  if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
+    char humBuf[4];
+    snprintf(humBuf, sizeof(humBuf), "H%d", ams.units[0].humidity);
+    tft.setTextDatum(MC_DATUM);
+    tft.setTextFont(1);
+    tft.setTextColor(hColor, bg);
+    tft.drawString(humBuf, cx, cy);
   }
 }

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -1133,7 +1133,7 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
   int16_t diagOff = (int16_t)(radius * 0.71f) + 4;  // just outside the circle edge
   tft.setTextDatum(MC_DATUM);
-  tft.setTextFont(2);  // Font 2 for slot numbers (larger, more readable)
+  tft.setTextFont(3);  // Font 3 for slot numbers (large, easy to read)
   for (int i = 0; i < 4; i++) {
     int16_t nx = cx + sNumX[i] * diagOff;
     int16_t ny = cy + sNumY[i] * diagOff;
@@ -1143,14 +1143,17 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
 
   // Humidity indicator: tiny circle at the center of the gauge
   // Bambu humidity: 5=dry(good), 1=wet(bad) — inverted display: 1=dry, 5=wet
-  const int16_t humCircleR = 12;
+  const int16_t humCircleR = 13;
   tft.fillCircle(cx, cy, humCircleR, bg);
   tft.drawCircle(cx, cy, humCircleR, dim);
   if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
     char humBuf[4];
-    // Invert displayed value: Bambu 5→1(dry), 1→5(wet) so higher=wetter (human intuition)
-    uint8_t displayHumid = (ams.units[0].humidity > 0 && ams.units[0].humidity <= 5)
-                           ? (6 - ams.units[0].humidity) : 0;
+    // Display humidity: show raw Bambu value. Bambu scale: 1=wet, 5=dry.
+    // Invert for display: higher=wetter (1→5 very wet, 5→1 dry)
+    uint8_t displayHumid = ams.units[0].humidity;
+    if (displayHumid >= 1 && displayHumid <= 5) {
+      displayHumid = 6 - displayHumid;
+    }
     snprintf(humBuf, sizeof(humBuf), "H%d", displayHumid);
     tft.setTextDatum(MC_DATUM);
     tft.setTextFont(2);

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -1133,7 +1133,7 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
   int16_t diagOff = (int16_t)(radius * 0.71f) + 4;  // just outside the circle edge
   tft.setTextDatum(MC_DATUM);
-  tft.setTextFont(3);  // Font 3 for slot numbers (large, easy to read)
+  tft.setTextFont(4);  // Font 4 for slot numbers (large, bold, easy to read)
   for (int i = 0; i < 4; i++) {
     int16_t nx = cx + sNumX[i] * diagOff;
     int16_t ny = cy + sNumY[i] * diagOff;

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -1131,7 +1131,8 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   static const char* sNumLabel[4] = {"1", "2", "3", "4"};
   // 45-degree offset: place labels along diagonal outside the circle
   // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
-  int16_t diagOff = (int16_t)(radius * 0.71f) + 4;  // just outside the circle edge
+  // Font 4 glyphs are ~26px tall; need extra offset to clear the circle edge
+  int16_t diagOff = (int16_t)(radius * 0.71f) + 14;
   tft.setTextDatum(MC_DATUM);
   tft.setTextFont(4);  // Font 4 for slot numbers (large, bold, easy to read)
   for (int i = 0; i < 4; i++) {

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -703,12 +703,15 @@ void drawHumidityGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t rad
   if (fillEnd > 300) fillEnd = 300;
 
   // Color based on humidity level (0-5): green = dry, red = humid
+  // Bambu AMS humidity field: 5 = bone dry (good), 1 = very wet (bad).
+  // Invert for color mapping: wetLevel = (6 - humidity) so 5→1(good/green) and 1→5(bad/red).
+  uint8_t wetLevel = (humidityLevel > 0) ? (6 - humidityLevel) : 0;
   uint16_t arcColor;
-  if (!present || humidityLevel == 0) {
+  if (!present || wetLevel == 0) {
     arcColor = CLR_TEXT_DIM;
-  } else if (humidityLevel <= 2) {
+  } else if (wetLevel <= 2) {
     arcColor = CLR_GREEN;
-  } else if (humidityLevel <= 3) {
+  } else if (wetLevel <= 3) {
     arcColor = CLR_YELLOW;
   } else {
     arcColor = CLR_RED;
@@ -966,19 +969,22 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   // Fill circle background
   tft.fillCircle(cx, cy, innerR, bg);
 
-  // Humidity color scale: 0=dry (green) to 5=wet (red)
+  // Humidity color scale: Bambu humidity field is INVERTED (5=dry/good, 1=wet/bad).
+  // Invert for display: idx=0→dim, idx 1,2→green-ish (dry), idx 3→yellow, idx 4,5→red-ish (wet)
   static const uint16_t humidColors[6] = {
-    0x07E0,  // 0 - green
-    0xAFE5,  // 1 - light green
-    0xFFE0,  // 2 - yellow
-    0xFC80,  // 3 - orange
-    0xF800,  // 4 - red
-    0x7800   // 5 - dark red
+    0x18E3,  // 0 - dim (no data)
+    0x07E0,  // 1 - green  (Bambu 5 = bone dry)
+    0xAFE5,  // 2 - light green (Bambu 4 = dry)
+    0xFFE0,  // 3 - yellow (Bambu 3 = moderate)
+    0xFC80,  // 4 - orange (Bambu 2 = humid)
+    0xF800   // 5 - red   (Bambu 1 = very wet)
   };
 
   uint8_t humidLevel = 0;
   if (ams.present && ams.unitCount > 0) {
-    humidLevel = ams.units[0].humidity;
+    // Invert: Bambu 5→1(dry), Bambu 1→5(wet), Bambu 0→0(no data)
+    uint8_t rawHumid = ams.units[0].humidity;
+    humidLevel = (rawHumid > 0 && rawHumid <= 5) ? (6 - rawHumid) : 0;
     if (humidLevel > 5) humidLevel = 5;
   }
   uint16_t hColor = humidColors[humidLevel];
@@ -1127,7 +1133,7 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
   int16_t diagOff = (int16_t)(radius * 0.71f) + 4;  // just outside the circle edge
   tft.setTextDatum(MC_DATUM);
-  tft.setTextFont(1);
+  tft.setTextFont(2);  // Font 2 for slot numbers (larger, more readable)
   for (int i = 0; i < 4; i++) {
     int16_t nx = cx + sNumX[i] * diagOff;
     int16_t ny = cy + sNumY[i] * diagOff;
@@ -1136,15 +1142,18 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   }
 
   // Humidity indicator: tiny circle at the center of the gauge
-  // Draw a small filled circle with bg color to clear the center, then outline + text
-  const int16_t humCircleR = 10;
+  // Bambu humidity: 5=dry(good), 1=wet(bad) — inverted display: 1=dry, 5=wet
+  const int16_t humCircleR = 12;
   tft.fillCircle(cx, cy, humCircleR, bg);
   tft.drawCircle(cx, cy, humCircleR, dim);
   if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
     char humBuf[4];
-    snprintf(humBuf, sizeof(humBuf), "H%d", ams.units[0].humidity);
+    // Invert displayed value: Bambu 5→1(dry), 1→5(wet) so higher=wetter (human intuition)
+    uint8_t displayHumid = (ams.units[0].humidity > 0 && ams.units[0].humidity <= 5)
+                           ? (6 - ams.units[0].humidity) : 0;
+    snprintf(humBuf, sizeof(humBuf), "H%d", displayHumid);
     tft.setTextDatum(MC_DATUM);
-    tft.setTextFont(1);
+    tft.setTextFont(2);
     tft.setTextColor(hColor, bg);
     tft.drawString(humBuf, cx, cy);
   }

--- a/src/display_gauges.h
+++ b/src/display_gauges.h
@@ -49,4 +49,17 @@ void drawLayerGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius
 // Reset cached text (call on screen/printer transitions)
 void resetGaugeTextCache();
 
+// Get short filament type label (e.g., "PLA", "PETG", "TPU", "ABS")
+const char* getFilamentTypeLabel(const char* fullType);
+
+// Draw AMS Filament gauge - shows active tray color swatch + type label
+void drawAmsFilamentGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                         int16_t thickness, const struct AmsState& ams,
+                         bool forceRedraw);
+
+// Draw AMS Filament All gauge - shows all 4 trays: color + type + % + humidity
+void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                             int16_t thickness, const struct AmsState& ams,
+                             bool forceRedraw);
+
 #endif // DISPLAY_GAUGES_H

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -12,6 +12,9 @@
 #include "tasmota.h"
 #include <WiFi.h>
 #include <time.h>
+#if defined(BOARD_IS_SENSECAP)
+#include <Wire.h>     // PCA9535PW I2C IO expander
+#endif
 #include <new>   // placement new for CYD panel variant selection
 
 // =============================================================================
@@ -243,8 +246,140 @@ public:
 };
 static LGFX_C3 _tft_instance;
 
+#elif defined(BOARD_IS_SENSECAP)
+// --- SenseCAP Indicator (ESP32-S3 + ST7701S 480x480 RGB) ---------------------
+//
+// Hardware:
+//   ST7701S 480x480 RGB TFT with SPI init commands
+//   PCA9535PW I2C IO expander (addr 0x20) for display CS/RST and touch INT/RST
+//   FT5X06 capacitive touch (I2C addr 0x38)
+//   Backlight PWM on GPIO45
+//
+// The display init sequence:
+//   1. Initialize I2C bus and PCA9535PW IO expander
+//   2. Toggle display reset via IO expander pin 5
+//   3. Pull display CS low via IO expander pin 4
+//   4. Send ST7701S init commands via SPI (3-wire: CLK=41, MOSI=48)
+//   5. Release display CS (high) via IO expander pin 4
+//   6. Switch to LCD_CAM RGB parallel mode for pixel data
+
+#include <lgfx/v1/platforms/esp32s3/Panel_RGB.hpp>
+#include <lgfx/v1/platforms/esp32s3/Bus_RGB.hpp>
+
+// PCA9535PW I2C IO expander definitions
+#define PCA9535_I2C_SDA   39
+#define PCA9535_I2C_SCL   40
+#define PCA9535_ADDR       0x20
+#define PCA9535_PIN_DISP_CS  4   // Display chip select (active LOW)
+#define PCA9535_PIN_DISP_RST  5   // Display reset (active LOW)
+#define PCA9535_PIN_TOUCH_RST 7 // Touch reset (active LOW)
+// IO_EXPANDER flag for LovyanGFX: upper bits of I2C expander GPIO pin
+// (pin | 0x40) tells LovyanGFX to use I2C expander for that GPIO
+#define IO_EXPANDER 0x40
+
+// Custom panel class for SenseCAP Indicator ST7701S.
+// Uses default Panel_ST7701 init commands (0x3A=0x60 RGB666, 0x21 IPS inversion).
+// The default LovyanGFX Panel_ST7701 init matches Meshtastic's working config.
+// RGB666 (0x60) is correct even with 16-bit bus — the ST7701S maps the 16 data
+// lines to its internal 18-bit RGB channels correctly when set to RGB666 mode.
+// Using RGB565 (0x50) caused R↔G channel swap because the bit packing differs.
+class Panel_ST7701_SenseCAP : public lgfx::Panel_ST7701 {
+  // No getInitCommands override — use default Panel_ST7701 init sequence:
+  // - 0x3A=0x60 (RGB666 pixel format)
+  // - 0x21 (IPS inversion on)
+  // - All voltage/gamma registers from default list0
+};
+
+class LGFX_SenseCAP : public lgfx::LGFX_Device {
+  Panel_ST7701_SenseCAP _panel;
+  lgfx::Bus_RGB          _bus;
+public:
+  LGFX_SenseCAP() {
+    // --- Panel config (480x480 ST7701S) ---
+    {
+      auto cfg = _panel.config();
+      cfg.memory_width  = 480;   // Match Meshtastic working config (ST7701S internal column count for 480px panel)
+      cfg.memory_height = 480;
+      cfg.panel_width   = 480;
+      cfg.panel_height  = 480;
+      cfg.offset_x    = 0;
+      cfg.offset_y  = 0;
+      cfg.invert     = false;  // Default Panel_ST7701 list0 already sends 0x21 (IPS inversion on). Setting this true would send 0x21 AGAIN toggling inversion OFF.
+      cfg.pin_rst    = -1;      // RST is via PCA9535PW — managed in initDisplay()
+      _panel.config(cfg);
+    }
+    // --- SPI init pins for ST7701S command interface ---
+    // Commands are sent via 3-wire SPI (9-bit) before the RGB data bus starts.
+    // CS is routed through the PCA9535PW IO expander (pin 4), so we tell
+    // LovyanGFX to use GPIO 4 | IO_EXPANDER (0x44) as the CS pin — this is
+    // how Meshtastic configures it too. LovyanGFX will handle CS toggling.
+    {
+      auto detail = _panel.config_detail();
+      detail.pin_cs    = (4 | IO_EXPANDER);  // CS via PCA9535 pin 4 — mverch67 fork handles IO expander GPIO
+      detail.pin_sclk  = 41;                 // SPI clock for init commands
+      detail.pin_mosi  = 48;                 // SPI data for init commands
+      detail.use_psram = 1;                   // Use PSRAM for framebuffer (per Meshtastic working config)
+      _panel.config_detail(detail);
+    }
+    // --- RGB data bus (via LCD_CAM peripheral) ---
+    // Pin mapping from Seeed's official SenseCAP Indicator Arduino tutorial
+    // and ESPHome ST7701S component. RGB565 = 16-bit, D0-D15.
+    {
+      auto bus_cfg = _bus.config();
+      bus_cfg.panel = &_panel;  // CRITICAL: Bus_RGB needs panel reference for getWriteDepth()
+
+      // Control signals
+      bus_cfg.pin_pclk    = 21;
+      bus_cfg.pin_vsync   = 17;
+      bus_cfg.pin_hsync   = 16;
+      bus_cfg.pin_henable = 18;  // DE (Data Enable)
+
+      // RGB565 data pins — matched to Meshtastic 2.7.15 working config
+      // R0-R4 = GPIOs 4,3,2,1,0 (d11-d15), G0-G5 = GPIOs 10,9,8,7,6,5 (d5-d10)
+      // B0-B4 = GPIOs 15,14,13,12,11 (d0-d4)
+      bus_cfg.pin_d0  = 15;  // B0
+      bus_cfg.pin_d1  = 14;  // B1
+      bus_cfg.pin_d2  = 13;  // B2
+      bus_cfg.pin_d3  = 12;  // B3
+      bus_cfg.pin_d4  = 11;  // B4
+      bus_cfg.pin_d5  = 10;  // G0
+      bus_cfg.pin_d6  =  9;  // G1
+      bus_cfg.pin_d7  =  8;  // G2
+      bus_cfg.pin_d8  =  7;  // G3
+      bus_cfg.pin_d9  =  6;  // G4
+      bus_cfg.pin_d10 =  5;  // G5
+      bus_cfg.pin_d11 =  4;  // R0
+      bus_cfg.pin_d12 =  3;  // R1
+      bus_cfg.pin_d13 =  2;  // R2
+      bus_cfg.pin_d14 =  1;  // R3
+      bus_cfg.pin_d15 =  0;  // R4
+
+      // Pixel clock frequency — 6 MHz per Meshtastic working config
+      bus_cfg.freq_write = 6000000;
+
+      // Timing — matched to Meshtastic 2.7.15 working config
+      bus_cfg.hsync_polarity    = 0;   // Active high (per Meshtastic)
+      bus_cfg.hsync_front_porch = 10;
+      bus_cfg.hsync_pulse_width = 8;
+      bus_cfg.hsync_back_porch  = 50;
+      bus_cfg.vsync_polarity    = 0;   // Active high (per Meshtastic)
+      bus_cfg.vsync_front_porch = 10;
+      bus_cfg.vsync_pulse_width = 8;
+      bus_cfg.vsync_back_porch  = 20;
+      bus_cfg.pclk_active_neg   = 0;   // PCLK active high (per Meshtastic)
+      bus_cfg.de_idle_high      = 1;   // DE idle high (per Meshtastic)
+      bus_cfg.pclk_idle_high    = 0;   // PCLK idle low (per Meshtastic)
+
+      _bus.config(bus_cfg);
+      _panel.setBus(&_bus);
+    }
+    setPanel(&_panel);
+  }
+};
+static LGFX_SenseCAP _tft_instance;
+
 #else
-  #error "No board variant defined. Add BOARD_IS_S3, DISPLAY_CYD, BOARD_IS_C3, BOARD_IS_WS200 or BOARD_IS_WS154 to build_flags."
+  #error "No board variant defined. Add BOARD_IS_S3, DISPLAY_CYD, BOARD_IS_C3, BOARD_IS_WS200, BOARD_IS_WS154 or BOARD_IS_SENSECAP to build_flags."
 #endif
 
 // Global pointer + reference — accessed via `tft` throughout the codebase.
@@ -368,8 +503,49 @@ static inline bool landBottomBarFullWidth(uint8_t) { return true; }
 //  Init
 // ---------------------------------------------------------------------------
 void initDisplay() {
-  Serial.println("Display: pre-init delay...");
   delay(500);
+
+#if defined(BOARD_IS_SENSECAP)
+  // Initialize PCA9535PW I2C IO expander before display init.
+  // The SenseCAP Indicator routes display CS and RESET through this expander
+  // since they can't be connected directly to ESP32-S3 GPIOs.
+  Wire.begin(PCA9535_I2C_SDA, PCA9535_I2C_SCL, 400000);
+
+  // Configure expander pins: P04 (DISP_CS), P05 (DISP_RST), P07 (TOUCH_RST) as outputs
+  // P06 (TOUCH_INT) stays as input. Write 0xBF to config register (bit 6 = 1 = input)
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x03);  // Configuration register
+  Wire.write(0x40);  // P06=input, rest=output
+  Wire.endTransmission();
+
+  // Start with CS HIGH (deselected), RST HIGH (not in reset), TOUCH_RST HIGH
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x01);  // Output register
+  Wire.write((1 << PCA9535_PIN_DISP_CS) | (1 << PCA9535_PIN_DISP_RST) | (1 << PCA9535_PIN_TOUCH_RST));
+  Wire.endTransmission();
+  delay(10);
+
+  // Hardware reset: pull RST LOW for 10ms then HIGH
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x01);
+  Wire.write((1 << PCA9535_PIN_DISP_CS) | (1 << PCA9535_PIN_TOUCH_RST));  // RST LOW
+  Wire.endTransmission();
+  delay(10);
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x01);
+  Wire.write((1 << PCA9535_PIN_DISP_CS) | (1 << PCA9535_PIN_DISP_RST) | (1 << PCA9535_PIN_TOUCH_RST));  // RST HIGH
+  Wire.endTransmission();
+  delay(120);  // ST7701S needs time after reset
+
+  // Pull CS LOW for SPI init commands. LovyanGFX uses IO_EXPANDER-aware GPIO
+  // for pin_cs=(4|IO_EXPANDER) when USE_ARDUINO_HAL_GPIO is defined.
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x01);
+  Wire.write((0 << PCA9535_PIN_DISP_CS) | (1 << PCA9535_PIN_DISP_RST) | (1 << PCA9535_PIN_TOUCH_RST));  // CS LOW
+  Wire.endTransmission();
+  delay(1);
+#endif
+
 #if defined(DISPLAY_CYD)
   // Pick CYD panel variant based on loaded settings. Default static-init
   // already constructed V2; swap to Classic if user selected it.
@@ -382,14 +558,19 @@ void initDisplay() {
   }
   // _tft_instance reference + tft_ptr already point at the same storage.
 #endif
-  Serial.println("Display: calling _tft_instance.init()...");
   _tft_instance.init();  // LovyanGFX configures SPI from the board class above
 #if defined(DISPLAY_CYD)
   applyCydPanelInversion();
 #elif defined(BOARD_IS_S3) || defined(BOARD_IS_C3) || defined(BOARD_IS_WS200) || defined(BOARD_IS_WS154)
   _tft_instance.invertDisplay(true);  // ST7789 requires color inversion
+#elif defined(BOARD_IS_SENSECAP)
+  // ST7701S IPS inversion already handled by default Panel_ST7701 init (0x21 command).
+  // Release SPI CS HIGH now that init commands are done
+  Wire.beginTransmission(PCA9535_ADDR);
+  Wire.write(0x01);
+  Wire.write((1 << PCA9535_PIN_DISP_CS) | (1 << PCA9535_PIN_DISP_RST) | (1 << PCA9535_PIN_TOUCH_RST));  // CS HIGH
+  Wire.endTransmission();
 #endif
-  Serial.println("Display: tft.init() done");
 #if defined(DISPLAY_240x320)
   // Clear entire GRAM at rotation 0 first (guarantees all 240x320 pixels
   // are addressed). Without this, rotations 1/3 leave 80px of uninitialized
@@ -403,15 +584,12 @@ void initDisplay() {
 #elif defined(DISPLAY_240x320)
   if (dispSettings.invertColors) _tft_instance.invertDisplay(false);
 #endif
-  Serial.println("Display: setRotation done");
   tft.fillScreen(CLR_BG);
-  Serial.println("Display: fillScreen done");
 
 #if defined(TOUCH_CS) && !defined(USE_XPT2046)
   // LovyanGFX touch calibration
   uint16_t calData[8] = {0, 0, 0, 65535, 0, 65535, 65535, 65535};
   tft.setTouchCalibrate(calData);
-  Serial.println("Display: touch calibration set");
 #endif
 
 #if defined(BACKLIGHT_PIN) && BACKLIGHT_PIN >= 0

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -252,7 +252,7 @@ static LGFX_C3 _tft_instance;
 // Hardware:
 //   ST7701S 480x480 RGB TFT with SPI init commands
 //   PCA9535PW I2C IO expander (addr 0x20) for display CS/RST and touch INT/RST
-//   FT5X06 capacitive touch (I2C addr 0x38)
+//   FT5X06 capacitive touch (I2C addr 0x48)
 //   Backlight PWM on GPIO45
 //
 // The display init sequence:
@@ -2224,6 +2224,29 @@ static void drawPrinting() {
           case GAUGE_HEATBREAK:   needDraw = animating || s.heatbreakFanPct != prevState.heatbreakFanPct; break;
           case GAUGE_CLOCK:       needDraw = true; break;  // text cache handles actual redraw
           case GAUGE_LAYER:       needDraw = s.layerNum != prevState.layerNum || s.totalLayers != prevState.totalLayers; break;
+          case GAUGE_AMS_FILAMENT: {
+            uint8_t at = s.ams.activeTray;
+            uint8_t pat = prevState.ams.activeTray;
+            const AmsTray& ct = s.ams.trays[at];
+            const AmsTray& pt = prevState.ams.trays[pat];
+            needDraw = ct.present != pt.present || ct.colorRgb565 != pt.colorRgb565 ||
+                       ct.remain != pt.remain || strcmp(ct.type, pt.type) != 0;
+            break;
+          }
+          case GAUGE_AMS_FILAMENT_ALL: {
+            bool anyDiff = false;
+            for (int i = 0; i < AMS_MAX_TRAYS && !anyDiff; i++) {
+              const AmsTray& ct = s.ams.trays[i];
+              const AmsTray& pt = prevState.ams.trays[i];
+              anyDiff = ct.present != pt.present || ct.colorRgb565 != pt.colorRgb565 ||
+                        ct.remain != pt.remain || strcmp(ct.type, pt.type) != 0;
+            }
+            // Also trigger on AMS presence or unit count change
+            anyDiff = anyDiff || s.ams.present != prevState.ams.present ||
+                      s.ams.unitCount != prevState.ams.unitCount;
+            needDraw = anyDiff;
+            break;
+          }
           default:
             // AMS humidity / temperature gauges — index derived from enum value
             if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
@@ -2286,6 +2309,13 @@ static void drawPrinting() {
           break;
         case GAUGE_EMPTY:
           if (fr) tft.fillCircle(cx, cy, gR + 2, dispSettings.bgColor);
+          break;
+        case GAUGE_AMS_FILAMENT:
+          // Disabled — AMS Filament All gauge replaces this
+          if (fr) tft.fillCircle(cx, cy, gR + 2, dispSettings.bgColor);
+          break;
+        case GAUGE_AMS_FILAMENT_ALL:
+          drawAmsFilamentAllGauge(tft, cx, cy, gR, gT, s.ams, fr);
           break;
         default: {
           // AMS humidity / temperature gauges — index derived from enum value

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -304,6 +304,7 @@ public:
       cfg.panel_height  = 480;
       cfg.offset_x    = 0;
       cfg.offset_y  = 0;
+      cfg.offset_rotation = 2;  // Panel is mounted 180° rotated — apply 180° offset so rotation 0 = upright
       cfg.invert     = false;  // Default Panel_ST7701 list0 already sends 0x21 (IPS inversion on). Setting this true would send 0x21 AGAIN toggling inversion OFF.
       cfg.pin_rst    = -1;      // RST is via PCA9535PW — managed in initDisplay()
       _panel.config(cfg);

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -56,6 +56,28 @@ bool isLedPinAllowed(uint8_t pin) {
   if (pin == 18 || pin == 19) return false;                                        // USB CDC D-/D+
   if (pin >= 11 && pin <= 17) return false;                                        // flash/PSRAM
   if (pin > 21) return false;
+
+#elif defined(BOARD_IS_SENSECAP)
+  // SenseCAP Indicator (ESP32-S3 + ST7701S 480x480 RGB)
+  // RGB data pins (16 pins for RGB565)
+  if (pin == 3 || pin == 4 || pin == 5 || pin == 6 || pin == 7 || pin == 8) return false;  // G4,G5,G3,G0,G2,G1
+  if (pin == 10 || pin == 11 || pin == 12 || pin == 13) return false;                     // R3,R0,B5,B4
+  if (pin == 14 || pin == 15 || pin == 16) return false;                                   // B3,B2,B1
+  // RGB control pins
+  if (pin == 9 || pin == 17 || pin == 46) return false;         // R1, DE/R2, HSYNC/R0
+  // SPI for display init
+  if (pin == 41 || pin == 48) return false;                      // SPI CLK, MOSI
+  // I2C (shared by touch FT5X06 and PCA9535PW)
+  if (pin == 39 || pin == 40) return false;                      // I2C SDA, SCL
+  // Peripherals
+  if (pin == 45) return false;                                   // backlight PWM
+  if (pin == 38) return false;                                   // user button
+  if (pin == 19 || pin == 20) return false;                       // USB CDC D-/D+ (UART to RP2040)
+  // SPI flash + PSRAM (opi_qspi)
+  if (pin >= 26 && pin <= 37) return false;
+  // MISO not used but on SPI bus
+  if (pin == 47) return false;
+  if (pin > 48) return false;
 #endif
 
   return true;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -330,7 +330,7 @@ void loadSettings() {
   rotState.lastRotateMs = 0;
 
   // Button settings
-#if defined(USE_CST816) || defined(USE_XPT2046) || defined(TOUCH_CS)
+#if defined(USE_CST816) || defined(USE_XPT2046) || defined(USE_FT5X06) || defined(TOUCH_CS)
   buttonType = (ButtonType)prefs.getUChar("btn_type", BTN_TOUCHSCREEN);
 #else
   buttonType = (ButtonType)prefs.getUChar("btn_type", BTN_DISABLED);

--- a/src/settings.h
+++ b/src/settings.h
@@ -4,30 +4,6 @@
 #include <Arduino.h>
 #include "bambu_state.h"
 
-// Gauge type identifiers for configurable slot layout
-enum GaugeType : uint8_t {
-  GAUGE_EMPTY       = 0,
-  GAUGE_PROGRESS    = 1,
-  GAUGE_NOZZLE      = 2,
-  GAUGE_BED         = 3,
-  GAUGE_PART_FAN    = 4,
-  GAUGE_AUX_FAN     = 5,
-  GAUGE_CHAMBER_FAN = 6,
-  GAUGE_CHAMBER_TEMP= 7,
-  GAUGE_HEATBREAK   = 8,
-  GAUGE_CLOCK       = 9,
-  GAUGE_AMS_HUM_1   = 10,  // AMS unit 1 humidity
-  GAUGE_AMS_HUM_2   = 11,  // AMS unit 2 humidity
-  GAUGE_AMS_HUM_3   = 12,  // AMS unit 3 humidity
-  GAUGE_AMS_HUM_4   = 13,  // AMS unit 4 humidity
-  GAUGE_LAYER       = 14,  // layer progress (current/total)
-  GAUGE_AMS_TEMP_1  = 15,  // AMS unit 1 temperature
-  GAUGE_AMS_TEMP_2  = 16,  // AMS unit 2 temperature
-  GAUGE_AMS_TEMP_3  = 17,  // AMS unit 3 temperature
-  GAUGE_AMS_TEMP_4  = 18,  // AMS unit 4 temperature
-  GAUGE_TYPE_COUNT  // sentinel - always last
-};
-
 static const uint8_t GAUGE_SLOT_COUNT = 6;
 
 // Per-gauge color config
@@ -35,6 +11,32 @@ struct GaugeColors {
   uint16_t arc;       // arc fill color (RGB565)
   uint16_t label;     // label text color
   uint16_t value;     // value text color
+};
+
+// Gauge type identifiers for configurable gauge slots
+enum GaugeType : uint8_t {
+  GAUGE_EMPTY        = 0,
+  GAUGE_PROGRESS     = 1,
+  GAUGE_NOZZLE       = 2,
+  GAUGE_BED          = 3,
+  GAUGE_PART_FAN     = 4,
+  GAUGE_AUX_FAN      = 5,
+  GAUGE_CHAMBER_FAN  = 6,
+  GAUGE_CHAMBER_TEMP = 7,
+  GAUGE_HEATBREAK    = 8,
+  GAUGE_CLOCK        = 9,
+  GAUGE_AMS_HUM_1    = 10,  // AMS unit 1 humidity
+  GAUGE_AMS_HUM_2    = 11,
+  GAUGE_AMS_HUM_3    = 12,
+  GAUGE_AMS_HUM_4    = 13,
+  GAUGE_LAYER        = 14,  // layer progress (current/total)
+  GAUGE_AMS_TEMP_1   = 15,  // AMS unit 1 temperature
+  GAUGE_AMS_TEMP_2   = 16,
+  GAUGE_AMS_TEMP_3   = 17,
+  GAUGE_AMS_TEMP_4   = 18,
+  GAUGE_AMS_FILAMENT = 19,  // AMS filament info: color swatch + type label (active tray)
+  GAUGE_AMS_FILAMENT_ALL = 20,  // All 4 trays: color + type + % + humidity
+  GAUGE_TYPE_COUNT   = 21   // sentinel - total count
 };
 
 // All display customization settings

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -822,7 +822,8 @@ var gaugeTypes=[
   'Heatbreak Fan','Clock',
   'AMS 1 Humidity','AMS 2 Humidity','AMS 3 Humidity','AMS 4 Humidity',
   'Layer Progress',
-  'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp'
+  'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp',
+  '~~ Disabled ~~','AMS Filament All'
 ];
 (function(){
   var sels=document.querySelectorAll('.gauge-slot-sel');


### PR DESCRIPTION
## Add SenseCAP Indicator board support

Adds full support for the SenseCAP Indicator (Seeed INDICATOR RP2040) with its ST7701S 480×480 RGB display and FT5X06 touch controller.

### Board Support
- **New board**: `sensecap_indicator` in PlatformIO with ST7701S panel driver, proper 480×480 RGB666 config, and FT5X06 touch
- **Display rotation**: `offset_rotation=2` for correct landscape orientation
- **PSRAM framebuffer**: tuned at 100ms refresh rate

### AMS Filament All Gauge — Circular Quadrant Design
- **4-slot circular layout**: TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4 with filament color fill clipped to circle boundary
- **Slot numbers** (1–4) labeled at diagonal corners just outside the circle
- **Auto-contrast text**: black on light filaments, white on dark — luminance-based color picker (`contrastTextColor565`)
- **Text inset** 5px toward center so type/% labels avoid the circle edge
- **Humidity indicator** in dedicated tiny circle at gauge center (H*n*)
- **Solid left separator** (TL↔BL), dotted lines elsewhere
- **Disabled** single-tray AMS Filament gauge (`~~ Disabled ~~` in settings dropdown)

### Pong Clock Flicker Fixes
- Date/time: replaced `fillRect(TFT_BLACK)` + `drawString` sequence with `setTextColor(fg, TFT_BLACK)` for per-glyph atomic background fill
- Time digits, colon, AM/PM all use per-glyph bg — no visible intermediate black state
- Ball/paddle draw order: paddle first, ball last (always on top)
- Ball erase+draw kept together in `drawBall()` — no queued erase gap

### Web UI
- Disabled AMS Filament single-tray option shown as `~~ Disabled ~~` in gauge type dropdown