### PR TITLE
feat: add tzt_2432 env for TZT L1435-2.4 (ESP32 + ST7789V 240x320)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tools/ams_dump.json
 *.bak-*
 CLAUDE.md
 VLW_FONTS_PARKED.md
+anycubic-support-plans.md

--- a/merge_bins.py
+++ b/merge_bins.py
@@ -5,6 +5,7 @@ Create BambuHelper release firmware files.
 Usage:
     python merge_bins.py                    # auto-reads version, builds esp32s3
     python merge_bins.py --board cyd        # build CYD firmware
+    python merge_bins.py --board tzt_2432   # build TZT L1435-2.4 firmware
     python merge_bins.py --board esp32c3    # build ESP32-C3 firmware
     python merge_bins.py --board esp32s3_zero  # build Waveshare ESP32-S3-Zero firmware
     python merge_bins.py --board ws_lcd_200 # build Waveshare 2.0 firmware
@@ -21,6 +22,8 @@ Output:
     firmware/v2.5/BambuHelper-esp32s3_zero-v2.5-ota.bin
     firmware/v2.5/BambuHelper-cyd-v2.5-Full.bin
     firmware/v2.5/BambuHelper-cyd-v2.5-ota.bin
+    firmware/v2.5/BambuHelper-tzt_2432-v2.5-Full.bin
+    firmware/v2.5/BambuHelper-tzt_2432-v2.5-ota.bin
     firmware/v2.5/BambuHelper-ws_lcd_200-v2.5-Full.bin
     firmware/v2.5/BambuHelper-ws_lcd_200-v2.5-ota.bin
     firmware/v2.5/BambuHelper-ws_lcd_154-v2.5-Full.bin
@@ -60,6 +63,14 @@ BOARDS = {
         'build_env': 'cyd',
         'board_id': 'cyd',
     },
+    'tzt_2432': {
+        'build_dir': '.pio/build/tzt_2432',
+        'bootloader_offset': 0x1000,    # Standard ESP32 starts at 0x1000
+        'partitions_offset': 0x8000,
+        'firmware_offset': 0x10000,
+        'build_env': 'tzt_2432',
+        'board_id': 'tzt_2432',
+    },
     'ws_lcd_200': {
         'build_dir': '.pio/build/ws_lcd_200',
         'bootloader_offset': 0x0,       # ESP32-S3 starts at 0x0
@@ -93,6 +104,8 @@ BOARD_ALIASES = {
     's3_zero': 'esp32s3_zero',
     'esp32s3_zero': 'esp32s3_zero',
     'cyd': 'cyd',
+    'tzt': 'tzt_2432',
+    'tzt_2432': 'tzt_2432',
     'ws': 'ws_lcd_200',
     'ws_lcd_200': 'ws_lcd_200',
     'ws154': 'ws_lcd_154',

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,6 +65,38 @@ build_flags =
     -D BACKLIGHT_PIN=21
 
 ; =============================================================================
+;  TZT L1435-2.4 (ESP32 + ST7789V 240x320 + XPT2046 touch)
+;  Aliexpress: "TZT ESP32 LVGL 2.4 inch LCD TFT 240*320 With Touch"
+;  Same ESP32 + SPI + touch pinout as CYD, but ST7789V driver and BL on GPIO27.
+; =============================================================================
+[env:tzt_2432]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_speed = 230400
+board_build.partitions = min_spiffs.csv
+lib_deps =
+    ${common.lib_deps}
+    https://github.com/PaulStoffregen/XPT2046_Touchscreen.git
+build_flags =
+    ; --- Touch (XPT2046 - same pins as CYD) ---
+    -D USE_XPT2046=1
+    -D TOUCH_CS=33
+    -D TOUCH_IRQ=36
+    -D TOUCH_MOSI=32
+    -D TOUCH_MISO=39
+    -D TOUCH_CLK=25
+    -D SPI_TOUCH_FREQUENCY=2500000
+    ; --- Layout profile ---
+    -D BOARD_IS_TZT_2432=1
+    -D DISPLAY_240x320=1
+    -D BOARD_VARIANT=\"tzt_2432\"
+    -D ENABLE_OTA_AUTO=1
+    -D BOARD_LOW_RAM=1
+    -D BACKLIGHT_PIN=27
+
+; =============================================================================
 ;  Waveshare ESP32-S3-Zero + external ST7789 240x240
 ;  https://www.waveshare.com/esp32-s3-zero.htm
 ;  Module ESP32-S3FH4R2: 4MB flash QIO + 2MB PSRAM QSPI (quad).

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -168,6 +168,52 @@ static LGFX_CYD_Storage   _tft_storage;
 // initDisplay() if the user selected Classic.
 static lgfx::LGFX_Device& _tft_instance = _tft_storage.v2;
 
+#elif defined(BOARD_IS_TZT_2432)
+// --- TZT L1435-2.4 (ESP32 + ST7789V 240x320) -------------------------------
+// Same SPI/CS/DC pinout as CYD, but ST7789V driver. Backlight is on GPIO27
+// (set via BACKLIGHT_PIN). RST is not wired on the typical TZT variant - if a
+// future user reports init failure we may need to switch pin_rst to 12.
+class LGFX_TZT_2432 : public lgfx::LGFX_Device {
+  lgfx::Panel_ST7789  _panel;
+  lgfx::Bus_SPI       _bus;
+public:
+  LGFX_TZT_2432() {
+    {
+      auto cfg = _bus.config();
+      cfg.spi_host   = VSPI_HOST;
+      cfg.spi_mode   = 0;
+      cfg.freq_write = 27000000;
+      cfg.freq_read  = 16000000;
+      cfg.pin_sclk   = 14;
+      cfg.pin_mosi   = 13;
+      cfg.pin_miso   = -1;
+      cfg.pin_dc     = 2;
+      cfg.use_lock   = true;
+      _bus.config(cfg);
+      _panel.setBus(&_bus);
+    }
+    {
+      auto cfg = _panel.config();
+      cfg.pin_cs    = 15;
+      cfg.pin_rst   = -1;
+      cfg.pin_busy  = -1;
+      cfg.memory_width  = 240;
+      cfg.memory_height = 320;
+      cfg.panel_width   = 240;
+      cfg.panel_height  = 320;
+      cfg.offset_x      = 0;
+      cfg.offset_y      = 0;
+      cfg.offset_rotation = 0;
+      cfg.invert        = true;
+      cfg.rgb_order     = false;
+      cfg.readable      = false;
+      _panel.config(cfg);
+    }
+    setPanel(&_panel);
+  }
+};
+static LGFX_TZT_2432 _tft_instance;
+
 #elif defined(BOARD_IS_WS200)
 // --- Waveshare ESP32-S3-Touch-LCD-2 (2.0" ST7789 240x320) --------------------
 class LGFX_WS200 : public lgfx::LGFX_Device {
@@ -631,7 +677,7 @@ void initDisplay() {
   _tft_instance.init();  // LovyanGFX configures SPI from the board class above
 #if defined(DISPLAY_CYD)
   applyCydPanelInversion();
-#elif defined(BOARD_IS_S3_ZERO) || defined(BOARD_IS_S3) || defined(BOARD_IS_C3) || defined(BOARD_IS_WS200) || defined(BOARD_IS_WS154)
+#elif defined(BOARD_IS_S3_ZERO) || defined(BOARD_IS_S3) || defined(BOARD_IS_C3) || defined(BOARD_IS_WS200) || defined(BOARD_IS_WS154) || defined(BOARD_IS_TZT_2432)
   _tft_instance.invertDisplay(true);  // ST7789 requires color inversion
 #elif defined(BOARD_IS_SENSECAP)
   // ST7701S IPS inversion already handled by default Panel_ST7701 init (0x21 command).

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -43,8 +43,8 @@ bool isLedPinAllowed(uint8_t pin) {
   if (buzzerSettings.enabled && pin == buzzerSettings.pin) return false;
   if (buttonType != BTN_DISABLED && pin == buttonPin) return false;
 
-#if defined(DISPLAY_CYD)
-  // CYD (classic ESP32, esp32dev)
+#if defined(DISPLAY_CYD) || defined(BOARD_IS_TZT_2432)
+  // CYD (ESP32-2432S028) and TZT L1435-2.4 - same ESP32 pinout, both esp32dev
   if (pin == 2 || pin == 12 || pin == 13 || pin == 14 || pin == 15) return false;  // display SPI
   if (pin == 25 || pin == 32 || pin == 33 || pin == 36 || pin == 39) return false; // XPT2046 touch
   if (pin == 4 || pin == 16 || pin == 17) return false;                            // onboard RGB


### PR DESCRIPTION
Same ESP32 + SPI/touch pinout as ESP32-2432S028 CYD, but uses ST7789V driver instead of ILI9341 and has backlight on GPIO27 instead of GPIO21. Reported in #88 - users were getting black screens on cyd builds because the boards are visually identical but electrically different.