### PR TITLE
Gauge grid modes: 8/9-slot layouts + AMS Bars gauge

### DIFF
--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -160,10 +160,9 @@ struct PrinterConfig {
   char name[24];              // friendly name
   char cloudUserId[32];       // cloud mode: "u_{uid}" for MQTT username
   CloudRegion region;          // cloud mode: US, EU, or CN server region
-  uint8_t gaugeSlots[9];       // configurable gauge layout (GaugeType values, see settings.h).
-                               // Slots 0-5 used everywhere; slots 6-7 used in landscape
-                               // 8-slot mode AND portrait 9-slot mode (shared positions
-                               // per orientation); slot 8 used only in portrait 9-slot mode.
+  uint8_t gaugeSlots[6];       // Standard 2x3 grid - used in every mode.
+  uint8_t landscapeExtras[2];  // Col 4 (top, bot) - landscape 8-slot mode only.
+  uint8_t portraitExtras[3];   // Row 3 (left, mid, right) - portrait 9-slot mode only.
   bool    amsView;             // 240x240: replace gauge row 2 with AMS strip (per-printer)
 };
 

--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -160,7 +160,10 @@ struct PrinterConfig {
   char name[24];              // friendly name
   char cloudUserId[32];       // cloud mode: "u_{uid}" for MQTT username
   CloudRegion region;          // cloud mode: US, EU, or CN server region
-  uint8_t gaugeSlots[6];       // configurable gauge layout (GaugeType values, see settings.h)
+  uint8_t gaugeSlots[9];       // configurable gauge layout (GaugeType values, see settings.h).
+                               // Slots 0-5 used everywhere; slots 6-7 used in landscape
+                               // 8-slot mode AND portrait 9-slot mode (shared positions
+                               // per orientation); slot 8 used only in portrait 9-slot mode.
   bool    amsView;             // 240x240: replace gauge row 2 with AMS strip (per-printer)
 };
 

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -39,6 +39,14 @@
 #define LY_ROW1      60
 #define LY_ROW2      148
 
+// 3x3 portrait variant (DisplaySettings.portrait9Slots = true).
+// Drops the AMS strip in favour of a third gauge row. R shrinks 32->28 so
+// row 3 + label fits above ETA (y=260) with ~10px clearance.
+#define LY_PORT9_GAUGE_R 28
+#define LY_PORT9_ROW1    60
+#define LY_PORT9_ROW2    134
+#define LY_PORT9_ROW3    208
+
 // --- AMS tray visualization zone (CYD portrait, between gauges and ETA) ---
 // Gauge row 2 labels extend to ~y=187, so AMS starts at 190 to avoid overlap.
 #define LY_AMS_Y          190   // top of AMS zone (below gauge row 2 labels)
@@ -64,6 +72,14 @@
 #define LY_LAND_COL3        LY_COL3
 #define LY_LAND_ROW1        LY_ROW1
 #define LY_LAND_ROW2        LY_ROW2
+// 4-column landscape variant (DisplaySettings.landscape8Slots = true).
+// Drops the right-side AMS sidebar and lays out a symmetric 2x4 grid across
+// the full 320px width. Same R/rows as the 3-col grid so other zones (ETA,
+// bottom bar) keep their landscape Y positions.
+#define LY_LAND8_COL1       40
+#define LY_LAND8_COL2       120
+#define LY_LAND8_COL3       200
+#define LY_LAND8_COL4       280
 #define LY_LAND_GAUGE_W     240   // gauge area width (left side)
 #define LY_LAND_ETA_Y       190   // ETA zone Y (same as default 240x240)
 #define LY_LAND_ETA_H       30

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -48,6 +48,14 @@
 #define LY_ROW1      92           // top row center Y (gauge top edge y=44)
 #define LY_ROW2      228          // bottom row center Y (gauge top edge y=180)
 
+// 3x3 portrait variant (DisplaySettings.portrait9Slots = true).
+// Drops the AMS strip in favour of a third gauge row. R shrinks 48->46 to
+// keep row 3's label clear of ETA (y=380) with comfortable headroom.
+#define LY_PORT9_GAUGE_R 46
+#define LY_PORT9_ROW1    86
+#define LY_PORT9_ROW2    196
+#define LY_PORT9_ROW3    306
+
 // --- AMS tray visualization zone (below gauge grid) ---
 // Row 2 gauges bottom edge is at y=276 (228+48). Labels extend ~12px below,
 // so AMS starts at y=295. Zone is 72 px tall with 42 px bars; ETA begins at
@@ -171,6 +179,13 @@
 #define LY_LAND_COL3          300
 #define LY_LAND_ROW1          76     // gauge spans y=28..124, label band 111..135
 #define LY_LAND_ROW2          192    // gauge spans y=144..240, label band 227..251
+// 4-column landscape variant (DisplaySettings.landscape8Slots).
+// Evenly spaced across 480px: 60 / 180 / 300 / 420. R=48 keeps gauges from
+// touching neighbours (96px diameter on 120px column pitch).
+#define LY_LAND8_COL1         60
+#define LY_LAND8_COL2         180
+#define LY_LAND8_COL3         300
+#define LY_LAND8_COL4         420
 
 // --- AMS sidebar (landscape) ---
 #define LY_LAND_AMS_X         365    // 5 px gap from right edge of gauge area (348)

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -777,9 +777,9 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="card-head">
       <div>
         <h3>Gauge Layout</h3>
-        <p>Per-printer display slots. The standard 2x3 grid is always shown. On 240x320 and 320x480 boards the extra rows below only render when the matching grid mode (<em>Landscape 8 slots</em> / <em>Portrait 9 slots</em>) is enabled under Display. Set any slot to <em>Empty</em> to hide it.</p>
+        <p>Per-printer display slots. The standard 2x3 grid is always shown. On 240x320 and 320x480 boards the extra rows below only render when the matching grid mode (<em>Landscape 8 slots</em> / <em>Portrait 9 slots</em>) is enabled under <strong>Advanced</strong>. Set any slot to <em>Empty</em> to hide it.</p>
       </div>
-      <button type="button" class="btn btn-ghost btn-sm" onclick="resetGaugeLayout()">Reset to default</button>
+      <button type="button" class="btn btn-ghost btn-sm" style="white-space:nowrap" onclick="resetGaugeLayout()">Reset to default</button>
     </div>
 %AMSV_ROW%
     <div class="row-divider" style="margin-top:var(--sp-3)">&#9650; Top row</div>

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -776,7 +776,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="card-head">
       <div>
         <h3>Gauge Layout</h3>
-        <p>Per-printer display slots. The first six are always shown; slots 7-9 only appear when <em>Landscape 8 slots</em> or <em>Portrait 9 slots</em> is enabled in Display. Set any slot to <em>Empty</em> to hide it.</p>
+        <p>Per-printer display slots. The standard 2x3 grid is always shown. On 240x320 and 320x480 boards the extra rows below only render when the matching grid mode (<em>Landscape 8 slots</em> / <em>Portrait 9 slots</em>) is enabled under Display. Set any slot to <em>Empty</em> to hide it.</p>
       </div>
       <button type="button" class="btn btn-ghost btn-sm" onclick="resetGaugeLayout()">Reset to default</button>
     </div>
@@ -795,14 +795,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
         <div class="cell"><label>Bot-right</label><select id="gs5" class="gauge-slot-sel"></select></div>
       </div>
     </div>
-    <div id="extraColGroup">
-      <div class="row-divider">&#9656; Extra slots (used by <em>Landscape 8 slots</em> and <em>Portrait 9 slots</em>; same gauge type, different physical position per orientation)</div>
-      <div class="gauge-grid">
-        <div class="cell"><label>Slot 7 (land col 4 top / port row 3 left)</label><select id="gs6" class="gauge-slot-sel"></select></div>
-        <div class="cell"><label>Slot 8 (land col 4 bot / port row 3 mid)</label><select id="gs7" class="gauge-slot-sel"></select></div>
-        <div class="cell"><label>Slot 9 (port row 3 right only)</label><select id="gs8" class="gauge-slot-sel"></select></div>
-      </div>
-    </div>
+%EXTRAS_SECTIONS%
     <div class="action-bar">
       <button type="button" class="btn btn-primary" onclick="saveGaugeLayout()">Save Gauge Layout</button>
     </div>
@@ -1545,17 +1538,40 @@ function stopPolling(){
 var _brightTimer = null;
 function sendBrightness(val){ clearTimeout(_brightTimer); _brightTimer = setTimeout(function(){ fetch('/brightness?val=' + val); }, 150); }
 
-/* ============ Gauge slot type labels (must match GaugeType enum in settings.h) ============ */
+/* ============ Gauge slot type labels (must match GaugeType enum in settings.h) ============
+   Array index = numeric gauge ID. Empty `group` renders ungrouped at the top
+   of the dropdown; named groups render as <optgroup> blocks in the order the
+   first member of each group appears below. */
 var gaugeTypes = [
-  '-- Empty --','Progress','Nozzle Temp','Bed Temp',
-  'Part Fan','Aux Fan','Chamber Fan','Chamber Temp',
-  'Heatbreak Fan','Clock',
-  'AMS 1 Humidity','AMS 2 Humidity','AMS 3 Humidity','AMS 4 Humidity',
-  'Layer Progress',
-  'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp',
-  'AMS 1 Filament','AMS 2 Filament','AMS 3 Filament','AMS 4 Filament',
-  'Aux Fan Right (X2D)','Exhaust Fan',
-  'AMS 1 Bars','AMS 2 Bars','AMS 3 Bars','AMS 4 Bars'
+  {name:'-- Empty --',        group:''},                  /*  0 */
+  {name:'Progress',           group:'Print status'},      /*  1 */
+  {name:'Nozzle Temp',        group:'Temperatures'},      /*  2 */
+  {name:'Bed Temp',           group:'Temperatures'},      /*  3 */
+  {name:'Part Fan',           group:'Fans'},              /*  4 */
+  {name:'Aux Fan',            group:'Fans'},              /*  5 */
+  {name:'Chamber Fan',        group:'Fans'},              /*  6 */
+  {name:'Chamber Temp',       group:'Temperatures'},      /*  7 */
+  {name:'Heatbreak Fan',      group:'Fans'},              /*  8 */
+  {name:'Clock',              group:'Other'},             /*  9 */
+  {name:'AMS 1 Humidity',     group:'AMS humidity'},      /* 10 */
+  {name:'AMS 2 Humidity',     group:'AMS humidity'},      /* 11 */
+  {name:'AMS 3 Humidity',     group:'AMS humidity'},      /* 12 */
+  {name:'AMS 4 Humidity',     group:'AMS humidity'},      /* 13 */
+  {name:'Layer Progress',     group:'Print status'},      /* 14 */
+  {name:'AMS 1 Temp',         group:'AMS temperature'},   /* 15 */
+  {name:'AMS 2 Temp',         group:'AMS temperature'},   /* 16 */
+  {name:'AMS 3 Temp',         group:'AMS temperature'},   /* 17 */
+  {name:'AMS 4 Temp',         group:'AMS temperature'},   /* 18 */
+  {name:'AMS 1 Filament',     group:'AMS filament (quad)'},/* 19 */
+  {name:'AMS 2 Filament',     group:'AMS filament (quad)'},/* 20 */
+  {name:'AMS 3 Filament',     group:'AMS filament (quad)'},/* 21 */
+  {name:'AMS 4 Filament',     group:'AMS filament (quad)'},/* 22 */
+  {name:'Aux Fan Right (X2D)',group:'Fans'},              /* 23 */
+  {name:'Exhaust Fan',        group:'Fans'},              /* 24 */
+  {name:'AMS 1 Bars',         group:'AMS filament (bars)'},/* 25 */
+  {name:'AMS 2 Bars',         group:'AMS filament (bars)'},/* 26 */
+  {name:'AMS 3 Bars',         group:'AMS filament (bars)'},/* 27 */
+  {name:'AMS 4 Bars',         group:'AMS filament (bars)'} /* 28 */
 ];
 var GAUGE_REQUIRES = { 23: 'hasAuxFanRight', 24: 'hasExhaustFan' };
 var gaugeCaps = {}, persistedGauges = {};
@@ -1566,15 +1582,35 @@ function gaugeAllowed(idx){
   return true;
 }
 function rebuildGaugeOptions(){
+  // Build ungrouped + groups once, then clone into each <select>.
+  // groups[] preserves first-seen order; groupMembers[g] is a list of {i, name}.
+  var ungrouped = [];
+  var groups = [];
+  var groupMembers = {};
+  gaugeTypes.forEach(function(gt, i){
+    if (!gaugeAllowed(i)) return;
+    if (!gt.group) { ungrouped.push({i:i, name:gt.name}); return; }
+    if (!groupMembers[gt.group]) { groups.push(gt.group); groupMembers[gt.group] = []; }
+    groupMembers[gt.group].push({i:i, name:gt.name});
+  });
   var sels = document.querySelectorAll('.gauge-slot-sel');
   sels.forEach(function(sel){
     var cur = sel.value;
     sel.innerHTML = '';
-    gaugeTypes.forEach(function(name, i){
-      if (!gaugeAllowed(i)) return;
+    ungrouped.forEach(function(e){
       var o = document.createElement('option');
-      o.value = i; o.textContent = name;
+      o.value = e.i; o.textContent = e.name;
       sel.appendChild(o);
+    });
+    groups.forEach(function(g){
+      var og = document.createElement('optgroup');
+      og.label = g;
+      groupMembers[g].forEach(function(e){
+        var o = document.createElement('option');
+        o.value = e.i; o.textContent = e.name;
+        og.appendChild(o);
+      });
+      sel.appendChild(og);
     });
     if (cur !== '') sel.value = cur;
   });
@@ -1591,9 +1627,12 @@ function refreshGaugeCaps(){
       if (v !== !!gaugeCaps[capName]){ gaugeCaps[capName] = v; changed = true; }
     });
     arr.forEach(function(d){
-      if (!d || !d.gaugeSlots) return;
-      d.gaugeSlots.forEach(function(v){
-        if (!persistedGauges[v]) { persistedGauges[v] = true; changed = true; }
+      if (!d) return;
+      ['gaugeSlots','landscapeExtras','portraitExtras'].forEach(function(key){
+        if (!Array.isArray(d[key])) return;
+        d[key].forEach(function(v){
+          if (!persistedGauges[v]) { persistedGauges[v] = true; changed = true; }
+        });
       });
     });
     if (changed) rebuildGaugeOptions();
@@ -1602,15 +1641,21 @@ function refreshGaugeCaps(){
 refreshGaugeCaps();
 
 function resetGaugeLayout(){
-  // Slots 0..5 = standard 2x3; slots 6..8 = extended-mode extras, default Empty.
-  var d = [1,2,3,4,5,6,0,0,0];
-  for (var i = 0; i < 9; i++) { var s = document.getElementById('gs' + i); if (s) s.value = d[i]; }
+  // Standard 2x3 grid -> Progress/Nozzle/Bed/PartFan/AuxFan/ChamberFan.
+  // Both extras arrays default to Empty (user opts in via mode toggles).
+  var d = [1,2,3,4,5,6];
+  for (var i = 0; i < 6; i++) { var s = document.getElementById('gs' + i); if (s) s.value = d[i]; }
+  var lx = ['lx0','lx1'], px = ['px0','px1','px2'];
+  lx.forEach(function(id){ var s = document.getElementById(id); if (s) s.value = 0; });
+  px.forEach(function(id){ var s = document.getElementById(id); if (s) s.value = 0; });
   showToast('Restored layout defaults');
 }
 function saveGaugeLayout(){
   var p = new URLSearchParams();
   p.append('slot', currentSlot);
-  for (var g = 0; g < 9; g++) { var s = document.getElementById('gs' + g); if (s) p.append('gs' + g, s.value); }
+  for (var g = 0; g < 6; g++) { var s = document.getElementById('gs' + g); if (s) p.append('gs' + g, s.value); }
+  for (var g = 0; g < 2; g++) { var s = document.getElementById('lx' + g); if (s) p.append('lx' + g, s.value); }
+  for (var g = 0; g < 3; g++) { var s = document.getElementById('px' + g); if (s) p.append('px' + g, s.value); }
   var av = document.getElementById('amsv');
   if (av && av.checked) p.append('amsv', '1');
   fetch('/save/gaugelayout',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
@@ -1648,7 +1693,9 @@ function selectPrinterTab(slot){
       });
     }
     if (capsChanged) rebuildGaugeOptions();
-    if (d.gaugeSlots) { for (var g = 0; g < 9; g++) { var sel = document.getElementById('gs' + g); if (sel) sel.value = d.gaugeSlots[g] || 0; } }
+    if (d.gaugeSlots) { for (var g = 0; g < 6; g++) { var sel = document.getElementById('gs' + g); if (sel) sel.value = d.gaugeSlots[g] || 0; } }
+    if (d.landscapeExtras) { for (var g = 0; g < 2; g++) { var sel = document.getElementById('lx' + g); if (sel) sel.value = d.landscapeExtras[g] || 0; } }
+    if (d.portraitExtras)  { for (var g = 0; g < 3; g++) { var sel = document.getElementById('px' + g); if (sel) sel.value = d.portraitExtras[g] || 0; } }
     var av = document.getElementById('amsv');
     if (av) { av.checked = !!d.amsView; syncAmsView(); }
     toggleConnMode();

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -634,6 +634,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
   <button class="nav-item" type="button" data-section="printer" aria-current="true"><span>Printer</span></button>
   <button class="nav-item" type="button" data-section="display"><span>Display</span></button>
   <button class="nav-item" type="button" data-section="hardware"><span>Hardware</span></button>
+  <button class="nav-item" type="button" data-section="advanced"><span>Advanced</span></button>
   <h4>Network</h4>
   <button class="nav-item" type="button" data-section="wifi"><span>WiFi &amp; System</span></button>
   <button class="nav-item" type="button" data-section="power"><span>Power</span></button>
@@ -836,8 +837,6 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <input type="checkbox" id="fanmp" value="1" %FMP% onchange="toggleSetting('fanmp',this.checked)">
       <label for="fanmp">Match printer fan % (10% steps - applies on next printer update)</label>
     </label>
-%L8S_ROW%
-%P9S_ROW%
 %INVCOL_ROW%
 %CYD_PANEL_ROW%
   </div>
@@ -1153,7 +1152,6 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
   </div>
 
 %BAT_TOGGLE_ROW%
-%DUALP_ADVANCED%
 
   <div class="card">
     <div class="card-head">
@@ -1176,7 +1174,33 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
   </div>
 </div>
 
-<!-- ===== Section 4: WiFi & System ===== -->
+<!-- ===== Section 4: Advanced ===== -->
+<div class="section" id="sec-advanced" hidden>
+  <div class="section-intro">
+    <h2>Advanced</h2>
+    <p>Extended display layouts and operations that need extra care. Most users do not need anything here.</p>
+  </div>
+
+%EXTENDED_MODES_CARD%
+
+  <div class="card" style="border-color:rgba(220, 69, 56, 0.30)">
+    <div class="card-head"><div><h3 style="color:var(--danger)">Danger zone</h3><p>Destructive operations and experimental settings. Unlock to reveal.</p></div></div>
+    <label class="check-row">
+      <input type="checkbox" id="dangerUnlock" onchange="toggleDangerUnlock(this.checked)">
+      <label for="dangerUnlock">Show advanced operations</label>
+    </label>
+    <div id="dangerOps" style="display:none;margin-top:var(--sp-3)">
+%DUALP_ADVANCED%
+      <div class="hstack" style="gap:var(--sp-2);flex-wrap:wrap;margin-top:var(--sp-3)">
+        <button type="button" class="btn btn-ghost" onclick="rebootDevice()">Reboot</button>
+        <button type="button" class="btn btn-danger" onclick="factoryReset()">Factory Reset...</button>
+      </div>
+      <p class="hint" style="margin-top:var(--sp-2)">Reboot does not change settings. Factory reset wipes WiFi, printers, gauge layout, everything.</p>
+    </div>
+  </div>
+</div>
+
+<!-- ===== Section 5: WiFi & System ===== -->
 <div class="section" id="sec-wifi" hidden>
   <div class="section-intro">
     <h2>WiFi &amp; System</h2>
@@ -1315,16 +1339,10 @@ R"rawliteral(
 R"rawliteral(
   </div>
 
-  <div class="card" style="border-color:rgba(220, 69, 56, 0.30)">
-    <div class="card-head"><div><h3 style="color:var(--danger)">Danger zone</h3><p>Reboot does not change settings. Factory reset wipes WiFi, printers, gauge layout, everything.</p></div></div>
-    <div class="hstack" style="gap:var(--sp-2);flex-wrap:wrap">
-      <button type="button" class="btn btn-ghost" onclick="rebootDevice()">Reboot</button>
-      <button type="button" class="btn btn-danger" onclick="factoryReset()">Factory Reset...</button>
-    </div>
-  </div>
+  <p class="hint" style="margin-top:var(--sp-3)">Reboot and factory reset have moved to the <strong>Advanced</strong> section.</p>
 </div>
 
-<!-- ===== Section 5: Power Monitoring ===== -->
+<!-- ===== Section 6: Power Monitoring ===== -->
 <div class="section" id="sec-power" hidden>
   <div class="section-intro">
     <h2>Power Monitoring</h2>
@@ -1444,6 +1462,7 @@ var SECTION_LABELS = {
   printer: 'Printer Settings',
   display: 'Display',
   hardware: 'Hardware',
+  advanced: 'Advanced',
   wifi: 'WiFi & System',
   power: 'Power Monitoring',
   diag: 'Diagnostics'
@@ -2107,6 +2126,19 @@ function toggleDualPrinterMode(on){
   var d = document.getElementById('topStatusDot1');
   if (d) d.style.display = on ? '' : 'none';
   if (!on) selectPrinterTab(0);
+}
+/* Toggle a grid mode (l8s / p9s) and sync the matching Gauge Layout extras
+   block in the Printer section. Hides the extra dropdowns when the user
+   doesn't have the mode enabled so the layout card stays compact. */
+function toggleGridMode(key, on){
+  toggleSetting(key, on);
+  var elId = (key === 'l8s') ? 'landExtrasGroup' : 'portExtrasGroup';
+  var el = document.getElementById(elId);
+  if (el) el.style.display = on ? '' : 'none';
+}
+function toggleDangerUnlock(on){
+  var ops = document.getElementById('dangerOps');
+  if (ops) ops.style.display = on ? '' : 'none';
 }
 
 /* ============ Diagnostics ============ */

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -776,7 +776,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="card-head">
       <div>
         <h3>Gauge Layout</h3>
-        <p>Six display slots, configured per printer. Set any slot to <em>Empty</em> to hide it.</p>
+        <p>Per-printer display slots. The first six are always shown; slots 7-9 only appear when <em>Landscape 8 slots</em> or <em>Portrait 9 slots</em> is enabled in Display. Set any slot to <em>Empty</em> to hide it.</p>
       </div>
       <button type="button" class="btn btn-ghost btn-sm" onclick="resetGaugeLayout()">Reset to default</button>
     </div>
@@ -793,6 +793,14 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
         <div class="cell"><label>Bot-left</label><select id="gs3" class="gauge-slot-sel"></select></div>
         <div class="cell"><label>Bot-center</label><select id="gs4" class="gauge-slot-sel"></select></div>
         <div class="cell"><label>Bot-right</label><select id="gs5" class="gauge-slot-sel"></select></div>
+      </div>
+    </div>
+    <div id="extraColGroup">
+      <div class="row-divider">&#9656; Extra slots (used by <em>Landscape 8 slots</em> and <em>Portrait 9 slots</em>; same gauge type, different physical position per orientation)</div>
+      <div class="gauge-grid">
+        <div class="cell"><label>Slot 7 (land col 4 top / port row 3 left)</label><select id="gs6" class="gauge-slot-sel"></select></div>
+        <div class="cell"><label>Slot 8 (land col 4 bot / port row 3 mid)</label><select id="gs7" class="gauge-slot-sel"></select></div>
+        <div class="cell"><label>Slot 9 (port row 3 right only)</label><select id="gs8" class="gauge-slot-sel"></select></div>
       </div>
     </div>
     <div class="action-bar">
@@ -835,6 +843,8 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <input type="checkbox" id="fanmp" value="1" %FMP% onchange="toggleSetting('fanmp',this.checked)">
       <label for="fanmp">Match printer fan % (10% steps - applies on next printer update)</label>
     </label>
+%L8S_ROW%
+%P9S_ROW%
 %INVCOL_ROW%
 %CYD_PANEL_ROW%
   </div>
@@ -1544,7 +1554,8 @@ var gaugeTypes = [
   'Layer Progress',
   'AMS 1 Temp','AMS 2 Temp','AMS 3 Temp','AMS 4 Temp',
   'AMS 1 Filament','AMS 2 Filament','AMS 3 Filament','AMS 4 Filament',
-  'Aux Fan Right (X2D)','Exhaust Fan'
+  'Aux Fan Right (X2D)','Exhaust Fan',
+  'AMS 1 Bars','AMS 2 Bars','AMS 3 Bars','AMS 4 Bars'
 ];
 var GAUGE_REQUIRES = { 23: 'hasAuxFanRight', 24: 'hasExhaustFan' };
 var gaugeCaps = {}, persistedGauges = {};
@@ -1591,14 +1602,15 @@ function refreshGaugeCaps(){
 refreshGaugeCaps();
 
 function resetGaugeLayout(){
-  var d = [1,2,3,4,5,6];
-  for (var i = 0; i < 6; i++) { var s = document.getElementById('gs' + i); if (s) s.value = d[i]; }
+  // Slots 0..5 = standard 2x3; slots 6..8 = extended-mode extras, default Empty.
+  var d = [1,2,3,4,5,6,0,0,0];
+  for (var i = 0; i < 9; i++) { var s = document.getElementById('gs' + i); if (s) s.value = d[i]; }
   showToast('Restored layout defaults');
 }
 function saveGaugeLayout(){
   var p = new URLSearchParams();
   p.append('slot', currentSlot);
-  for (var g = 0; g < 6; g++) { var s = document.getElementById('gs' + g); if (s) p.append('gs' + g, s.value); }
+  for (var g = 0; g < 9; g++) { var s = document.getElementById('gs' + g); if (s) p.append('gs' + g, s.value); }
   var av = document.getElementById('amsv');
   if (av && av.checked) p.append('amsv', '1');
   fetch('/save/gaugelayout',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
@@ -1636,7 +1648,7 @@ function selectPrinterTab(slot){
       });
     }
     if (capsChanged) rebuildGaugeOptions();
-    if (d.gaugeSlots) { for (var g = 0; g < 6; g++) { var sel = document.getElementById('gs' + g); if (sel) sel.value = d.gaugeSlots[g] || 0; } }
+    if (d.gaugeSlots) { for (var g = 0; g < 9; g++) { var sel = document.getElementById('gs' + g); if (sel) sel.value = d.gaugeSlots[g] || 0; } }
     var av = document.getElementById('amsv');
     if (av) { av.checked = !!d.amsView; syncAmsView(); }
     toggleConnMode();

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2211,7 +2211,12 @@ static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
                              bool forceRedraw) {
   uint16_t bg = dispSettings.bgColor;
   if (forceRedraw) {
-    tft.fillCircle(cx, cy, radius + 2, bg);
+    // Rect clear (not circle) - bars are top-anchored and reach into the
+    // corners of the bounding square, where a circle of radius+2 would miss
+    // a few pixels at every corner. Match the slot-type-change clear in
+    // the printing-screen slot loop so behaviour stays consistent.
+    const int16_t side = radius * 2 + 4;
+    tft.fillRect(cx - radius - 2, cy - radius - 2, side, side, bg);
   }
 
   const int16_t bars = AMS_TRAYS_PER_UNIT;
@@ -2643,26 +2648,28 @@ static int16_t drawBatteryPrefix(int16_t y) {
 // ---------------------------------------------------------------------------
 //  Helper: gauge slot grid descriptor.
 //
-//  drawPrinting() supports three slot layouts that all read from the same
-//  per-printer gaugeSlots[GAUGE_SLOT_COUNT] array:
-//    - 2x3  (6 slots, default everywhere)
-//    - 2x4  (8 slots, DisplaySettings.landscape8Slots, landscape only)
-//    - 3x3  (9 slots, DisplaySettings.portrait9Slots, portrait only, only on
-//            layouts that define LY_PORT9_GAUGE_R)
+//  drawPrinting() supports three slot layouts that draw from three INDEPENDENT
+//  per-printer arrays so each physical position has its own gauge type:
+//    - 2x3 standard  (6 slots, cfg.gaugeSlots[0..5])              every mode
+//    - 2x4 landscape (+2 slots, cfg.landscapeExtras[0..1])        landscape8Slots
+//    - 3x3 portrait  (+3 slots, cfg.portraitExtras[0..2])         portrait9Slots
+//                                                       (LY_PORT9_GAUGE_R only)
 //
-//  The struct keeps the per-mode positions + radius/count in one place so the
-//  printing-screen body just reads grid.x/y/r/count. To add a new mode, add a
-//  new branch in computeSlotGrid() — the slot loop stays untouched.
+//  computeSlotGrid resolves which array each visible slot pulls from for the
+//  current mode, so the printing-screen body just reads grid.types[si] and
+//  grid.x/y[si] without caring about the storage layout. To add a new mode:
+//  add a new PrinterConfig extras array, a new branch here, and a web-UI
+//  section - the slot loop stays untouched.
 // ---------------------------------------------------------------------------
 struct SlotGrid {
-  int16_t x[GAUGE_SLOT_COUNT];
-  int16_t y[GAUGE_SLOT_COUNT];
-  int16_t r;        // per-mode gauge radius (LY_GAUGE_R for 6/8-slot,
-                    // LY_PORT9_GAUGE_R for 9-slot portrait)
-  uint8_t count;    // 6, 8, or 9 - upper bound for the slot loop
+  int16_t x[GAUGE_SLOT_MAX];
+  int16_t y[GAUGE_SLOT_MAX];
+  uint8_t types[GAUGE_SLOT_MAX];  // resolved gauge type per visible slot
+  int16_t r;                       // per-mode gauge radius
+  uint8_t count;                   // 6, 8, or 9 - upper bound for the slot loop
 };
 
-static void computeSlotGrid(SlotGrid& g, bool landscape) {
+static void computeSlotGrid(SlotGrid& g, const PrinterConfig& cfg, bool landscape) {
   const bool eight = landscape && dispSettings.landscape8Slots;
 #if defined(LY_PORT9_GAUGE_R)
   const bool nine  = !landscape && dispSettings.portrait9Slots;
@@ -2670,8 +2677,13 @@ static void computeSlotGrid(SlotGrid& g, bool landscape) {
   const bool nine  = false;
 #endif
 
-  // Zero everything first so unused slots resolve to (0, 0) and skip cleanly.
-  for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) { g.x[i] = 0; g.y[i] = 0; }
+  // Zero everything first so unused slots resolve to (0, 0)/EMPTY and skip.
+  for (uint8_t i = 0; i < GAUGE_SLOT_MAX; i++) {
+    g.x[i] = 0; g.y[i] = 0; g.types[i] = GAUGE_EMPTY;
+  }
+
+  // Slots 0-5 always come from the standard array, regardless of mode.
+  for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) g.types[i] = cfg.gaugeSlots[i];
 
   if (eight) {
 #if defined(LAYOUT_HAS_LANDSCAPE)
@@ -2683,6 +2695,8 @@ static void computeSlotGrid(SlotGrid& g, bool landscape) {
         g.x[row * 4 + col] = cs[col];
         g.y[row * 4 + col] = rs[row];
       }
+    g.types[6] = cfg.landscapeExtras[0];
+    g.types[7] = cfg.landscapeExtras[1];
     return;
 #endif
   }
@@ -2696,6 +2710,9 @@ static void computeSlotGrid(SlotGrid& g, bool landscape) {
         g.x[row * 3 + col] = cs[col];
         g.y[row * 3 + col] = rs[row];
       }
+    g.types[6] = cfg.portraitExtras[0];
+    g.types[7] = cfg.portraitExtras[1];
+    g.types[8] = cfg.portraitExtras[2];
     return;
   }
 #endif
@@ -2754,7 +2771,7 @@ static void drawPrinting() {
   // thickness) stays at the layout default because the arc geometry scales
   // with radius internally.
   SlotGrid grid;
-  computeSlotGrid(grid, isLandscape());
+  computeSlotGrid(grid, p.config, isLandscape());
   const int16_t gR = grid.r;
   const int16_t gT = LY_GAUGE_T;
 
@@ -2933,7 +2950,7 @@ static void drawPrinting() {
     const int16_t* slotX = grid.x;
     const int16_t* slotY = grid.y;
     const uint8_t  slotCount = grid.count;
-    static uint8_t prevSlotTypes[GAUGE_SLOT_COUNT] = {
+    static uint8_t prevSlotTypes[GAUGE_SLOT_MAX] = {
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
     };
     // Invalidate per-slot redraw cache when rotation flips, so the gauges
@@ -2941,14 +2958,14 @@ static void drawPrinting() {
     // at the old positions.
     static uint8_t prevSlotRotation = 0xFF;
     if (prevSlotRotation != dispSettings.rotation) {
-      for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) prevSlotTypes[i] = 0xFF;
+      for (uint8_t i = 0; i < GAUGE_SLOT_MAX; i++) prevSlotTypes[i] = 0xFF;
       prevSlotRotation = dispSettings.rotation;
     }
     // Same cache invalidation when slot count changes (6 <-> 8 <-> 9) — the
     // grid shape itself shifts and any frame-cached positions are stale.
     static uint8_t prevSlotCount = 0;
     if (prevSlotCount != slotCount) {
-      for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) prevSlotTypes[i] = 0xFF;
+      for (uint8_t i = 0; i < GAUGE_SLOT_MAX; i++) prevSlotTypes[i] = 0xFF;
       prevSlotCount = slotCount;
     }
     // Labels for GAUGE_CHAMBER_FAN (Chamber vs Exhaust) and GAUGE_AUX_FAN (Aux vs
@@ -2960,8 +2977,8 @@ static void drawPrinting() {
     // mask changes (typically once per session, on the first pushall).
     static uint32_t prevAirductFuncs = 0;
     if (prevAirductFuncs != s.airductFuncs) {
-      for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) {
-        uint8_t gtPrev = p.config.gaugeSlots[i];
+      for (uint8_t i = 0; i < slotCount; i++) {
+        uint8_t gtPrev = grid.types[i];
         if (gtPrev == GAUGE_CHAMBER_FAN || gtPrev == GAUGE_AUX_FAN) prevSlotTypes[i] = 0xFF;
       }
       prevAirductFuncs = s.airductFuncs;
@@ -2969,22 +2986,30 @@ static void drawPrinting() {
 
     // Mark any slots beyond the current mode's count as needing a clean
     // redraw if they ever become active again — they aren't drawn this frame.
-    for (uint8_t si = slotCount; si < GAUGE_SLOT_COUNT; si++) prevSlotTypes[si] = 0xFF;
+    for (uint8_t si = slotCount; si < GAUGE_SLOT_MAX; si++) prevSlotTypes[si] = 0xFF;
 
     for (uint8_t si = 0; si < slotCount; si++) {
       // Skip row-2 slots when AMS view replaces them. Mark prevSlotTypes as
       // invalid so toggling back later forces a clean redraw.
       if (amsViewActive && si >= 3) { prevSlotTypes[si] = 0xFF; continue; }
-      uint8_t gt = p.config.gaugeSlots[si];
+      uint8_t gt = grid.types[si];
       if (gt >= GAUGE_TYPE_COUNT) gt = GAUGE_EMPTY;
 
       bool typeChanged = (gt != prevSlotTypes[si]);
       if (typeChanged) {
         // Slot type changed (or first draw) - clear area and reset cache.
+        // Use a square fill, not a circle: GAUGE_AMS_BARS draws a rectangular
+        // bar block that extends into the corners of the slot bounding box,
+        // so a circular clear would leave ghost pixels behind when switching
+        // away from it. Spacing math (see computeSlotGrid) leaves >=4px
+        // between this square and the next slot's, even on the densest
+        // 320x480 9-slot grid.
+        const int16_t slotClear = gR * 2 + 4;
+        tft.fillRect(slotX[si] - gR - 2, slotY[si] - gR - 2,
+                     slotClear, slotClear, dispSettings.bgColor);
         // Label is drawn MC_DATUM at labelY, so its glyphs straddle that line;
         // FONT_BODY (~20px) and FONT_SMALL (~14px) need a generous band to fully
         // erase a longer previous label when shrinking to a shorter one.
-        tft.fillCircle(slotX[si], slotY[si], gR + 2, dispSettings.bgColor);
         bool sm = dispSettings.smallLabels;
         int16_t labelY = slotY[si] + gR + (sm ? 3 : -1);
         int16_t lh     = sm ? 18 : 24;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2203,14 +2203,36 @@ static void drawAmsTrayBar(int16_t x, int16_t y, int16_t w, int16_t h,
   }
 }
 
-// Gauge-slot AMS visualization: 4 rounded vertical tray bars (same look as
-// the landscape sidebar / portrait strip), no humidity. Centered in a square
-// 2R x 2R region; "AMS N" label below at the standard gauge-label position.
+// Gauge-slot AMS visualization: one rounded vertical bar per loaded tray (same
+// look as the landscape sidebar / portrait strip), no humidity. Bar count tracks
+// the unit's actual trayCount, so an AMS HT (single slot) shows one centered bar
+// instead of three empty ones. Centered in a square 2R x 2R region; "AMS N"
+// label below at the standard gauge-label position.
 static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
                              const AmsState& ams, uint8_t unitIndex,
                              bool forceRedraw) {
   uint16_t bg = dispSettings.bgColor;
-  if (forceRedraw) {
+
+  const bool unitPresent = ams.present
+                        && unitIndex < AMS_MAX_UNITS
+                        && unitIndex < ams.unitCount
+                        && ams.units[unitIndex].present;
+
+  // Number of bars = the unit's actual tray count, so an AMS HT (1 slot) draws
+  // a single centered bar. Mirrors the standard AMS strip/sidebar (drawAmsZone),
+  // which also centers `trayCount` bars. Fall back to the full count while the
+  // unit isn't reporting yet (placeholder before AMS data arrives).
+  uint8_t bars = unitPresent ? ams.units[unitIndex].trayCount : AMS_TRAYS_PER_UNIT;
+  if (bars == 0 || bars > AMS_TRAYS_PER_UNIT) bars = AMS_TRAYS_PER_UNIT;
+
+  // The bar count can shrink at runtime (4 placeholder bars before AMS HT data
+  // arrives, then 1). That transition doesn't always come with forceRedraw, so
+  // the leftover bars would ghost; track the last-drawn count per unit and wipe
+  // the slot whenever it changes as well.
+  static uint8_t prevBars[AMS_MAX_UNITS] = { 0, 0, 0, 0 };
+  bool clear = forceRedraw || (unitIndex < AMS_MAX_UNITS && prevBars[unitIndex] != bars);
+  if (unitIndex < AMS_MAX_UNITS) prevBars[unitIndex] = bars;
+  if (clear) {
     // Rect clear (not circle) - bars are top-anchored and reach into the
     // corners of the bounding square, where a circle of radius+2 would miss
     // a few pixels at every corner. Match the slot-type-change clear in
@@ -2219,10 +2241,11 @@ static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
     tft.fillRect(cx - radius - 2, cy - radius - 2, side, side, bg);
   }
 
-  const int16_t bars = AMS_TRAYS_PER_UNIT;
   const int16_t innerSize = radius * 2;
   const int16_t barGap = 2;
-  int16_t barW = (innerSize - (bars - 1) * barGap) / bars;
+  // Bar width is sized for the full 4-slot layout so a 1-tray HT unit shows a
+  // single bar the same width as one bar in a 4-tray unit, just centered.
+  int16_t barW = (innerSize - (AMS_TRAYS_PER_UNIT - 1) * barGap) / AMS_TRAYS_PER_UNIT;
   if (barW < 4) barW = 4;
   if (barW > 18) barW = 18;
   // Reserve top space for the active-tray notch and bottom space so the slot
@@ -2235,11 +2258,6 @@ static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
   const int16_t totalW = barW * bars + (bars - 1) * barGap;
   const int16_t startX = cx - totalW / 2;
   const int16_t startY = cy - innerSize / 2 + barTopMargin;
-
-  const bool unitPresent = ams.present
-                        && unitIndex < AMS_MAX_UNITS
-                        && unitIndex < ams.unitCount
-                        && ams.units[unitIndex].present;
 
   AmsTray absent{};
   absent.present = false;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2686,7 +2686,7 @@ static void computeSlotGrid(SlotGrid& g, const PrinterConfig& cfg, bool landscap
   for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) g.types[i] = cfg.gaugeSlots[i];
 
   if (eight) {
-#if defined(LAYOUT_HAS_LANDSCAPE)
+#if defined(LAYOUT_HAS_LANDSCAPE) && defined(LY_LAND8_COL1)
     const int16_t cs[4] = { LY_LAND8_COL1, LY_LAND8_COL2, LY_LAND8_COL3, LY_LAND8_COL4 };
     const int16_t rs[2] = { LY_LAND_ROW1,  LY_LAND_ROW2 };
     g.r = LY_GAUGE_R; g.count = 8;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2203,6 +2203,59 @@ static void drawAmsTrayBar(int16_t x, int16_t y, int16_t w, int16_t h,
   }
 }
 
+// Gauge-slot AMS visualization: 4 rounded vertical tray bars (same look as
+// the landscape sidebar / portrait strip), no humidity. Centered in a square
+// 2R x 2R region; "AMS N" label below at the standard gauge-label position.
+static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
+                             const AmsState& ams, uint8_t unitIndex,
+                             bool forceRedraw) {
+  uint16_t bg = dispSettings.bgColor;
+  if (forceRedraw) {
+    tft.fillCircle(cx, cy, radius + 2, bg);
+  }
+
+  const int16_t bars = AMS_TRAYS_PER_UNIT;
+  const int16_t innerSize = radius * 2;
+  const int16_t barGap = 2;
+  int16_t barW = (innerSize - (bars - 1) * barGap) / bars;
+  if (barW < 4) barW = 4;
+  if (barW > 18) barW = 18;
+  // Reserve top space for the active-tray notch and bottom space so the slot
+  // label ("AMS N") sits below the bars without clipping into them. Bars are
+  // top-anchored — the saved height becomes the breathing room above the label.
+  const int16_t barTopMargin    = 2;
+  const int16_t barLabelMargin  = 14;
+  int16_t barH = innerSize - barTopMargin - barLabelMargin;
+  if (barH < 10) barH = 10;
+  const int16_t totalW = barW * bars + (bars - 1) * barGap;
+  const int16_t startX = cx - totalW / 2;
+  const int16_t startY = cy - innerSize / 2 + barTopMargin;
+
+  const bool unitPresent = ams.present
+                        && unitIndex < AMS_MAX_UNITS
+                        && unitIndex < ams.unitCount
+                        && ams.units[unitIndex].present;
+
+  AmsTray absent{};
+  absent.present = false;
+
+  for (uint8_t t = 0; t < bars; t++) {
+    int16_t bx = startX + t * (barW + barGap);
+    uint8_t trayIdx = unitIndex * AMS_TRAYS_PER_UNIT + t;
+    bool active = unitPresent && (trayIdx == ams.activeTray);
+    const AmsTray& tray = unitPresent ? ams.trays[trayIdx] : absent;
+    drawAmsTrayBarRounded(bx, startY, barW, barH, tray, active);
+  }
+
+  static const char* amsLabel[AMS_MAX_UNITS] = { "AMS 1", "AMS 2", "AMS 3", "AMS 4" };
+  bool sm = dispSettings.smallLabels;
+  int16_t labelY = cy + radius + (sm ? 3 : -1);
+  tft.setTextDatum(MC_DATUM);
+  setFont(tft, sm ? FONT_SMALL : FONT_BODY);
+  tft.setTextColor(CLR_TEXT_DIM, bg);
+  tft.drawString(amsLabel[unitIndex], cx, labelY);
+}
+
 // Portrait AMS strip: horizontal row of tray bars, usable from printing/idle/finished.
 // Draws at (0, zoneY) full width, clears zoneH pixels, bars are barH tall.
 // All groups get uniform width (based on AMS_TRAYS_PER_UNIT slots) so labels
@@ -2588,6 +2641,82 @@ static int16_t drawBatteryPrefix(int16_t y) {
 }
 
 // ---------------------------------------------------------------------------
+//  Helper: gauge slot grid descriptor.
+//
+//  drawPrinting() supports three slot layouts that all read from the same
+//  per-printer gaugeSlots[GAUGE_SLOT_COUNT] array:
+//    - 2x3  (6 slots, default everywhere)
+//    - 2x4  (8 slots, DisplaySettings.landscape8Slots, landscape only)
+//    - 3x3  (9 slots, DisplaySettings.portrait9Slots, portrait only, only on
+//            layouts that define LY_PORT9_GAUGE_R)
+//
+//  The struct keeps the per-mode positions + radius/count in one place so the
+//  printing-screen body just reads grid.x/y/r/count. To add a new mode, add a
+//  new branch in computeSlotGrid() — the slot loop stays untouched.
+// ---------------------------------------------------------------------------
+struct SlotGrid {
+  int16_t x[GAUGE_SLOT_COUNT];
+  int16_t y[GAUGE_SLOT_COUNT];
+  int16_t r;        // per-mode gauge radius (LY_GAUGE_R for 6/8-slot,
+                    // LY_PORT9_GAUGE_R for 9-slot portrait)
+  uint8_t count;    // 6, 8, or 9 - upper bound for the slot loop
+};
+
+static void computeSlotGrid(SlotGrid& g, bool landscape) {
+  const bool eight = landscape && dispSettings.landscape8Slots;
+#if defined(LY_PORT9_GAUGE_R)
+  const bool nine  = !landscape && dispSettings.portrait9Slots;
+#else
+  const bool nine  = false;
+#endif
+
+  // Zero everything first so unused slots resolve to (0, 0) and skip cleanly.
+  for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) { g.x[i] = 0; g.y[i] = 0; }
+
+  if (eight) {
+#if defined(LAYOUT_HAS_LANDSCAPE)
+    const int16_t cs[4] = { LY_LAND8_COL1, LY_LAND8_COL2, LY_LAND8_COL3, LY_LAND8_COL4 };
+    const int16_t rs[2] = { LY_LAND_ROW1,  LY_LAND_ROW2 };
+    g.r = LY_GAUGE_R; g.count = 8;
+    for (uint8_t row = 0; row < 2; row++)
+      for (uint8_t col = 0; col < 4; col++) {
+        g.x[row * 4 + col] = cs[col];
+        g.y[row * 4 + col] = rs[row];
+      }
+    return;
+#endif
+  }
+#if defined(LY_PORT9_GAUGE_R)
+  if (nine) {
+    const int16_t cs[3] = { LY_COL1, LY_COL2, LY_COL3 };
+    const int16_t rs[3] = { LY_PORT9_ROW1, LY_PORT9_ROW2, LY_PORT9_ROW3 };
+    g.r = LY_PORT9_GAUGE_R; g.count = 9;
+    for (uint8_t row = 0; row < 3; row++)
+      for (uint8_t col = 0; col < 3; col++) {
+        g.x[row * 3 + col] = cs[col];
+        g.y[row * 3 + col] = rs[row];
+      }
+    return;
+  }
+#endif
+
+  // Default: 2x3, columns + rows pick portrait/landscape variant.
+#if defined(LAYOUT_HAS_LANDSCAPE)
+  const int16_t c0 = landscape ? LY_LAND_COL1 : LY_COL1;
+  const int16_t c1 = landscape ? LY_LAND_COL2 : LY_COL2;
+  const int16_t c2 = landscape ? LY_LAND_COL3 : LY_COL3;
+  const int16_t r0 = landscape ? LY_LAND_ROW1 : LY_ROW1;
+  const int16_t r1 = landscape ? LY_LAND_ROW2 : LY_ROW2;
+#else
+  const int16_t c0 = LY_COL1, c1 = LY_COL2, c2 = LY_COL3;
+  const int16_t r0 = LY_ROW1, r1 = LY_ROW2;
+#endif
+  g.r = LY_GAUGE_R; g.count = 6;
+  g.x[0]=c0; g.x[1]=c1; g.x[2]=c2; g.x[3]=c0; g.x[4]=c1; g.x[5]=c2;
+  g.y[0]=r0; g.y[1]=r0; g.y[2]=r0; g.y[3]=r1; g.y[4]=r1; g.y[5]=r1;
+}
+
+// ---------------------------------------------------------------------------
 //  Screen: Printing (main dashboard)
 //  Layout: LED bar | header | 2x3 gauge grid | info line
 // ---------------------------------------------------------------------------
@@ -2621,19 +2750,29 @@ static void drawPrinting() {
   const bool unitsZoneChanged = false;
 #endif
 
-  // 2x3 gauge grid constants (from layout profile)
-  const int16_t gR = LY_GAUGE_R;
+  // Gauge grid constants. gR is per-mode (shrunk for 3x3 portrait); gT (arc
+  // thickness) stays at the layout default because the arc geometry scales
+  // with radius internally.
+  SlotGrid grid;
+  computeSlotGrid(grid, isLandscape());
+  const int16_t gR = grid.r;
   const int16_t gT = LY_GAUGE_T;
 
   // Effective Y positions — landscape on CYD uses 240x240-style positions
 #if defined(LAYOUT_HAS_AMS_STRIP)
   const bool land = isLandscape();
   const uint8_t units = s.ams.unitCount;
-  // Right column (badge + AMS) only used in landscape with at least one AMS.
-  const bool landAmsCol = land && units >= 1;
+  // 8-slot landscape mode: drops the AMS sidebar in favour of a 2x4 gauge
+  // grid spanning the full canvas. Everything that branches on landAmsCol
+  // (header clear width, ETA/bot-bar widths, sidebar badge) naturally folds
+  // back to the "no right column" path.
+  const bool land8 = land && dispSettings.landscape8Slots;
+  // Right column (badge + AMS) only used in landscape with at least one AMS
+  // and when the 8-slot mode hasn't claimed that strip for gauges.
+  const bool landAmsCol = land && units >= 1 && !land8;
   // Bottom bar / ETA span the full 320 only when right column doesn't need
   // to extend down to the screen edge (0..2 AMS, or no AMS).
-  const bool botFull = land && landBottomBarFullWidth(units);
+  const bool botFull = land && (land8 || landBottomBarFullWidth(units));
   const int16_t eff_etaY     = land ? LY_LAND_ETA_Y     : LY_ETA_Y;
   const int16_t eff_etaH     = land ? LY_LAND_ETA_H     : LY_ETA_H;
   const int16_t eff_etaTextY = land ? LY_LAND_ETA_TEXT_Y : LY_ETA_TEXT_Y;
@@ -2787,24 +2926,16 @@ static void drawPrinting() {
   const bool amsStripVisible = false;
 #endif
 
-  // === Configurable 2x3 gauge grid ===
+  // === Configurable gauge grid (6 / 8 / 9 slots, see computeSlotGrid) ===
   {
-    // Slot positions are rotation-dependent (LY_LAND_* on landscape boards),
-    // so build the tables at call time instead of caching as static const.
-#if defined(LAYOUT_HAS_LANDSCAPE)
-    const bool gaugeLand = isLandscape();
-    const int16_t c0 = gaugeLand ? LY_LAND_COL1 : LY_COL1;
-    const int16_t c1 = gaugeLand ? LY_LAND_COL2 : LY_COL2;
-    const int16_t c2 = gaugeLand ? LY_LAND_COL3 : LY_COL3;
-    const int16_t r0 = gaugeLand ? LY_LAND_ROW1 : LY_ROW1;
-    const int16_t r1 = gaugeLand ? LY_LAND_ROW2 : LY_ROW2;
-#else
-    const int16_t c0 = LY_COL1, c1 = LY_COL2, c2 = LY_COL3;
-    const int16_t r0 = LY_ROW1, r1 = LY_ROW2;
-#endif
-    const int16_t slotX[GAUGE_SLOT_COUNT] = { c0, c1, c2, c0, c1, c2 };
-    const int16_t slotY[GAUGE_SLOT_COUNT] = { r0, r0, r0, r1, r1, r1 };
-    static uint8_t prevSlotTypes[GAUGE_SLOT_COUNT] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    // Grid is already populated for this frame at the top of drawPrinting()
+    // (gR/gT use grid.r). Read-only here.
+    const int16_t* slotX = grid.x;
+    const int16_t* slotY = grid.y;
+    const uint8_t  slotCount = grid.count;
+    static uint8_t prevSlotTypes[GAUGE_SLOT_COUNT] = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
     // Invalidate per-slot redraw cache when rotation flips, so the gauges
     // get a clean redraw at their new (x, y) instead of leaving artefacts
     // at the old positions.
@@ -2812,6 +2943,13 @@ static void drawPrinting() {
     if (prevSlotRotation != dispSettings.rotation) {
       for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) prevSlotTypes[i] = 0xFF;
       prevSlotRotation = dispSettings.rotation;
+    }
+    // Same cache invalidation when slot count changes (6 <-> 8 <-> 9) — the
+    // grid shape itself shifts and any frame-cached positions are stale.
+    static uint8_t prevSlotCount = 0;
+    if (prevSlotCount != slotCount) {
+      for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++) prevSlotTypes[i] = 0xFF;
+      prevSlotCount = slotCount;
     }
     // Labels for GAUGE_CHAMBER_FAN (Chamber vs Exhaust) and GAUGE_AUX_FAN (Aux vs
     // L.Aux) depend on s.airductFuncs, which starts at 0 and gets bits OR'd in
@@ -2829,7 +2967,11 @@ static void drawPrinting() {
       prevAirductFuncs = s.airductFuncs;
     }
 
-    for (uint8_t si = 0; si < GAUGE_SLOT_COUNT; si++) {
+    // Mark any slots beyond the current mode's count as needing a clean
+    // redraw if they ever become active again — they aren't drawn this frame.
+    for (uint8_t si = slotCount; si < GAUGE_SLOT_COUNT; si++) prevSlotTypes[si] = 0xFF;
+
+    for (uint8_t si = 0; si < slotCount; si++) {
       // Skip row-2 slots when AMS view replaces them. Mark prevSlotTypes as
       // invalid so toggling back later forces a clean redraw.
       if (amsViewActive && si >= 3) { prevSlotTypes[si] = 0xFF; continue; }
@@ -2877,22 +3019,31 @@ static void drawPrinting() {
               uint8_t ui = gt - GAUGE_AMS_TEMP_1;
               const AmsUnit &cu = s.ams.units[ui], &pu = prevState.ams.units[ui];
               needDraw = cu.temp != pu.temp || cu.present != pu.present;
-            } else if (gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) {
-              uint8_t ui = gt - GAUGE_AMS_FILAMENT_1;
+            } else if ((gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4)
+                    || (gt >= GAUGE_AMS_BARS_1     && gt <= GAUGE_AMS_BARS_4)) {
+              uint8_t ui = (gt >= GAUGE_AMS_BARS_1) ? (gt - GAUGE_AMS_BARS_1)
+                                                    : (gt - GAUGE_AMS_FILAMENT_1);
+              const bool isBars = (gt >= GAUGE_AMS_BARS_1);
               needDraw = s.ams.present != prevState.ams.present
                       || s.ams.unitCount != prevState.ams.unitCount;
               if (!needDraw) {
                 const AmsUnit &cu = s.ams.units[ui], &pu = prevState.ams.units[ui];
+                // Bars gauge does not show humidity, so skip the humidity diff
+                // to avoid redundant redraws.
                 if (cu.present != pu.present
-                    || cu.humidity != pu.humidity
+                    || (!isBars && cu.humidity != pu.humidity)
                     || cu.trayCount != pu.trayCount) needDraw = true;
+              }
+              if (!needDraw && isBars && s.ams.activeTray != prevState.ams.activeTray) {
+                needDraw = true;
               }
               if (!needDraw) {
                 for (int t = 0; t < AMS_TRAYS_PER_UNIT; t++) {
                   int idx = ui * AMS_TRAYS_PER_UNIT + t;
                   const AmsTray &ct = s.ams.trays[idx], &pt = prevState.ams.trays[idx];
                   if (ct.present != pt.present || ct.colorRgb565 != pt.colorRgb565
-                      || ct.remain != pt.remain || strcmp(ct.type, pt.type) != 0) {
+                      || ct.remain != pt.remain
+                      || (!isBars && strcmp(ct.type, pt.type) != 0)) {
                     needDraw = true; break;
                   }
                 }
@@ -2983,6 +3134,9 @@ static void drawPrinting() {
           } else if (gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) {
             uint8_t ui = gt - GAUGE_AMS_FILAMENT_1;
             drawAmsFilamentAllGauge(tft, cx, cy, gR, gT, s.ams, ui, fr);
+          } else if (gt >= GAUGE_AMS_BARS_1 && gt <= GAUGE_AMS_BARS_4) {
+            uint8_t ui = gt - GAUGE_AMS_BARS_1;
+            drawAmsBarsGauge(cx, cy, gR, s.ams, ui, fr);
           } else {
             if (fr) tft.fillCircle(cx, cy, gR + 2, dispSettings.bgColor);
           }
@@ -2999,7 +3153,18 @@ static void drawPrinting() {
   // (e.g. transient unitCount=0 from MQTT reconnect).
 #if defined(LAYOUT_HAS_AMS_STRIP)
   const bool amsForce = forceRedraw || unitsZoneChanged;
-  if (isLandscape() || (s.ams.present && s.ams.unitCount > 0)) {
+  // Both extended grid modes claim the area drawAmsZone would paint into:
+  //  - landscape 8-slot replaces the right-side sidebar
+  //  - portrait 9-slot replaces the bottom AMS strip
+  // Skip drawAmsZone whenever the corresponding mode is on; the toggle-change
+  // detector at the top of displayUI() forces a clean repaint when flipping.
+  const bool skipAmsZone =
+        ( isLandscape() && dispSettings.landscape8Slots)
+#if defined(LY_PORT9_GAUGE_R)
+     || (!isLandscape() && dispSettings.portrait9Slots)
+#endif
+        ;
+  if (!skipAmsZone && (isLandscape() || (s.ams.present && s.ams.unitCount > 0))) {
     drawAmsZone(s, amsForce);
   }
 #endif
@@ -3660,6 +3825,21 @@ void updateDisplay() {
       setBacklight(getEffectiveBrightness());  // dim for screensaver
     }
     prevScreen = currentScreen;
+  }
+
+  // Grid-mode toggles (landscape-8 / portrait-9): flipping either mid-frame
+  // leaves pixels from the previous layout on screen (the AMS sidebar, the
+  // AMS strip, or a now-unused column/row) until something else forces a
+  // redraw. Treat it like a screen change so the next frame paints clean.
+  static bool prev8Slots = dispSettings.landscape8Slots;
+  static bool prev9Slots = dispSettings.portrait9Slots;
+  if (prev8Slots != dispSettings.landscape8Slots ||
+      prev9Slots != dispSettings.portrait9Slots) {
+    tft.fillScreen(dispSettings.bgColor);
+    markFrameDirty();
+    forceRedraw = true;
+    prev8Slots = dispSettings.landscape8Slots;
+    prev9Slots = dispSettings.portrait9Slots;
   }
 
   switch (currentScreen) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -165,9 +165,7 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.heatbreak = { CLR_ORANGE, CLR_ORANGE, CLR_TEXT };
 }
 
-// Default gauge slot layout: Progress, Nozzle, Bed, Part Fan, Aux Fan, Chamber Fan.
-// Slots 6-8 only render in landscape-8 / portrait-9 modes — default to EMPTY
-// so enabling either mode does not surprise the user with random gauges.
+// Default standard 2x3 grid: Progress, Nozzle, Bed, Part Fan, Aux Fan, Chamber Fan.
 static void defaultGaugeSlots(uint8_t* slots) {
   slots[0] = GAUGE_PROGRESS;
   slots[1] = GAUGE_NOZZLE;
@@ -175,9 +173,6 @@ static void defaultGaugeSlots(uint8_t* slots) {
   slots[3] = GAUGE_PART_FAN;
   slots[4] = GAUGE_AUX_FAN;
   slots[5] = GAUGE_CHAMBER_FAN;
-  slots[6] = GAUGE_EMPTY;
-  slots[7] = GAUGE_EMPTY;
-  slots[8] = GAUGE_EMPTY;
 }
 
 // ---------------------------------------------------------------------------
@@ -246,24 +241,38 @@ void loadSettings() {
     snprintf(key, sizeof(key), "p%d_region", i);
     cfg.region = (CloudRegion)prefs.getUChar(key, REGION_US);
 
-    // Gauge slot layout (per-printer).
-    // Legacy records hold only 6 bytes (pre-landscape-8-slot mode). Treat any
-    // partial read >=6 as valid and default the missing trailing slots to EMPTY
-    // so the user opts in to landscape extras via the web UI.
+    // Gauge slot layout (per-printer). 3 NVS keys:
+    //   p%d_slots - standard 2x3 (6 bytes, always present after first save)
+    //   p%d_lext  - landscape extras (2 bytes, only after enabling 8-slot mode)
+    //   p%d_pext  - portrait  extras (3 bytes, only after enabling 9-slot mode)
+    // Missing keys -> EMPTY. Legacy 8/9-byte records from the in-development
+    // 'shared extras' branch read as 6-byte standard slots (trailing bytes
+    // ignored); their old landscape slots 6/7 will be re-set in the web UI.
     snprintf(key, sizeof(key), "p%d_slots", i);
-    memset(cfg.gaugeSlots, GAUGE_EMPTY, GAUGE_SLOT_COUNT);
-    size_t read = prefs.getBytes(key, cfg.gaugeSlots, GAUGE_SLOT_COUNT);
-    if (read < 6) {
+    memset(cfg.gaugeSlots, GAUGE_EMPTY, sizeof(cfg.gaugeSlots));
+    size_t read = prefs.getBytes(key, cfg.gaugeSlots, sizeof(cfg.gaugeSlots));
+    if (read < sizeof(cfg.gaugeSlots)) {
       defaultGaugeSlots(cfg.gaugeSlots);
     } else {
-      // Anything past `read` was zeroed by memset (GAUGE_EMPTY == 0).
+      uint8_t def[GAUGE_SLOT_COUNT];
+      defaultGaugeSlots(def);
       for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) {
-        if (cfg.gaugeSlots[g] >= GAUGE_TYPE_COUNT) {
-          uint8_t def[GAUGE_SLOT_COUNT];
-          defaultGaugeSlots(def);
-          cfg.gaugeSlots[g] = def[g];
-        }
+        if (cfg.gaugeSlots[g] >= GAUGE_TYPE_COUNT) cfg.gaugeSlots[g] = def[g];
       }
+    }
+
+    snprintf(key, sizeof(key), "p%d_lext", i);
+    memset(cfg.landscapeExtras, GAUGE_EMPTY, sizeof(cfg.landscapeExtras));
+    prefs.getBytes(key, cfg.landscapeExtras, sizeof(cfg.landscapeExtras));
+    for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT; g++) {
+      if (cfg.landscapeExtras[g] >= GAUGE_TYPE_COUNT) cfg.landscapeExtras[g] = GAUGE_EMPTY;
+    }
+
+    snprintf(key, sizeof(key), "p%d_pext", i);
+    memset(cfg.portraitExtras, GAUGE_EMPTY, sizeof(cfg.portraitExtras));
+    prefs.getBytes(key, cfg.portraitExtras, sizeof(cfg.portraitExtras));
+    for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT; g++) {
+      if (cfg.portraitExtras[g] >= GAUGE_TYPE_COUNT) cfg.portraitExtras[g] = GAUGE_EMPTY;
     }
 
     // AMS view (per-printer): 240x240 only, replaces gauge row 2 with AMS strip
@@ -655,7 +664,11 @@ void savePrinterConfig(uint8_t index) {
   prefs.putUChar(key, cfg.region);
 
   snprintf(key, sizeof(key), "p%d_slots", index);
-  prefs.putBytes(key, cfg.gaugeSlots, GAUGE_SLOT_COUNT);
+  prefs.putBytes(key, cfg.gaugeSlots, sizeof(cfg.gaugeSlots));
+  snprintf(key, sizeof(key), "p%d_lext", index);
+  prefs.putBytes(key, cfg.landscapeExtras, sizeof(cfg.landscapeExtras));
+  snprintf(key, sizeof(key), "p%d_pext", index);
+  prefs.putBytes(key, cfg.portraitExtras, sizeof(cfg.portraitExtras));
 
   snprintf(key, sizeof(key), "p%d_amsv", index);
   prefs.putBool(key, cfg.amsView);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -135,6 +135,8 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.fanMatchPrinter = true;
   ds.invertColors = false;
   ds.cydPanelClassic = false;
+  ds.landscape8Slots = false;
+  ds.portrait9Slots = false;
   ds.clockTimeColor = CLR_TEXT;
   ds.clockDateColor = CLR_TEXT_DIM;
   ds.clockTimeSize = 0;        // Auto
@@ -163,7 +165,9 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.heatbreak = { CLR_ORANGE, CLR_ORANGE, CLR_TEXT };
 }
 
-// Default gauge slot layout: Progress, Nozzle, Bed, Part Fan, Aux Fan, Chamber Fan
+// Default gauge slot layout: Progress, Nozzle, Bed, Part Fan, Aux Fan, Chamber Fan.
+// Slots 6-8 only render in landscape-8 / portrait-9 modes — default to EMPTY
+// so enabling either mode does not surprise the user with random gauges.
 static void defaultGaugeSlots(uint8_t* slots) {
   slots[0] = GAUGE_PROGRESS;
   slots[1] = GAUGE_NOZZLE;
@@ -171,6 +175,9 @@ static void defaultGaugeSlots(uint8_t* slots) {
   slots[3] = GAUGE_PART_FAN;
   slots[4] = GAUGE_AUX_FAN;
   slots[5] = GAUGE_CHAMBER_FAN;
+  slots[6] = GAUGE_EMPTY;
+  slots[7] = GAUGE_EMPTY;
+  slots[8] = GAUGE_EMPTY;
 }
 
 // ---------------------------------------------------------------------------
@@ -239,12 +246,17 @@ void loadSettings() {
     snprintf(key, sizeof(key), "p%d_region", i);
     cfg.region = (CloudRegion)prefs.getUChar(key, REGION_US);
 
-    // Gauge slot layout (per-printer)
+    // Gauge slot layout (per-printer).
+    // Legacy records hold only 6 bytes (pre-landscape-8-slot mode). Treat any
+    // partial read >=6 as valid and default the missing trailing slots to EMPTY
+    // so the user opts in to landscape extras via the web UI.
     snprintf(key, sizeof(key), "p%d_slots", i);
+    memset(cfg.gaugeSlots, GAUGE_EMPTY, GAUGE_SLOT_COUNT);
     size_t read = prefs.getBytes(key, cfg.gaugeSlots, GAUGE_SLOT_COUNT);
-    if (read != GAUGE_SLOT_COUNT) {
+    if (read < 6) {
       defaultGaugeSlots(cfg.gaugeSlots);
     } else {
+      // Anything past `read` was zeroed by memset (GAUGE_EMPTY == 0).
       for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) {
         if (cfg.gaugeSlots[g] >= GAUGE_TYPE_COUNT) {
           uint8_t def[GAUGE_SLOT_COUNT];
@@ -292,6 +304,8 @@ void loadSettings() {
   dispSettings.fanMatchPrinter = prefs.getBool("dsp_fanmp", def.fanMatchPrinter);
   dispSettings.invertColors = prefs.getBool("dsp_inv", def.invertColors);
   dispSettings.cydPanelClassic = prefs.getBool("dsp_cydcls", def.cydPanelClassic);
+  dispSettings.landscape8Slots = prefs.getBool("dsp_l8s", def.landscape8Slots);
+  dispSettings.portrait9Slots = prefs.getBool("dsp_p9s", def.portrait9Slots);
   dispSettings.clockTimeColor = prefs.getUShort("dsp_clkt", CLR_TEXT);
   dispSettings.clockDateColor = prefs.getUShort("dsp_clkd", CLR_TEXT_DIM);
   {
@@ -530,6 +544,8 @@ void saveSettings() {
   prefs.putBool("dsp_fanmp", dispSettings.fanMatchPrinter);
   prefs.putBool("dsp_inv", dispSettings.invertColors);
   prefs.putBool("dsp_cydcls", dispSettings.cydPanelClassic);
+  prefs.putBool("dsp_l8s", dispSettings.landscape8Slots);
+  prefs.putBool("dsp_p9s", dispSettings.portrait9Slots);
   prefs.putUShort("dsp_clkt", dispSettings.clockTimeColor);
   prefs.putUShort("dsp_clkd", dispSettings.clockDateColor);
   prefs.putUChar("dsp_clkts", dispSettings.clockTimeSize);

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,10 +31,22 @@ enum GaugeType : uint8_t {
   GAUGE_AMS_FILAMENT_4 = 22,    // AMS unit 4 - all 4 trays + humidity
   GAUGE_AUX_FAN_RIGHT  = 23,    // X2D right aux fan (device.airduct.parts func=6)
   GAUGE_EXHAUST_FAN    = 24,    // X2D exhaust fan (device.airduct.parts func=2)
+  GAUGE_AMS_BARS_1     = 25,    // AMS unit 1 - 4 vertical color bars (no humidity)
+  GAUGE_AMS_BARS_2     = 26,    // AMS unit 2
+  GAUGE_AMS_BARS_3     = 27,    // AMS unit 3
+  GAUGE_AMS_BARS_4     = 28,    // AMS unit 4
   GAUGE_TYPE_COUNT  // sentinel - always last
 };
 
-static const uint8_t GAUGE_SLOT_COUNT = 6;
+// Slot count: 6 are always used (portrait + 3-col landscape). Slots 6-7 also
+// render when DisplaySettings.landscape8Slots enables the 4-column landscape
+// grid (replaces the AMS sidebar). Slots 6-8 render when
+// DisplaySettings.portrait9Slots enables the 3x3 portrait grid (replaces the
+// AMS strip). Slots 6 and 7 are SHARED between the two extended modes - the
+// gauge type config is the same, only the physical (x, y) position differs
+// by orientation. Slot 8 is portrait-only.
+static const uint8_t GAUGE_SLOT_COUNT = 9;
+static const uint8_t GAUGE_SLOT_EXTRA_START = 6;
 
 // Per-gauge color config
 struct GaugeColors {
@@ -58,6 +70,10 @@ struct DisplaySettings {
   bool     cydPanelClassic; // CYD only: use plain Panel_ILI9341 (no inversion)
                             // instead of Panel_ILI9341_2 — for the other
                             // hardware revision that shows mirrored image.
+  bool     landscape8Slots; // 240x320 landscape: replace AMS sidebar with a
+                            // symmetric 2x4 gauge grid (8 slots, no sidebar).
+  bool     portrait9Slots;  // 240x320 / 320x480 portrait: replace AMS strip
+                            // with a 3x3 gauge grid (9 slots, smaller R).
   uint16_t clockTimeColor; // clock digits color (RGB565)
   uint16_t clockDateColor; // clock date/AM-PM color (RGB565)
   uint8_t  clockTimeSize;  // 0=Auto, 1=Normal(1.0x), 2=Medium(1.5x), 3=Large(2.0x). Auto = Large on >=480, Medium on >=320, else Normal.

--- a/src/settings.h
+++ b/src/settings.h
@@ -38,15 +38,16 @@ enum GaugeType : uint8_t {
   GAUGE_TYPE_COUNT  // sentinel - always last
 };
 
-// Slot count: 6 are always used (portrait + 3-col landscape). Slots 6-7 also
-// render when DisplaySettings.landscape8Slots enables the 4-column landscape
-// grid (replaces the AMS sidebar). Slots 6-8 render when
-// DisplaySettings.portrait9Slots enables the 3x3 portrait grid (replaces the
-// AMS strip). Slots 6 and 7 are SHARED between the two extended modes - the
-// gauge type config is the same, only the physical (x, y) position differs
-// by orientation. Slot 8 is portrait-only.
-static const uint8_t GAUGE_SLOT_COUNT = 9;
-static const uint8_t GAUGE_SLOT_EXTRA_START = 6;
+// Standard 2x3 gauge grid - the 6 slots are used in every mode.
+static const uint8_t GAUGE_SLOT_COUNT = 6;
+// Extended grids add a 4th column (landscape) or 3rd row (portrait).
+// Each extension stores its slots in its own PrinterConfig array so the gauge
+// type for "col 4 row 1" and "row 3 col 1" can be set independently.
+static const uint8_t LANDSCAPE_EXTRA_COUNT = 2;  // col 4 top, col 4 bot
+static const uint8_t PORTRAIT_EXTRA_COUNT  = 3;  // row 3 left, mid, right
+// Max slots displayed by any mode at once. Used to size per-frame slot caches
+// in display_ui.cpp (prevSlotTypes, SlotGrid arrays).
+static const uint8_t GAUGE_SLOT_MAX = GAUGE_SLOT_COUNT + PORTRAIT_EXTRA_COUNT;  // 9
 
 // Per-gauge color config
 struct GaugeColors {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -456,6 +456,8 @@ static void handleToggleSetting() {
   else if (key == "fanmp")   dispSettings.fanMatchPrinter = on;
   else if (key == "invcol")  dispSettings.invertColors = on;
   else if (key == "cydcls")  dispSettings.cydPanelClassic = on;
+  else if (key == "l8s")     dispSettings.landscape8Slots = on;
+  else if (key == "p9s")     dispSettings.portrait9Slots = on;
   else if (key == "nighten") dpSettings.nightModeEnabled = on;
   else if (key == "use24h")  netSettings.use24h = on;
 #ifdef BOARD_LOW_RAM
@@ -1062,14 +1064,23 @@ static void handleSettingsImportFinish() {
       if (p["cloudUserId"].is<const char*>()) strlcpy(cfg.cloudUserId, p["cloudUserId"], sizeof(cfg.cloudUserId));
       if (p["region"].is<uint8_t>())          cfg.region = (CloudRegion)p["region"].as<uint8_t>();
       JsonArray slots = p["gaugeSlots"];
-      if (slots && slots.size() == GAUGE_SLOT_COUNT) {
+      // Accept the current 9-slot format and any earlier 6/8-slot export;
+      // fill missing trailing entries with EMPTY so importing an older config
+      // doesn't randomise the extended-mode slots.
+      if (slots && slots.size() >= 6) {
         static const uint8_t defSlots[GAUGE_SLOT_COUNT] = {
           GAUGE_PROGRESS, GAUGE_NOZZLE, GAUGE_BED,
-          GAUGE_PART_FAN, GAUGE_AUX_FAN, GAUGE_CHAMBER_FAN
+          GAUGE_PART_FAN, GAUGE_AUX_FAN, GAUGE_CHAMBER_FAN,
+          GAUGE_EMPTY,    GAUGE_EMPTY,    GAUGE_EMPTY
         };
+        const size_t n = slots.size();
         for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) {
-          uint8_t v = slots[g].as<uint8_t>();
-          cfg.gaugeSlots[g] = (v < GAUGE_TYPE_COUNT) ? v : defSlots[g];
+          if (g < n) {
+            uint8_t v = slots[g].as<uint8_t>();
+            cfg.gaugeSlots[g] = (v < GAUGE_TYPE_COUNT) ? v : defSlots[g];
+          } else {
+            cfg.gaugeSlots[g] = GAUGE_EMPTY;
+          }
         }
       }
       if (p["amsView"].is<bool>()) {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -238,14 +238,17 @@ static void handleSaveGaugeLayout() {
 #endif
 
   PrinterConfig& cfg = printers[slot].config;
-  for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) {
+  auto readSlotArg = [&](const char* prefix, uint8_t idx, uint8_t& out) {
     char argName[8];
-    snprintf(argName, sizeof(argName), "gs%d", g);
+    snprintf(argName, sizeof(argName), "%s%d", prefix, idx);
     if (server.hasArg(argName)) {
       uint8_t val = server.arg(argName).toInt();
-      cfg.gaugeSlots[g] = (val < GAUGE_TYPE_COUNT) ? val : GAUGE_EMPTY;
+      out = (val < GAUGE_TYPE_COUNT) ? val : GAUGE_EMPTY;
     }
-  }
+  };
+  for (uint8_t g = 0; g < GAUGE_SLOT_COUNT;       g++) readSlotArg("gs", g, cfg.gaugeSlots[g]);
+  for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT;  g++) readSlotArg("lx", g, cfg.landscapeExtras[g]);
+  for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;   g++) readSlotArg("px", g, cfg.portraitExtras[g]);
   cfg.amsView = server.hasArg("amsv");
 
   savePrinterConfig(slot);
@@ -526,6 +529,10 @@ static void handlePrinterConfig() {
   doc["hasExhaustFan"]  = (st.airductFuncs & (1u << 2)) != 0;  // X2D + H2C
   JsonArray slots = doc["gaugeSlots"].to<JsonArray>();
   for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) slots.add(cfg.gaugeSlots[g]);
+  JsonArray lext = doc["landscapeExtras"].to<JsonArray>();
+  for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT; g++) lext.add(cfg.landscapeExtras[g]);
+  JsonArray pext = doc["portraitExtras"].to<JsonArray>();
+  for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
   doc["amsView"] = cfg.amsView;
 
   String json;
@@ -854,6 +861,10 @@ static void handleSettingsExport() {
     p["region"] = (uint8_t)cfg.region;
     JsonArray slots = p["gaugeSlots"].to<JsonArray>();
     for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) slots.add(cfg.gaugeSlots[g]);
+    JsonArray lext = p["landscapeExtras"].to<JsonArray>();
+    for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT; g++) lext.add(cfg.landscapeExtras[g]);
+    JsonArray pext = p["portraitExtras"].to<JsonArray>();
+    for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
     p["amsView"] = cfg.amsView;
   }
 
@@ -1064,25 +1075,32 @@ static void handleSettingsImportFinish() {
       if (p["cloudUserId"].is<const char*>()) strlcpy(cfg.cloudUserId, p["cloudUserId"], sizeof(cfg.cloudUserId));
       if (p["region"].is<uint8_t>())          cfg.region = (CloudRegion)p["region"].as<uint8_t>();
       JsonArray slots = p["gaugeSlots"];
-      // Accept the current 9-slot format and any earlier 6/8-slot export;
-      // fill missing trailing entries with EMPTY so importing an older config
-      // doesn't randomise the extended-mode slots.
+      // Standard 2x3 grid. Accept any export with size >= 6 (legacy 8/9-byte
+      // arrays from the in-development shared-extras branch get truncated -
+      // their extras moved to dedicated landscapeExtras / portraitExtras
+      // fields in the same export, so nothing is lost).
       if (slots && slots.size() >= 6) {
         static const uint8_t defSlots[GAUGE_SLOT_COUNT] = {
           GAUGE_PROGRESS, GAUGE_NOZZLE, GAUGE_BED,
-          GAUGE_PART_FAN, GAUGE_AUX_FAN, GAUGE_CHAMBER_FAN,
-          GAUGE_EMPTY,    GAUGE_EMPTY,    GAUGE_EMPTY
+          GAUGE_PART_FAN, GAUGE_AUX_FAN, GAUGE_CHAMBER_FAN
         };
-        const size_t n = slots.size();
         for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) {
-          if (g < n) {
-            uint8_t v = slots[g].as<uint8_t>();
-            cfg.gaugeSlots[g] = (v < GAUGE_TYPE_COUNT) ? v : defSlots[g];
-          } else {
-            cfg.gaugeSlots[g] = GAUGE_EMPTY;
-          }
+          uint8_t v = slots[g].as<uint8_t>();
+          cfg.gaugeSlots[g] = (v < GAUGE_TYPE_COUNT) ? v : defSlots[g];
         }
       }
+      auto importExtras = [](JsonArray arr, uint8_t* out, uint8_t count) {
+        for (uint8_t g = 0; g < count; g++) {
+          if (arr && g < arr.size()) {
+            uint8_t v = arr[g].as<uint8_t>();
+            out[g] = (v < GAUGE_TYPE_COUNT) ? v : GAUGE_EMPTY;
+          } else {
+            out[g] = GAUGE_EMPTY;
+          }
+        }
+      };
+      importExtras(p["landscapeExtras"].as<JsonArray>(), cfg.landscapeExtras, LANDSCAPE_EXTRA_COUNT);
+      importExtras(p["portraitExtras"].as<JsonArray>(),  cfg.portraitExtras,  PORTRAIT_EXTRA_COUNT);
       if (p["amsView"].is<bool>()) {
         cfg.amsView = p["amsView"].as<bool>();
       } else if (legacyAmsViewPresent) {

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -235,11 +235,6 @@ static bool resolvePlaceholder(const char* name, String& out) {
 #endif
     return true;
   }
-  if (strcmp(name, "L8S_ROW") == 0) {
-    // Kept as a no-op token in case any old template still references it.
-    out = "";
-    return true;
-  }
   if (strcmp(name, "EXTRAS_SECTIONS") == 0) {
     // Two independent extras blocks - landscape col 4 + portrait row 3.
     // Each is gauge-type-configured per-printer through landscapeExtras /
@@ -266,11 +261,6 @@ static bool resolvePlaceholder(const char* name, String& out) {
 #else
     out = "";
 #endif
-    return true;
-  }
-  if (strcmp(name, "P9S_ROW") == 0) {
-    // Kept as a no-op token after the toggle moved into EXTENDED_MODES_CARD.
-    out = "";
     return true;
   }
   if (strcmp(name, "AMSV_ROW") == 0) {

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -210,6 +210,37 @@ static bool resolvePlaceholder(const char* name, String& out) {
 #endif
     return true;
   }
+  if (strcmp(name, "L8S_ROW") == 0) {
+    // 8-slot landscape grid is meaningful only on layouts that actually flip
+    // to landscape (LAYOUT_HAS_LANDSCAPE). Hide the toggle elsewhere so it
+    // doesn't read as "broken on this board".
+#if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
+    out  = "<label class=\"check-row\">";
+    out += "<input type=\"checkbox\" id=\"l8s\" value=\"1\" ";
+    out += dispSettings.landscape8Slots ? "checked" : "";
+    out += " onchange=\"toggleSetting('l8s',this.checked)\">";
+    out += "<label for=\"l8s\">Landscape 8 gauge slots (replaces AMS sidebar with a 2x4 grid; configure slots 7/8 under Gauge Layout)</label>";
+    out += "</label>";
+#else
+    out = "";
+#endif
+    return true;
+  }
+  if (strcmp(name, "P9S_ROW") == 0) {
+    // 9-slot portrait grid: 240x320 + 320x480 only. Gauge R shrinks to fit
+    // a third row above ETA, and the permanent AMS strip is replaced.
+#if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
+    out  = "<label class=\"check-row\">";
+    out += "<input type=\"checkbox\" id=\"p9s\" value=\"1\" ";
+    out += dispSettings.portrait9Slots ? "checked" : "";
+    out += " onchange=\"toggleSetting('p9s',this.checked)\">";
+    out += "<label for=\"p9s\">Portrait 9 gauge slots (replaces AMS strip with a 3x3 grid; configure slots 7/8/9 under Gauge Layout)</label>";
+    out += "</label>";
+#else
+    out = "";
+#endif
+    return true;
+  }
   if (strcmp(name, "AMSV_ROW") == 0) {
 #if !defined(DISPLAY_240x320) && !defined(DISPLAY_320x480) && !defined(DISPLAY_480x480)
     out  = "<label class=\"check-row\">";

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -158,18 +158,16 @@ static bool resolvePlaceholder(const char* name, String& out) {
     return true;
   }
   if (strcmp(name, "DUALP_ADVANCED") == 0) {
+    // Renders bare inside the Advanced > Danger Zone card; no outer card
+    // wrapper. The danger-zone gate checkbox controls the surrounding
+    // <div id="dangerOps"> visibility.
 #ifdef BOARD_LOW_RAM
-    out  = "<div class=\"card\" style=\"border-color:rgba(216, 154, 44, 0.30)\">";
-    out += "<div class=\"card-head\"><div><h3>Advanced (experimental)</h3>";
-    out += "<p>Low-RAM boards are tight on memory. Two simultaneous TLS+MQTT sessions may exhaust the heap and crash the device.</p>";
-    out += "</div></div>";
-    out += "<label class=\"check-row\">";
+    out  = "<label class=\"check-row\">";
     out += "<input type=\"checkbox\" id=\"dualp\" value=\"1\" ";
     if (dualPrinterUnsafe) out += "checked";
     out += " onchange=\"toggleDualPrinterMode(this.checked)\">";
-    out += "<label for=\"dualp\">Enable 2-printer mode (not supported on this board, may crash)</label>";
+    out += "<label for=\"dualp\">Enable 2-printer mode (experimental on low-RAM boards: two simultaneous TLS+MQTT sessions may exhaust the heap and crash the device)</label>";
     out += "</label>";
-    out += "</div>";
 #else
     out = "";
 #endif
@@ -210,20 +208,36 @@ static bool resolvePlaceholder(const char* name, String& out) {
 #endif
     return true;
   }
-  if (strcmp(name, "L8S_ROW") == 0) {
-    // 8-slot landscape grid is meaningful only on layouts that actually flip
-    // to landscape (LAYOUT_HAS_LANDSCAPE). Hide the toggle elsewhere so it
-    // doesn't read as "broken on this board".
+  if (strcmp(name, "EXTENDED_MODES_CARD") == 0) {
+    // Card lives in the Advanced section. Only renders on layouts that
+    // actually have extended grid modes, otherwise the whole card is empty.
 #if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
-    out  = "<label class=\"check-row\">";
+    out  = "<div class=\"card\">";
+    out += "<div class=\"card-head\"><div><h3>Extended grid modes</h3>";
+    out += "<p>Trade the on-screen AMS area for extra gauge slots. ";
+    out += "Configure the new slots under <strong>Gauge Layout</strong>.</p>";
+    out += "</div></div>";
+    out += "<label class=\"check-row\">";
     out += "<input type=\"checkbox\" id=\"l8s\" value=\"1\" ";
     out += dispSettings.landscape8Slots ? "checked" : "";
-    out += " onchange=\"toggleSetting('l8s',this.checked)\">";
-    out += "<label for=\"l8s\">Landscape 8 gauge slots (replaces AMS sidebar with a 2x4 grid; configure slots 7/8 under Gauge Layout)</label>";
+    out += " onchange=\"toggleGridMode('l8s', this.checked)\">";
+    out += "<label for=\"l8s\">Landscape 8 gauge slots (replaces AMS sidebar with a 2x4 grid)</label>";
     out += "</label>";
+    out += "<label class=\"check-row\">";
+    out += "<input type=\"checkbox\" id=\"p9s\" value=\"1\" ";
+    out += dispSettings.portrait9Slots ? "checked" : "";
+    out += " onchange=\"toggleGridMode('p9s', this.checked)\">";
+    out += "<label for=\"p9s\">Portrait 9 gauge slots (replaces AMS strip with a 3x3 grid)</label>";
+    out += "</label>";
+    out += "</div>";
 #else
     out = "";
 #endif
+    return true;
+  }
+  if (strcmp(name, "L8S_ROW") == 0) {
+    // Kept as a no-op token in case any old template still references it.
+    out = "";
     return true;
   }
   if (strcmp(name, "EXTRAS_SECTIONS") == 0) {
@@ -231,16 +245,19 @@ static bool resolvePlaceholder(const char* name, String& out) {
     // Each is gauge-type-configured per-printer through landscapeExtras /
     // portraitExtras. Boards without LAYOUT_HAS_LANDSCAPE / LY_PORT9_GAUGE_R
     // don't render anything here so the user isn't offered settings the
-    // device can't use.
+    // device can't use. Inline display:none reflects the toggle's state at
+    // render time; toggleGridMode() in the Advanced section keeps it in sync.
 #if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
-    out  = "<div id=\"landExtrasGroup\">";
-    out += "<div class=\"row-divider\">&#9656; Landscape extras (column 4, rendered when <em>Landscape 8 slots</em> is on)</div>";
+    out  = "<div id=\"landExtrasGroup\"";
+    if (!dispSettings.landscape8Slots) out += " style=\"display:none\"";
+    out += "><div class=\"row-divider\">&#9656; Landscape extras (column 4, used by <em>Landscape 8 slots</em>)</div>";
     out += "<div class=\"gauge-grid\">";
     out += "<div class=\"cell\"><label>Col 4 top</label><select id=\"lx0\" class=\"gauge-slot-sel\"></select></div>";
     out += "<div class=\"cell\"><label>Col 4 bot</label><select id=\"lx1\" class=\"gauge-slot-sel\"></select></div>";
     out += "</div></div>";
-    out += "<div id=\"portExtrasGroup\">";
-    out += "<div class=\"row-divider\">&#9656; Portrait extras (row 3, rendered when <em>Portrait 9 slots</em> is on)</div>";
+    out += "<div id=\"portExtrasGroup\"";
+    if (!dispSettings.portrait9Slots) out += " style=\"display:none\"";
+    out += "><div class=\"row-divider\">&#9656; Portrait extras (row 3, used by <em>Portrait 9 slots</em>)</div>";
     out += "<div class=\"gauge-grid\">";
     out += "<div class=\"cell\"><label>Row 3 left</label><select id=\"px0\" class=\"gauge-slot-sel\"></select></div>";
     out += "<div class=\"cell\"><label>Row 3 mid</label><select id=\"px1\" class=\"gauge-slot-sel\"></select></div>";
@@ -252,18 +269,8 @@ static bool resolvePlaceholder(const char* name, String& out) {
     return true;
   }
   if (strcmp(name, "P9S_ROW") == 0) {
-    // 9-slot portrait grid: 240x320 + 320x480 only. Gauge R shrinks to fit
-    // a third row above ETA, and the permanent AMS strip is replaced.
-#if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
-    out  = "<label class=\"check-row\">";
-    out += "<input type=\"checkbox\" id=\"p9s\" value=\"1\" ";
-    out += dispSettings.portrait9Slots ? "checked" : "";
-    out += " onchange=\"toggleSetting('p9s',this.checked)\">";
-    out += "<label for=\"p9s\">Portrait 9 gauge slots (replaces AMS strip with a 3x3 grid; configure slots 7/8/9 under Gauge Layout)</label>";
-    out += "</label>";
-#else
+    // Kept as a no-op token after the toggle moved into EXTENDED_MODES_CARD.
     out = "";
-#endif
     return true;
   }
   if (strcmp(name, "AMSV_ROW") == 0) {

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -226,6 +226,31 @@ static bool resolvePlaceholder(const char* name, String& out) {
 #endif
     return true;
   }
+  if (strcmp(name, "EXTRAS_SECTIONS") == 0) {
+    // Two independent extras blocks - landscape col 4 + portrait row 3.
+    // Each is gauge-type-configured per-printer through landscapeExtras /
+    // portraitExtras. Boards without LAYOUT_HAS_LANDSCAPE / LY_PORT9_GAUGE_R
+    // don't render anything here so the user isn't offered settings the
+    // device can't use.
+#if defined(DISPLAY_240x320) || defined(DISPLAY_320x480)
+    out  = "<div id=\"landExtrasGroup\">";
+    out += "<div class=\"row-divider\">&#9656; Landscape extras (column 4, rendered when <em>Landscape 8 slots</em> is on)</div>";
+    out += "<div class=\"gauge-grid\">";
+    out += "<div class=\"cell\"><label>Col 4 top</label><select id=\"lx0\" class=\"gauge-slot-sel\"></select></div>";
+    out += "<div class=\"cell\"><label>Col 4 bot</label><select id=\"lx1\" class=\"gauge-slot-sel\"></select></div>";
+    out += "</div></div>";
+    out += "<div id=\"portExtrasGroup\">";
+    out += "<div class=\"row-divider\">&#9656; Portrait extras (row 3, rendered when <em>Portrait 9 slots</em> is on)</div>";
+    out += "<div class=\"gauge-grid\">";
+    out += "<div class=\"cell\"><label>Row 3 left</label><select id=\"px0\" class=\"gauge-slot-sel\"></select></div>";
+    out += "<div class=\"cell\"><label>Row 3 mid</label><select id=\"px1\" class=\"gauge-slot-sel\"></select></div>";
+    out += "<div class=\"cell\"><label>Row 3 right</label><select id=\"px2\" class=\"gauge-slot-sel\"></select></div>";
+    out += "</div></div>";
+#else
+    out = "";
+#endif
+    return true;
+  }
   if (strcmp(name, "P9S_ROW") == 0) {
     // 9-slot portrait grid: 240x320 + 320x480 only. Gauge R shrinks to fit
     // a third row above ETA, and the permanent AMS strip is replaced.


### PR DESCRIPTION
## Summary

Reworks the printing-screen gauge grid so the AMS area can be traded for extra
configurable gauge slots, and adds a cleaner per-unit AMS visualization. Three
on-screen layouts are now selectable at runtime:

| Mode        | Grid | Slots | When                                   | Boards            |
|-------------|------|-------|----------------------------------------|-------------------|
| Standard    | 2x3  | 6     | always                                 | all               |
| Landscape 8 | 2x4  | 8     | `landscape8Slots` + landscape          | 240x320, 320x480  |
| Portrait 9  | 3x3  | 9     | `portrait9Slots` + portrait            | 240x320, 320x480  |

Landscape 8 drops the right-side AMS sidebar; Portrait 9 drops the bottom AMS
strip. Boards that cannot fit the extra rows (240x240, 480x480) silently keep
the 6-slot grid and the web UI hides the toggles, so nothing is offered that the
device cannot render.

## What's included

- **New gauge type `GAUGE_AMS_BARS_1..4`** - rounded vertical tray bars matching
  the existing AMS strip/sidebar look (no humidity), readable even in the small
  9-slot portrait slots. The bar count tracks the unit's actual `trayCount`, so
  an AMS HT (single slot) shows one centered bar instead of three empty ones,
  consistent with the standard AMS view.
- **Per-mode storage** - each physical slot maps 1:1 to a storage cell:
  `gaugeSlots[6]` (standard) + `landscapeExtras[2]` (col 4) + `portraitExtras[3]`
  (row 3). No shared slots, so "col 4 top" and "row 3 left" are configured
  independently per printer.
- **Web UI** - new **Advanced** section gathers the grid-mode toggles plus a
  gated Danger Zone (reboot / factory reset / low-RAM dual-printer). Gauge Layout
  dropdowns are now grouped by category (`<optgroup>`), and the extra rows only
  appear when their mode is enabled.
- **Persistence + import/export** - three NVS keys per printer
  (`p%d_slots` / `_lext` / `_pext`); settings export/import round-trips all three
  arrays and tolerates older single-array exports.
- **Pre-merge cleanups** - removed dead `L8S_ROW` / `P9S_ROW` template tokens and
  tightened the landscape-8 compile guard to require `LY_LAND8_COL1` (mirrors the
  9-slot `LY_PORT9_GAUGE_R` guard).

## Build status

Compiles clean. Verified on `ws_lcd_200` (tightest flash budget): 81.3% used.
Recommend a CI/local pass on all envs before merge (`esp32s3`, `cyd`,
`jc3248w535`, `esp32c3`, `ws_lcd_200`, `ws_lcd_154`, `esp32s3_zero`).

## Test points

1. **Standard grid regression** - default 6-slot layout looks/behaves exactly as
   before on every board; gauges update, labels redraw on type change.
2. **Landscape 8** - enable under Advanced on a 240x320/320x480 board in
   landscape; AMS sidebar is replaced by a full-width 2x4 grid, badge moves back
   into the header, ETA/bottom bar span full width. Configure col-4 extras under
   Gauge Layout.
3. **Portrait 9** - enable in portrait; AMS strip is replaced by a 3x3 grid with
   smaller-radius gauges; row-3 labels clear the ETA line. Configure row-3 extras.
4. **AMS Bars - multi-tray** - set a slot to "AMS N Bars" on an AMS2 Pro unit:
   4 bars, correct colors, active-tray highlight.
5. **AMS Bars - AMS HT** - set a slot to the HT unit's "AMS N Bars": exactly one
   centered bar, no empty bars. Confirm it matches the standard AMS strip.
6. **Mode toggle mid-print** - flip Landscape 8 / Portrait 9 while the printing
   screen is live: screen repaints cleanly with no leftover sidebar/strip/column
   pixels.
7. **Bar-count change** - watch a slot from boot (placeholder bars) until AMS data
   arrives: bar count settles to the real tray count with no ghost bars.
8. **Persistence** - set extras, reboot, confirm they survive; export settings,
   factory reset, import, confirm all three slot arrays restore.
9. **Unsupported boards** - 240x240 build (e.g. `esp32s3`) hides the grid toggles
   and shows only the standard 2x3 dropdowns; device renders 6 slots.
