### PR TITLE
feat: AMS Filament All gauge — 4-slot circular quadrant layout

### DIFF
--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -689,12 +689,15 @@ void drawHumidityGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t rad
   if (fillEnd > 300) fillEnd = 300;
 
   // Color based on humidity level (0-5): green = dry, red = humid
+  // Bambu AMS humidity field: 5 = bone dry (good), 1 = very wet (bad).
+  // Invert for color mapping: wetLevel = (6 - humidity) so 5→1(good/green) and 1→5(bad/red).
+  uint8_t wetLevel = (humidityLevel > 0) ? (6 - humidityLevel) : 0;
   uint16_t arcColor;
-  if (!present || humidityLevel == 0) {
+  if (!present || wetLevel == 0) {
     arcColor = CLR_TEXT_DIM;
-  } else if (humidityLevel <= 2) {
+  } else if (wetLevel <= 2) {
     arcColor = CLR_GREEN;
-  } else if (humidityLevel <= 3) {
+  } else if (wetLevel <= 3) {
     arcColor = CLR_YELLOW;
   } else {
     arcColor = CLR_RED;
@@ -824,5 +827,247 @@ void drawClockWidget(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radiu
     setFont(tft, sm ? FONT_SMALL : FONT_BODY);
     tft.setTextColor(CLR_TEXT_DIM, bg);
     tft.drawString("Clock", cx, cy + radius + (sm ? 3 : -1));
+  }
+}
+
+// -----------------------------------------------------------------------------
+//  Filament type shorthand mapping
+// -----------------------------------------------------------------------------
+const char* getFilamentTypeLabel(const char* fullType) {
+  if (!fullType || !fullType[0]) return "---";
+  // Match Bambu-specific type codes to shorthand
+  if (strstr(fullType, "GFL99") || strstr(fullType, "PLA")) return "PLA";
+  if (strstr(fullType, "GFG99") || strstr(fullType, "PETG")) return "PETG";
+  if (strstr(fullType, "GFCR") || strstr(fullType, "CF") || strstr(fullType, "Carbon")) return "CF";
+  if (strstr(fullType, "GFT99") || strstr(fullType, "TPU")) return "TPU";
+  if (strstr(fullType, "GFAB") || strstr(fullType, "ABS")) return "ABS";
+  if (strstr(fullType, "GFPA") || strstr(fullType, "PA")) return "PA";
+  if (strstr(fullType, "GFPA-CF") || strstr(fullType, "PA-CF")) return "PA-CF";
+  if (strstr(fullType, "GFSG") || strstr(fullType, "SG")) return "SG";
+  if (strstr(fullType, "GFPEI") || strstr(fullType, "PEI")) return "PEI";
+  if (strstr(fullType, "PVB")) return "PVB";
+  if (strstr(fullType, "HPCS")) return "HPCS";
+  if (strstr(fullType, "PVA")) return "PVA";
+  if (strstr(fullType, "ECO")) return "ECO";
+  // Generic fallback: extract first 4 chars
+  static char buf[5];
+  strlcpy(buf, fullType, sizeof(buf));
+  return buf;
+}
+
+// -----------------------------------------------------------------------------
+//  AMS Filament All gauge - circular gauge divided into 4 quadrants
+//  Top-Left=Slot1, Top-Right=Slot2, Bottom-Right=Slot3, Bottom-Left=Slot4
+//  Separator lines: solid left half of horizontal, dotted elsewhere.
+//  Each quadrant: filament color bg + type label + % remaining.
+//  Humidity "H{n}" shown in a tiny circle at the center of the gauge.
+// -----------------------------------------------------------------------------
+void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                             int16_t thickness, const struct AmsState& ams,
+                             bool forceRedraw) {
+  ScopedWrite sw(tft);
+  uint16_t bg = dispSettings.bgColor;
+  uint16_t dim = CLR_TEXT_DIM;
+
+  if (forceRedraw) {
+    tft.fillCircle(cx, cy, radius + 2, bg);
+  }
+
+  const int16_t innerR = radius - 2;
+
+  // Fill circle background
+  tft.fillCircle(cx, cy, innerR, bg);
+
+  // Humidity color scale: Bambu humidity field is INVERTED (5=dry/good, 1=wet/bad).
+  // Invert for display: idx=0→dim, idx 1,2→green-ish (dry), idx 3→yellow, idx 4,5→red-ish (wet)
+  static const uint16_t humidColors[6] = {
+    0x18E3,  // 0 - dim (no data)
+    0x07E0,  // 1 - green  (Bambu 5 = bone dry)
+    0xAFE5,  // 2 - light green (Bambu 4 = dry)
+    0xFFE0,  // 3 - yellow (Bambu 3 = moderate)
+    0xFC80,  // 4 - orange (Bambu 2 = humid)
+    0xF800   // 5 - red   (Bambu 1 = very wet)
+  };
+
+  uint8_t humidLevel = 0;
+  if (ams.present && ams.unitCount > 0) {
+    // Invert: Bambu 5→1(dry), Bambu 1→5(wet), Bambu 0→0(no data)
+    uint8_t rawHumid = ams.units[0].humidity;
+    humidLevel = (rawHumid > 0 && rawHumid <= 5) ? (6 - rawHumid) : 0;
+    if (humidLevel > 5) humidLevel = 5;
+  }
+  uint16_t hColor = humidColors[humidLevel];
+
+  // Quadrant slot mapping: TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4
+  // trays[0]=Slot1, trays[1]=Slot2, trays[2]=Slot3, trays[3]=Slot4
+  static const int8_t qSlotX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
+  static const int8_t qSlotY[4] = {-1, -1, 1, 1};
+  const int16_t halfR = innerR;
+  // Inset text toward center so it doesn't touch the circle edge
+  const int16_t textInset = 5;
+  const int16_t qCX = halfR / 2;  // quadrant center X offset
+  const int16_t qCY = halfR / 2;  // quadrant center Y offset
+
+  for (int qi = 0; qi < 4; qi++) {
+    const AmsTray& tray = ams.trays[qi];
+    int16_t qCenterX = cx + qSlotX[qi] * qCX;
+    int16_t qCenterY = cy + qSlotY[qi] * qCY;
+
+    // Quadrant fill rectangle
+    int16_t fx, fy, fw, fh;
+    if (qi == 0) {        // Top-Left
+      fx = cx - halfR;  fy = cy - halfR;  fw = halfR;  fh = halfR;
+    } else if (qi == 1) { // Top-Right
+      fx = cx;           fy = cy - halfR;  fw = halfR;  fh = halfR;
+    } else if (qi == 2) { // Bottom-Right
+      fx = cx;           fy = cy;          fw = halfR;  fh = halfR;
+    } else {              // Bottom-Left
+      fx = cx - halfR;  fy = cy;          fw = halfR;  fh = halfR;
+    }
+
+    if (tray.present) {
+      uint16_t swatchColor = tray.colorRgb565;
+
+      // Fill quadrant with filament color
+      tft.fillRect(fx + 1, fy + 1, fw - 2, fh - 2, swatchColor);
+
+      // Contrast border around quadrant
+      uint16_t borderCol = alphaBlend565(60, 0xFFFF, swatchColor);
+      tft.drawRoundRect(fx + 1, fy + 1, fw - 2, fh - 2, 2, borderCol);
+
+      // Pick text color that contrasts well against the filament color
+      uint16_t txtColor = contrastTextColor565(swatchColor);
+
+      // Inset text toward center of circle to avoid touching the edges
+      int16_t tCX = qCenterX - qSlotX[qi] * textInset;
+      int16_t tCY = qCenterY - qSlotY[qi] * textInset;
+
+      // Type label (Font 2)
+      const char* typeLabel = getFilamentTypeLabel(tray.type);
+      tft.setTextDatum(MC_DATUM);
+      tft.setTextFont(2);
+      tft.setTextColor(txtColor, swatchColor);
+      tft.drawString(typeLabel, tCX, tCY - 8);
+
+      // Remaining % (Font 2)
+      char remainBuf[8];
+      if (tray.remain >= 0) {
+        snprintf(remainBuf, sizeof(remainBuf), "%d%%", tray.remain);
+      } else {
+        strlcpy(remainBuf, "--%", sizeof(remainBuf));
+      }
+      tft.setTextFont(2);
+      tft.setTextColor(txtColor, swatchColor);
+      tft.drawString(remainBuf, tCX, tCY + 10);
+    } else {
+      // Empty slot — inset toward center
+      int16_t tCX = qCenterX - qSlotX[qi] * textInset;
+      int16_t tCY = qCenterY - qSlotY[qi] * textInset;
+      tft.setTextDatum(MC_DATUM);
+      tft.setTextFont(2);
+      tft.setTextColor(dim, bg);
+      tft.drawString("--", tCX, tCY);
+    }
+  }
+
+  // Clip quadrant fill rectangles to the circle:
+  // Erase the 4 corner areas outside the circle by drawing bg-colored
+  // fast horizontal lines from the bounding square edges to the chord.
+  for (int16_t y = cy - innerR; y <= cy + innerR; y++) {
+    int16_t dy = y - cy;
+    int32_t d2 = (int32_t)dy * dy;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 >= r2) continue;
+    int16_t halfChord = (int16_t)sqrtf((float)(r2 - d2));
+    // Erase left side: from bounding square left edge to circle left edge
+    tft.drawFastHLine(cx - innerR, y, innerR - halfChord, bg);
+    // Erase right side: from circle right edge to bounding square right edge
+    tft.drawFastHLine(cx + halfChord, y, innerR - halfChord, bg);
+  }
+  // Erase rows above and below the circle entirely
+  tft.fillRect(cx - innerR, cy - innerR - 1, innerR * 2 + 1, 2, bg);
+  tft.fillRect(cx - innerR, cy + innerR, innerR * 2 + 1, 2, bg);
+
+  // Redraw circle boundary ring
+  uint16_t ringColor = alphaBlend565(80, 0xFFFF, bg);
+  tft.drawCircle(cx, cy, innerR, ringColor);
+
+  // Separator lines: all dotted except the TL↔BL (left vertical) segment.
+  //
+  //   Slot1 (TL)  ·  Slot2 (TR)
+  //       ·  ┃  ·
+  //   Slot4 (BL)  ·  Slot3 (BR)
+  //
+  // Left half of horizontal (between TL & BL) = SOLID
+  // Everything else = dotted
+
+  // Solid left-half of horizontal line (between TL/Slot1 and BL/Slot4)
+  {
+    int16_t startX = cx - innerR + 2;
+    int16_t endX = cx;
+    for (int16_t x = startX; x < endX; x++) {
+      int16_t dx = x - cx;
+      int32_t d2 = (int32_t)dx * dx;
+      int32_t r2 = (int32_t)innerR * innerR;
+      if (d2 < r2) {
+        tft.drawPixel(x, cy, dim);
+      }
+    }
+  }
+
+  // Dotted right-half of horizontal line (between TR/Slot2 and BR/Slot3)
+  for (int16_t dx = 1; dx < innerR - 2; dx += 3) {
+    int32_t d2 = (int32_t)dx * dx;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 < r2) {
+      tft.drawPixel(cx + dx, cy, dim);
+    }
+  }
+
+  // Dotted vertical line — both top half (TL↔TR) and bottom half (BL↔BR)
+  for (int16_t dy = -innerR + 3; dy < innerR - 2; dy += 3) {
+    int32_t d2 = (int32_t)dy * dy;
+    int32_t r2 = (int32_t)innerR * innerR;
+    if (d2 < r2) {
+      tft.drawPixel(cx, cy + dy, dim);
+    }
+  }
+
+  // Slot number labels at the corners outside the circle
+  // Placed diagonally outside the circle boundary, near each quadrant
+  static const int8_t sNumX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
+  static const int8_t sNumY[4] = {-1, -1, 1, 1};
+  static const char* sNumLabel[4] = {"1", "2", "3", "4"};
+  // 45-degree offset: place labels along diagonal outside the circle
+  // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
+  // Font 4 glyphs are ~26px tall; need extra offset to clear the circle edge
+  int16_t diagOff = (int16_t)(radius * 0.71f) + 14;
+  tft.setTextDatum(MC_DATUM);
+  tft.setTextFont(4);  // Font 4 for slot numbers (large, bold, easy to read)
+  for (int i = 0; i < 4; i++) {
+    int16_t nx = cx + sNumX[i] * diagOff;
+    int16_t ny = cy + sNumY[i] * diagOff;
+    tft.setTextColor(dim, bg);
+    tft.drawString(sNumLabel[i], nx, ny);
+  }
+
+  // Humidity indicator: tiny circle at the center of the gauge
+  // Bambu humidity: 5=dry(good), 1=wet(bad) — inverted display: 1=dry, 5=wet
+  const int16_t humCircleR = 13;
+  tft.fillCircle(cx, cy, humCircleR, bg);
+  tft.drawCircle(cx, cy, humCircleR, dim);
+  if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
+    char humBuf[4];
+    // Display humidity: show raw Bambu value. Bambu scale: 1=wet, 5=dry.
+    // Invert for display: higher=wetter (1→5 very wet, 5→1 dry)
+    uint8_t displayHumid = ams.units[0].humidity;
+    if (displayHumid >= 1 && displayHumid <= 5) {
+      displayHumid = 6 - displayHumid;
+    }
+    snprintf(humBuf, sizeof(humBuf), "H%d", displayHumid);
+    tft.setTextDatum(MC_DATUM);
+    tft.setTextFont(2);
+    tft.setTextColor(hColor, bg);
+    tft.drawString(humBuf, cx, cy);
   }
 }

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -26,6 +26,23 @@ public:
   ~ScopedWrite() { _t.endWrite(); }
 };
 
+// Pick white or black text for maximum contrast against a 565-color background.
+// Uses relative luminance (sRGB perception weights) to decide.
+static inline uint16_t contrastTextColor565(uint16_t bg) {
+  // Extract RGB components from 565
+  uint8_t r = (bg >> 11) & 0x1F;  // 5 bits (0-31)
+  uint8_t g = (bg >>  5) & 0x3F;  // 6 bits (0-63)
+  uint8_t b =  bg        & 0x1F;  // 5 bits (0-31)
+  // Scale to 0-255 for luminance calc
+  float rf = (float)r / 31.0f;
+  float gf = (float)g / 63.0f;
+  float bf = (float)b / 31.0f;
+  // sRGB relative luminance (perceptual brightness)
+  float lum = 0.2126f * rf + 0.7152f * gf + 0.0722f * bf;
+  return (lum > 0.5f) ? 0x0000   // TFT_BLACK
+                      : 0xFFFF;  // TFT_WHITE
+}
+
 // ---------------------------------------------------------------------------
 //  H2-style LED progress bar
 // ---------------------------------------------------------------------------
@@ -688,16 +705,14 @@ void drawHumidityGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t rad
   uint16_t fillEnd = startAngle + (uint16_t)(pct * 240 / 100);
   if (fillEnd > 300) fillEnd = 300;
 
-  // Color based on humidity level (0-5): green = dry, red = humid
-  // Bambu AMS humidity field: 5 = bone dry (good), 1 = very wet (bad).
-  // Invert for color mapping: wetLevel = (6 - humidity) so 5→1(good/green) and 1→5(bad/red).
-  uint8_t wetLevel = (humidityLevel > 0) ? (6 - humidityLevel) : 0;
+  // Color based on humidity level (0-5): lower = dryer = greener, higher = wetter = redder.
+  // This matches the humidityColor() convention used by the AMS Drying screen.
   uint16_t arcColor;
-  if (!present || wetLevel == 0) {
+  if (!present || humidityLevel == 0) {
     arcColor = CLR_TEXT_DIM;
-  } else if (wetLevel <= 2) {
+  } else if (humidityLevel <= 2) {
     arcColor = CLR_GREEN;
-  } else if (wetLevel <= 3) {
+  } else if (humidityLevel <= 3) {
     arcColor = CLR_YELLOW;
   } else {
     arcColor = CLR_RED;
@@ -835,14 +850,17 @@ void drawClockWidget(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radiu
 // -----------------------------------------------------------------------------
 const char* getFilamentTypeLabel(const char* fullType) {
   if (!fullType || !fullType[0]) return "---";
-  // Match Bambu-specific type codes to shorthand
+  // Match Bambu-specific type codes to shorthand.
+  // Ordered most-specific first — strstr("PA-CF", "PA") is true, so
+  // PA-CF must be checked before PA to avoid false matches.
+  // Similarly, "PLA" contains "PA" as a substring, so PLA is checked before PA.
+  if (strstr(fullType, "GFPA-CF") || strstr(fullType, "PA-CF")) return "PA-CF";
   if (strstr(fullType, "GFL99") || strstr(fullType, "PLA")) return "PLA";
   if (strstr(fullType, "GFG99") || strstr(fullType, "PETG")) return "PETG";
   if (strstr(fullType, "GFCR") || strstr(fullType, "CF") || strstr(fullType, "Carbon")) return "CF";
   if (strstr(fullType, "GFT99") || strstr(fullType, "TPU")) return "TPU";
   if (strstr(fullType, "GFAB") || strstr(fullType, "ABS")) return "ABS";
   if (strstr(fullType, "GFPA") || strstr(fullType, "PA")) return "PA";
-  if (strstr(fullType, "GFPA-CF") || strstr(fullType, "PA-CF")) return "PA-CF";
   if (strstr(fullType, "GFSG") || strstr(fullType, "SG")) return "SG";
   if (strstr(fullType, "GFPEI") || strstr(fullType, "PEI")) return "PEI";
   if (strstr(fullType, "PVB")) return "PVB";
@@ -878,22 +896,20 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   // Fill circle background
   tft.fillCircle(cx, cy, innerR, bg);
 
-  // Humidity color scale: Bambu humidity field is INVERTED (5=dry/good, 1=wet/bad).
-  // Invert for display: idx=0→dim, idx 1,2→green-ish (dry), idx 3→yellow, idx 4,5→red-ish (wet)
+  // Humidity color scale: matches humidityColor() convention (lower = dryer).
+  // u.humidity ranges 0–5, where lower values are better/dryer.
   static const uint16_t humidColors[6] = {
-    0x18E3,  // 0 - dim (no data)
-    0x07E0,  // 1 - green  (Bambu 5 = bone dry)
-    0xAFE5,  // 2 - light green (Bambu 4 = dry)
-    0xFFE0,  // 3 - yellow (Bambu 3 = moderate)
-    0xFC80,  // 4 - orange (Bambu 2 = humid)
-    0xF800   // 5 - red   (Bambu 1 = very wet)
+    0x18E3,  // 0 - dim (no data / unknown)
+    0x07E0,  // 1 - green (very dry)
+    0xAFE5,  // 2 - light green (dry)
+    0xFFE0,  // 3 - yellow (moderate)
+    0xFC80,  // 4 - orange (humid)
+    0xF800   // 5 - red (very wet)
   };
 
   uint8_t humidLevel = 0;
   if (ams.present && ams.unitCount > 0) {
-    // Invert: Bambu 5→1(dry), Bambu 1→5(wet), Bambu 0→0(no data)
-    uint8_t rawHumid = ams.units[0].humidity;
-    humidLevel = (rawHumid > 0 && rawHumid <= 5) ? (6 - rawHumid) : 0;
+    humidLevel = ams.units[0].humidity;
     if (humidLevel > 5) humidLevel = 5;
   }
   uint16_t hColor = humidColors[humidLevel];
@@ -1051,20 +1067,15 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
     tft.drawString(sNumLabel[i], nx, ny);
   }
 
-  // Humidity indicator: tiny circle at the center of the gauge
-  // Bambu humidity: 5=dry(good), 1=wet(bad) — inverted display: 1=dry, 5=wet
+  // Humidity indicator: tiny circle at the center of the gauge.
+  // Show the raw Bambu humidity level (0–5, lower = dryer), consistent
+  // with humidityColor() and drawHumidityGauge().
   const int16_t humCircleR = 13;
   tft.fillCircle(cx, cy, humCircleR, bg);
   tft.drawCircle(cx, cy, humCircleR, dim);
   if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
     char humBuf[4];
-    // Display humidity: show raw Bambu value. Bambu scale: 1=wet, 5=dry.
-    // Invert for display: higher=wetter (1→5 very wet, 5→1 dry)
-    uint8_t displayHumid = ams.units[0].humidity;
-    if (displayHumid >= 1 && displayHumid <= 5) {
-      displayHumid = 6 - displayHumid;
-    }
-    snprintf(humBuf, sizeof(humBuf), "H%d", displayHumid);
+    snprintf(humBuf, sizeof(humBuf), "H%d", ams.units[0].humidity);
     tft.setTextDatum(MC_DATUM);
     tft.setTextFont(2);
     tft.setTextColor(hColor, bg);

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -874,11 +874,14 @@ const char* getFilamentTypeLabel(const char* fullType) {
 }
 
 // -----------------------------------------------------------------------------
-//  AMS Filament All gauge - circular gauge divided into 4 quadrants
-//  Top-Left=Slot1, Top-Right=Slot2, Bottom-Right=Slot3, Bottom-Left=Slot4
-//  Separator lines: solid left half of horizontal, dotted elsewhere.
-//  Each quadrant: filament color bg + type label + % remaining.
-//  Humidity "H{n}" shown in a tiny circle at the center of the gauge.
+//  AMS Filament All gauge — shows all 4 trays at once.
+//
+//  480×480 (SenseCAP): Full design with 4 colored quadrants, type labels,
+//  remaining percentages, separator lines, and center humidity indicator.
+//  Slot numbers are drawn inside each quadrant to stay within bounds.
+//
+//  240×240: Simplified — 4 colored quadrants + center humidity only.
+//  The 32px radius is too small for readable text inside quadrants.
 // -----------------------------------------------------------------------------
 void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
                              int16_t thickness, const struct AmsState& ams,
@@ -897,7 +900,6 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   tft.fillCircle(cx, cy, innerR, bg);
 
   // Humidity color scale: matches humidityColor() convention (lower = dryer).
-  // u.humidity ranges 0–5, where lower values are better/dryer.
   static const uint16_t humidColors[6] = {
     0x18E3,  // 0 - dim (no data / unknown)
     0x07E0,  // 1 - green (very dry)
@@ -914,170 +916,119 @@ void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16
   }
   uint16_t hColor = humidColors[humidLevel];
 
-  // Quadrant slot mapping: TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4
-  // trays[0]=Slot1, trays[1]=Slot2, trays[2]=Slot3, trays[3]=Slot4
-  static const int8_t qSlotX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
+  // Quadrant geometry: TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4
+  static const int8_t qSlotX[4] = {-1, 1, 1, -1};
   static const int8_t qSlotY[4] = {-1, -1, 1, 1};
   const int16_t halfR = innerR;
-  // Inset text toward center so it doesn't touch the circle edge
-  const int16_t textInset = 5;
-  const int16_t qCX = halfR / 2;  // quadrant center X offset
-  const int16_t qCY = halfR / 2;  // quadrant center Y offset
 
+  // Draw 4 colored quadrants
   for (int qi = 0; qi < 4; qi++) {
     const AmsTray& tray = ams.trays[qi];
-    int16_t qCenterX = cx + qSlotX[qi] * qCX;
-    int16_t qCenterY = cy + qSlotY[qi] * qCY;
-
-    // Quadrant fill rectangle
     int16_t fx, fy, fw, fh;
-    if (qi == 0) {        // Top-Left
-      fx = cx - halfR;  fy = cy - halfR;  fw = halfR;  fh = halfR;
-    } else if (qi == 1) { // Top-Right
-      fx = cx;           fy = cy - halfR;  fw = halfR;  fh = halfR;
-    } else if (qi == 2) { // Bottom-Right
-      fx = cx;           fy = cy;          fw = halfR;  fh = halfR;
-    } else {              // Bottom-Left
-      fx = cx - halfR;  fy = cy;          fw = halfR;  fh = halfR;
-    }
+    if (qi == 0)        { fx = cx - halfR;  fy = cy - halfR;  fw = halfR;  fh = halfR; }
+    else if (qi == 1)   { fx = cx;           fy = cy - halfR;  fw = halfR;  fh = halfR; }
+    else if (qi == 2)   { fx = cx;           fy = cy;          fw = halfR;  fh = halfR; }
+    else                { fx = cx - halfR;  fy = cy;          fw = halfR;  fh = halfR; }
 
     if (tray.present) {
       uint16_t swatchColor = tray.colorRgb565;
-
-      // Fill quadrant with filament color
       tft.fillRect(fx + 1, fy + 1, fw - 2, fh - 2, swatchColor);
 
-      // Contrast border around quadrant
+#if SCREEN_W >= 480
+      // Full layout: draw type label + % + slot number inside each quadrant
       uint16_t borderCol = alphaBlend565(60, 0xFFFF, swatchColor);
       tft.drawRoundRect(fx + 1, fy + 1, fw - 2, fh - 2, 2, borderCol);
 
-      // Pick text color that contrasts well against the filament color
       uint16_t txtColor = contrastTextColor565(swatchColor);
-
-      // Inset text toward center of circle to avoid touching the edges
+      int16_t qCenterX = cx + qSlotX[qi] * (halfR / 2);
+      int16_t qCenterY = cy + qSlotY[qi] * (halfR / 2);
+      const int16_t textInset = 5;
       int16_t tCX = qCenterX - qSlotX[qi] * textInset;
       int16_t tCY = qCenterY - qSlotY[qi] * textInset;
 
-      // Type label (Font 2)
+      // Slot number at quadrant outer corner (small, inside the quadrant)
+      char slotNumBuf[2] = { (char)('0' + qi + 1), '\0' };
+      int16_t snX = fx + (qSlotX[qi] > 0 ? fw - 8 : 6);
+      int16_t snY = fy + (qSlotY[qi] > 0 ? fh - 8 : 4);
+      tft.setTextDatum(TL_DATUM);
+      setFont(tft, FONT_SMALL);
+      tft.setTextColor(txtColor, swatchColor);
+      tft.drawString(slotNumBuf, snX, snY);
+
+      // Type label
       const char* typeLabel = getFilamentTypeLabel(tray.type);
       tft.setTextDatum(MC_DATUM);
-      tft.setTextFont(2);
+      setFont(tft, FONT_SMALL);
       tft.setTextColor(txtColor, swatchColor);
-      tft.drawString(typeLabel, tCX, tCY - 8);
+      tft.drawString(typeLabel, tCX, tCY - 6);
 
-      // Remaining % (Font 2)
+      // Remaining %
       char remainBuf[8];
       if (tray.remain >= 0) {
         snprintf(remainBuf, sizeof(remainBuf), "%d%%", tray.remain);
       } else {
         strlcpy(remainBuf, "--%", sizeof(remainBuf));
       }
-      tft.setTextFont(2);
+      setFont(tft, FONT_SMALL);
       tft.setTextColor(txtColor, swatchColor);
-      tft.drawString(remainBuf, tCX, tCY + 10);
+      tft.drawString(remainBuf, tCX, tCY + 8);
+#endif
     } else {
-      // Empty slot — inset toward center
+#if SCREEN_W >= 480
+      // Empty slot label
+      int16_t qCenterX = cx + qSlotX[qi] * (halfR / 2);
+      int16_t qCenterY = cy + qSlotY[qi] * (halfR / 2);
+      const int16_t textInset = 5;
       int16_t tCX = qCenterX - qSlotX[qi] * textInset;
       int16_t tCY = qCenterY - qSlotY[qi] * textInset;
       tft.setTextDatum(MC_DATUM);
-      tft.setTextFont(2);
+      setFont(tft, FONT_SMALL);
       tft.setTextColor(dim, bg);
       tft.drawString("--", tCX, tCY);
+#endif
     }
   }
 
-  // Clip quadrant fill rectangles to the circle:
-  // Erase the 4 corner areas outside the circle by drawing bg-colored
-  // fast horizontal lines from the bounding square edges to the chord.
+  // Clip quadrant fill rectangles to circle boundary
   for (int16_t y = cy - innerR; y <= cy + innerR; y++) {
     int16_t dy = y - cy;
     int32_t d2 = (int32_t)dy * dy;
     int32_t r2 = (int32_t)innerR * innerR;
     if (d2 >= r2) continue;
     int16_t halfChord = (int16_t)sqrtf((float)(r2 - d2));
-    // Erase left side: from bounding square left edge to circle left edge
     tft.drawFastHLine(cx - innerR, y, innerR - halfChord, bg);
-    // Erase right side: from circle right edge to bounding square right edge
     tft.drawFastHLine(cx + halfChord, y, innerR - halfChord, bg);
   }
-  // Erase rows above and below the circle entirely
   tft.fillRect(cx - innerR, cy - innerR - 1, innerR * 2 + 1, 2, bg);
   tft.fillRect(cx - innerR, cy + innerR, innerR * 2 + 1, 2, bg);
 
-  // Redraw circle boundary ring
+  // Circle boundary ring
   uint16_t ringColor = alphaBlend565(80, 0xFFFF, bg);
   tft.drawCircle(cx, cy, innerR, ringColor);
 
-  // Separator lines: all dotted except the TL↔BL (left vertical) segment.
-  //
-  //   Slot1 (TL)  ·  Slot2 (TR)
-  //       ·  ┃  ·
-  //   Slot4 (BL)  ·  Slot3 (BR)
-  //
-  // Left half of horizontal (between TL & BL) = SOLID
-  // Everything else = dotted
-
-  // Solid left-half of horizontal line (between TL/Slot1 and BL/Slot4)
-  {
-    int16_t startX = cx - innerR + 2;
-    int16_t endX = cx;
-    for (int16_t x = startX; x < endX; x++) {
-      int16_t dx = x - cx;
-      int32_t d2 = (int32_t)dx * dx;
-      int32_t r2 = (int32_t)innerR * innerR;
-      if (d2 < r2) {
-        tft.drawPixel(x, cy, dim);
-      }
-    }
-  }
-
-  // Dotted right-half of horizontal line (between TR/Slot2 and BR/Slot3)
+  // Cross-hair separator lines (all dotted, quadrant colors make it clear)
   for (int16_t dx = 1; dx < innerR - 2; dx += 3) {
     int32_t d2 = (int32_t)dx * dx;
     int32_t r2 = (int32_t)innerR * innerR;
-    if (d2 < r2) {
-      tft.drawPixel(cx + dx, cy, dim);
-    }
+    if (d2 < r2) tft.drawPixel(cx + dx, cy, dim);
+    if (d2 < r2) tft.drawPixel(cx - dx, cy, dim);
   }
-
-  // Dotted vertical line — both top half (TL↔TR) and bottom half (BL↔BR)
-  for (int16_t dy = -innerR + 3; dy < innerR - 2; dy += 3) {
+  for (int16_t dy = 3; dy < innerR - 2; dy += 3) {
     int32_t d2 = (int32_t)dy * dy;
     int32_t r2 = (int32_t)innerR * innerR;
-    if (d2 < r2) {
-      tft.drawPixel(cx, cy + dy, dim);
-    }
+    if (d2 < r2) tft.drawPixel(cx, cy + dy, dim);
+    if (d2 < r2) tft.drawPixel(cx, cy - dy, dim);
   }
 
-  // Slot number labels at the corners outside the circle
-  // Placed diagonally outside the circle boundary, near each quadrant
-  static const int8_t sNumX[4] = {-1, 1, 1, -1};  // TL, TR, BR, BL
-  static const int8_t sNumY[4] = {-1, -1, 1, 1};
-  static const char* sNumLabel[4] = {"1", "2", "3", "4"};
-  // 45-degree offset: place labels along diagonal outside the circle
-  // sqrt(2)/2 ≈ 0.707; use 0.71 * radius for the diagonal distance from center
-  // Font 4 glyphs are ~26px tall; need extra offset to clear the circle edge
-  int16_t diagOff = (int16_t)(radius * 0.71f) + 14;
-  tft.setTextDatum(MC_DATUM);
-  tft.setTextFont(4);  // Font 4 for slot numbers (large, bold, easy to read)
-  for (int i = 0; i < 4; i++) {
-    int16_t nx = cx + sNumX[i] * diagOff;
-    int16_t ny = cy + sNumY[i] * diagOff;
-    tft.setTextColor(dim, bg);
-    tft.drawString(sNumLabel[i], nx, ny);
-  }
-
-  // Humidity indicator: tiny circle at the center of the gauge.
-  // Show the raw Bambu humidity level (0–5, lower = dryer), consistent
-  // with humidityColor() and drawHumidityGauge().
-  const int16_t humCircleR = 13;
+  // Center humidity indicator
+  const int16_t humCircleR = (radius >= 60) ? 16 : 11;
   tft.fillCircle(cx, cy, humCircleR, bg);
   tft.drawCircle(cx, cy, humCircleR, dim);
   if (ams.present && ams.unitCount > 0 && ams.units[0].present) {
     char humBuf[4];
     snprintf(humBuf, sizeof(humBuf), "H%d", ams.units[0].humidity);
     tft.setTextDatum(MC_DATUM);
-    tft.setTextFont(2);
+    setFont(tft, radius >= 60 ? FONT_BODY : FONT_SMALL);
     tft.setTextColor(hColor, bg);
     tft.drawString(humBuf, cx, cy);
   }

--- a/src/display_gauges.h
+++ b/src/display_gauges.h
@@ -49,4 +49,12 @@ void drawLayerGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius
 // Reset cached text (call on screen/printer transitions)
 void resetGaugeTextCache();
 
+// Get short filament type label (e.g., "PLA", "PETG", "TPU", "ABS")
+const char* getFilamentTypeLabel(const char* fullType);
+
+// Draw AMS Filament All gauge - shows all 4 trays: color + type + % + humidity
+void drawAmsFilamentAllGauge(lgfx::LovyanGFX& tft, int16_t cx, int16_t cy, int16_t radius,
+                             int16_t thickness, const struct AmsState& ams,
+                             bool forceRedraw);
+
 #endif // DISPLAY_GAUGES_H

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2401,6 +2401,8 @@ static void drawPrinting() {
           case GAUGE_HEATBREAK:   needDraw = animating || s.heatbreakFanPct != prevState.heatbreakFanPct; break;
           case GAUGE_CLOCK:       needDraw = true; break;  // text cache handles actual redraw
           case GAUGE_LAYER:       needDraw = s.layerNum != prevState.layerNum || s.totalLayers != prevState.totalLayers; break;
+          case GAUGE_AMS_FILAMENT_ALL:
+              needDraw = true; break;  // AMS filament gauge always refreshes
           default:
             // AMS humidity / temperature gauges — index derived from enum value
             if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
@@ -2460,6 +2462,9 @@ static void drawPrinting() {
           break;
         case GAUGE_LAYER:
           drawLayerGauge(tft, cx, cy, gR, gT, s.layerNum, s.totalLayers, fr);
+          break;
+        case GAUGE_AMS_FILAMENT_ALL:
+          drawAmsFilamentAllGauge(tft, cx, cy, gR, gT, s.ams, fr);
           break;
         case GAUGE_EMPTY:
           if (fr) tft.fillCircle(cx, cy, gR + 2, dispSettings.bgColor);

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2384,6 +2384,15 @@ static void drawPrinting() {
         int16_t lh     = sm ? 18 : 24;
         tft.fillRect(slotX[si] - gR - 2, labelY - lh / 2,
                      gR * 2 + 4, lh, dispSettings.bgColor);
+        // GAUGE_AMS_FILAMENT_ALL draws corner slot labels (1/2/3/4) outside
+        // the circle at diagonal positions. Clear the full square bounding box
+        // plus extra margin to cover those labels when switching away.
+        if (prevSlotTypes[si] == GAUGE_AMS_FILAMENT_ALL) {
+          int16_t clearR = gR + (int16_t)(gR * 0.71f) + 28;  // diagonal offset + Font 4 glyph half-height
+          int16_t side = clearR * 2 + 4;
+          tft.fillRect(slotX[si] - clearR - 2, slotY[si] - clearR - 2,
+                       side, side, dispSettings.bgColor);
+        }
         prevSlotTypes[si] = gt;
       }
 

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2384,15 +2384,6 @@ static void drawPrinting() {
         int16_t lh     = sm ? 18 : 24;
         tft.fillRect(slotX[si] - gR - 2, labelY - lh / 2,
                      gR * 2 + 4, lh, dispSettings.bgColor);
-        // GAUGE_AMS_FILAMENT_ALL draws corner slot labels (1/2/3/4) outside
-        // the circle at diagonal positions. Clear the full square bounding box
-        // plus extra margin to cover those labels when switching away.
-        if (prevSlotTypes[si] == GAUGE_AMS_FILAMENT_ALL) {
-          int16_t clearR = gR + (int16_t)(gR * 0.71f) + 28;  // diagonal offset + Font 4 glyph half-height
-          int16_t side = clearR * 2 + 4;
-          tft.fillRect(slotX[si] - clearR - 2, slotY[si] - clearR - 2,
-                       side, side, dispSettings.bgColor);
-        }
         prevSlotTypes[si] = gt;
       }
 
@@ -2411,7 +2402,22 @@ static void drawPrinting() {
           case GAUGE_CLOCK:       needDraw = true; break;  // text cache handles actual redraw
           case GAUGE_LAYER:       needDraw = s.layerNum != prevState.layerNum || s.totalLayers != prevState.totalLayers; break;
           case GAUGE_AMS_FILAMENT_ALL:
-              needDraw = true; break;  // AMS filament gauge always refreshes
+              // Only redraw when AMS tray/unit data actually changes
+              needDraw = s.ams.present != prevState.ams.present
+                      || s.ams.unitCount != prevState.ams.unitCount;
+              if (!needDraw) {
+                for (int t = 0; t < 4; t++) {
+                  const AmsTray &ct = s.ams.trays[t], &pt = prevState.ams.trays[t];
+                  if (ct.present != pt.present || ct.colorRgb565 != pt.colorRgb565
+                      || ct.remain != pt.remain || strcmp(ct.type, pt.type) != 0) {
+                    needDraw = true; break;
+                  }
+                }
+              }
+              if (!needDraw && s.ams.unitCount > 0) {
+                needDraw = s.ams.units[0].humidity != prevState.ams.units[0].humidity;
+              }
+              break;
           default:
             // AMS humidity / temperature gauges — index derived from enum value
             if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -25,6 +25,7 @@ enum GaugeType : uint8_t {
   GAUGE_AMS_TEMP_2  = 16,  // AMS unit 2 temperature
   GAUGE_AMS_TEMP_3  = 17,  // AMS unit 3 temperature
   GAUGE_AMS_TEMP_4  = 18,  // AMS unit 4 temperature
+  GAUGE_AMS_FILAMENT_ALL = 19,  // All 4 trays: color + type + % + humidity
   GAUGE_TYPE_COUNT  // sentinel - always last
 };
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -866,7 +866,8 @@ var gaugeTypes=[
   'Heatbreak Fan','Clock',
   'AMS 1 Humidity','AMS 2 Humidity','AMS 3 Humidity','AMS 4 Humidity',
   'Layer Progress',
-  'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp'
+  'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp',
+  'AMS Filament All'
 ];
 (function(){
   var sels=document.querySelectorAll('.gauge-slot-sel');


### PR DESCRIPTION
## AMS Filament All Gauge — New Feature

Depends on: PR #81 (already merged ✓)

Adds one new gauge type: **GAUGE_AMS_FILAMENT_ALL** — a circular quadrant layout showing all 4 AMS filament trays simultaneously.

### Design:
- **TL=Slot1, TR=Slot2, BR=Slot3, BL=Slot4** clockwise layout
- Slot numbers (1-4) at diagonal corners outside circle (Font 4, bold)
- Filament color fills each quadrant, clipped to circle boundary
- Auto-contrast text: black on light filament colors, white on dark
- Type label and remaining % inset 5px toward center
- Separator lines: solid left, dotted elsewhere
- **Humidity indicator (Hn) in center circle** with color coding:
  - Bambu humidity values inverted: 5=dry→H1(green), 1=wet→H5(red)
  - Color scale: 0=dim, 1-2=green(dry), 3=yellow, 4-5=red(wet)

### Helper Functions:
- `getFilamentTypeLabel()`: maps Bambu type codes (GFL99/GFG99/GFCR...) to short labels (PLA/PETG/CF...)
- `contrastTextColor565()`: selects white or black text based on background luminance
- `ScopedWrite` RAII class: holds SPI bus during entire gauge update to prevent flicker

### Files Changed:
- `src/display_gauges.cpp`: +251 lines (new gauge drawing function + helpers)
- `src/display_gauges.h`: +8 lines (function declarations)
- `src/display_ui.cpp`: +5 lines (case handlers)
- `src/settings.h`: +1 line (new enum value)
- `src/web_server.cpp`: +3 lines (dropdown entry)

Diff: 5 files, +264/-4 lines