### PR TITLE
Split dual-printer dashboard: portrait + landscape, with ETA

### DIFF
--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -194,6 +194,8 @@ struct RotationState {
   uint8_t displayIndex;           // which printer slot is currently shown
   unsigned long lastRotateMs;
   unsigned long displayHoldUntilMs;  // suppresses Smart snap/rotation so a manually-peeked or freshly-finished slot stays on screen for one interval
+  bool splitEnabled;              // checkbox: show two active printers together (composes with mode)
+  uint8_t splitIndexB;            // second printer slot shown in split view (displayIndex is the first)
 };
 
 extern RotationState rotState;

--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -195,6 +195,7 @@ struct RotationState {
   unsigned long lastRotateMs;
   unsigned long displayHoldUntilMs;  // suppresses Smart snap/rotation so a manually-peeked or freshly-finished slot stays on screen for one interval
   bool splitEnabled;              // checkbox: show two active printers together (composes with mode)
+  bool splitForce;                // testing checkbox: always split the first two configured slots, ignoring activity
   uint8_t splitIndexB;            // second printer slot shown in split view (displayIndex is the first)
 };
 

--- a/include/display_split.h
+++ b/include/display_split.h
@@ -1,0 +1,15 @@
+#ifndef DISPLAY_SPLIT_H
+#define DISPLAY_SPLIT_H
+
+// Split (dual-printer) screen: two printers shown at once in a top band and a
+// bottom band, no rotation. Engaged by the orchestration in main.cpp when
+// rotState.splitEnabled is set and two printers are active (printing or drying).
+// Renders printers[rotState.displayIndex] (top) and printers[rotState.splitIndexB]
+// (bottom), reusing each printer's existing gaugeSlots[] configuration.
+//
+// Compiled to a no-op on layout profiles that do not define LAYOUT_HAS_SPLIT
+// (e.g. 480x480 SenseCAP); displaySupportsSplit() returns false there so this is
+// never reached anyway.
+void drawSplit();
+
+#endif // DISPLAY_SPLIT_H

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -47,6 +47,24 @@
 #define LY_PORT9_ROW2    134
 #define LY_PORT9_ROW3    208
 
+// --- Split dual-printer screen (top/bottom bands, 3 gauges each) ---
+// Two 160px bands; roomier than 240x240 so R grows to 34.
+#define LAYOUT_HAS_SPLIT   1
+#define LY_SPLIT_SLOTS     3
+#define LY_SPLIT_DIV_Y     160
+#define LY_SPLIT_GAUGE_R   34
+#define LY_SPLIT_GAUGE_T   LY_GAUGE_T
+#define LY_SPLIT_BAR_H     5
+#define LY_SPLIT_BAR_MARGIN 8
+// Band A (top, y 0..159)
+#define LY_SPLIT_A_HDR_CY  14
+#define LY_SPLIT_A_BAR_Y   28
+#define LY_SPLIT_A_ROW1    82
+// Band B (bottom, y 160..319)
+#define LY_SPLIT_B_HDR_CY  174
+#define LY_SPLIT_B_BAR_Y   188
+#define LY_SPLIT_B_ROW1    242
+
 // --- AMS tray visualization zone (CYD portrait, between gauges and ETA) ---
 // Gauge row 2 labels extend to ~y=187, so AMS starts at 190 to avoid overlap.
 #define LY_AMS_Y          190   // top of AMS zone (below gauge row 2 labels)

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -59,12 +59,13 @@
 // Band A (top, y 0..159). Gauge row vertically centred in the area below the
 // progress bar (R is capped at 34 by the 78px column pitch, so centring is the
 // only lever to fill the 160px band - a larger R would collide horizontally).
-#define LY_SPLIT_A_HDR_CY  14
-#define LY_SPLIT_A_BAR_Y   28
+// progress bar on top, name row beneath it
+#define LY_SPLIT_A_BAR_Y   10
+#define LY_SPLIT_A_HDR_CY  26
 #define LY_SPLIT_A_ROW1    90
 // Band B (bottom, y 160..319) = Band A + 160
-#define LY_SPLIT_B_HDR_CY  174
-#define LY_SPLIT_B_BAR_Y   188
+#define LY_SPLIT_B_BAR_Y   170
+#define LY_SPLIT_B_HDR_CY  186
 #define LY_SPLIT_B_ROW1    250
 
 // --- AMS tray visualization zone (CYD portrait, between gauges and ETA) ---

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -59,14 +59,15 @@
 // Band A (top, y 0..159). Gauge row vertically centred in the area below the
 // progress bar (R is capped at 34 by the 78px column pitch, so centring is the
 // only lever to fill the 160px band - a larger R would collide horizontally).
-// progress bar on top, name row beneath it
+// progress bar on top, name row beneath it; gauges nudged up to clear the ETA
+// line that sits just above the foot.
 #define LY_SPLIT_A_BAR_Y   10
 #define LY_SPLIT_A_HDR_CY  26
-#define LY_SPLIT_A_ROW1    90
+#define LY_SPLIT_A_ROW1    74
 // Band B (bottom, y 160..319) = Band A + 160
 #define LY_SPLIT_B_BAR_Y   170
 #define LY_SPLIT_B_HDR_CY  186
-#define LY_SPLIT_B_ROW1    250
+#define LY_SPLIT_B_ROW1    234
 
 // --- Landscape split (panel rotated to 320x240) -----------------------------
 // Two full-height 160-wide bands side by side, each a 2x2 gauge grid
@@ -84,8 +85,9 @@
 #define LY_SPLIT_L_BAR_MARGIN 8
 #define LY_SPLIT_L_BAR_Y    10
 #define LY_SPLIT_L_HDR_CY   26
-#define LY_SPLIT_L_ROW1     74
-#define LY_SPLIT_L_ROW2     160
+// Rows sit just below the name; the freed lower space holds a larger ETA line.
+#define LY_SPLIT_L_ROW1     64
+#define LY_SPLIT_L_ROW2     142
 #define LY_SPLIT_L_COL1     42
 #define LY_SPLIT_L_COL2     118
 #endif

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -63,11 +63,11 @@
 // line that sits just above the foot.
 #define LY_SPLIT_A_BAR_Y   10
 #define LY_SPLIT_A_HDR_CY  26
-#define LY_SPLIT_A_ROW1    74
+#define LY_SPLIT_A_ROW1    82
 // Band B (bottom, y 160..319) = Band A + 160
 #define LY_SPLIT_B_BAR_Y   170
 #define LY_SPLIT_B_HDR_CY  186
-#define LY_SPLIT_B_ROW1    234
+#define LY_SPLIT_B_ROW1    242
 
 // --- Landscape split (panel rotated to 320x240) -----------------------------
 // Two full-height 160-wide bands side by side, each a 2x2 gauge grid

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -68,6 +68,28 @@
 #define LY_SPLIT_B_HDR_CY  186
 #define LY_SPLIT_B_ROW1    250
 
+// --- Landscape split (panel rotated to 320x240) -----------------------------
+// Two full-height 160-wide bands side by side, each a 2x2 gauge grid
+// (gaugeSlots[0..3]). R=28 fits the 76px column pitch in a 160px band. Gated
+// out of the single-printer low-RAM boards (cyd, tzt_2432), where split never
+// engages anyway, so they pay no extra flash. Column centres are band-relative
+// (the renderer adds the right band's x offset).
+#if !defined(BOARD_LOW_RAM)
+#define LAYOUT_HAS_SPLIT_LANDSCAPE 1
+#define LY_SPLIT_L_SLOTS    4
+#define LY_SPLIT_L_NCOLS    2
+#define LY_SPLIT_L_GAUGE_R  28
+#define LY_SPLIT_L_GAUGE_T  LY_GAUGE_T
+#define LY_SPLIT_L_BAR_H    5
+#define LY_SPLIT_L_BAR_MARGIN 8
+#define LY_SPLIT_L_BAR_Y    10
+#define LY_SPLIT_L_HDR_CY   26
+#define LY_SPLIT_L_ROW1     74
+#define LY_SPLIT_L_ROW2     160
+#define LY_SPLIT_L_COL1     42
+#define LY_SPLIT_L_COL2     118
+#endif
+
 // --- AMS tray visualization zone (CYD portrait, between gauges and ETA) ---
 // Gauge row 2 labels extend to ~y=187, so AMS starts at 190 to avoid overlap.
 #define LY_AMS_Y          190   // top of AMS zone (below gauge row 2 labels)

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -56,14 +56,16 @@
 #define LY_SPLIT_GAUGE_T   LY_GAUGE_T
 #define LY_SPLIT_BAR_H     5
 #define LY_SPLIT_BAR_MARGIN 8
-// Band A (top, y 0..159)
+// Band A (top, y 0..159). Gauge row vertically centred in the area below the
+// progress bar (R is capped at 34 by the 78px column pitch, so centring is the
+// only lever to fill the 160px band - a larger R would collide horizontally).
 #define LY_SPLIT_A_HDR_CY  14
 #define LY_SPLIT_A_BAR_Y   28
-#define LY_SPLIT_A_ROW1    82
-// Band B (bottom, y 160..319)
+#define LY_SPLIT_A_ROW1    90
+// Band B (bottom, y 160..319) = Band A + 160
 #define LY_SPLIT_B_HDR_CY  174
 #define LY_SPLIT_B_BAR_Y   188
-#define LY_SPLIT_B_ROW1    242
+#define LY_SPLIT_B_ROW1    250
 
 // --- AMS tray visualization zone (CYD portrait, between gauges and ETA) ---
 // Gauge row 2 labels extend to ~y=187, so AMS starts at 190 to avoid overlap.

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -68,14 +68,14 @@
 #define LY_SPLIT_GAUGE_T   LY_GAUGE_T
 #define LY_SPLIT_BAR_H     6
 #define LY_SPLIT_BAR_MARGIN 10
-// Band A (top, y 0..239) - two gauge rows
-#define LY_SPLIT_A_HDR_CY  16
-#define LY_SPLIT_A_BAR_Y   32
+// Band A (top, y 0..239) - two gauge rows; progress bar on top, name beneath
+#define LY_SPLIT_A_BAR_Y   12
+#define LY_SPLIT_A_HDR_CY  30
 #define LY_SPLIT_A_ROW1    78
 #define LY_SPLIT_A_ROW2    170
 // Band B (bottom, y 240..479)
-#define LY_SPLIT_B_HDR_CY  256
-#define LY_SPLIT_B_BAR_Y   272
+#define LY_SPLIT_B_BAR_Y   252
+#define LY_SPLIT_B_HDR_CY  270
 #define LY_SPLIT_B_ROW1    318
 #define LY_SPLIT_B_ROW2    410
 

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -56,6 +56,26 @@
 #define LY_PORT9_ROW2    196
 #define LY_PORT9_ROW3    306
 
+// --- Split dual-printer screen (top/bottom bands, 6 gauges each) ---
+// Two 240px bands; each holds a full 2x3 grid (gaugeSlots[0..5]) at R=44.
+#define LAYOUT_HAS_SPLIT   1
+#define LY_SPLIT_SLOTS     6
+#define LY_SPLIT_DIV_Y     240
+#define LY_SPLIT_GAUGE_R   44
+#define LY_SPLIT_GAUGE_T   LY_GAUGE_T
+#define LY_SPLIT_BAR_H     6
+#define LY_SPLIT_BAR_MARGIN 10
+// Band A (top, y 0..239) - two gauge rows
+#define LY_SPLIT_A_HDR_CY  18
+#define LY_SPLIT_A_BAR_Y   34
+#define LY_SPLIT_A_ROW1    90
+#define LY_SPLIT_A_ROW2    190
+// Band B (bottom, y 240..479)
+#define LY_SPLIT_B_HDR_CY  258
+#define LY_SPLIT_B_BAR_Y   274
+#define LY_SPLIT_B_ROW1    330
+#define LY_SPLIT_B_ROW2    430
+
 // --- AMS tray visualization zone (below gauge grid) ---
 // Row 2 gauges bottom edge is at y=276 (228+48). Labels extend ~12px below,
 // so AMS starts at y=295. Zone is 72 px tall with 42 px bars; ETA begins at

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -57,24 +57,27 @@
 #define LY_PORT9_ROW3    306
 
 // --- Split dual-printer screen (top/bottom bands, 6 gauges each) ---
-// Two 240px bands; each holds a full 2x3 grid (gaugeSlots[0..5]) at R=44.
+// Two 240px bands; each holds a full 2x3 grid (gaugeSlots[0..5]). R=38 (not 44):
+// two rows of R=44 + labels overflow the 240px band and crowd the divider at
+// y=239; R=38 leaves ~20px clearance between the bottom-row labels and the band
+// edge. Bands are vertically symmetric (Band B = Band A + 240).
 #define LAYOUT_HAS_SPLIT   1
 #define LY_SPLIT_SLOTS     6
 #define LY_SPLIT_DIV_Y     240
-#define LY_SPLIT_GAUGE_R   44
+#define LY_SPLIT_GAUGE_R   38
 #define LY_SPLIT_GAUGE_T   LY_GAUGE_T
 #define LY_SPLIT_BAR_H     6
 #define LY_SPLIT_BAR_MARGIN 10
 // Band A (top, y 0..239) - two gauge rows
-#define LY_SPLIT_A_HDR_CY  18
-#define LY_SPLIT_A_BAR_Y   34
-#define LY_SPLIT_A_ROW1    90
-#define LY_SPLIT_A_ROW2    190
+#define LY_SPLIT_A_HDR_CY  16
+#define LY_SPLIT_A_BAR_Y   32
+#define LY_SPLIT_A_ROW1    78
+#define LY_SPLIT_A_ROW2    170
 // Band B (bottom, y 240..479)
-#define LY_SPLIT_B_HDR_CY  258
-#define LY_SPLIT_B_BAR_Y   274
-#define LY_SPLIT_B_ROW1    330
-#define LY_SPLIT_B_ROW2    430
+#define LY_SPLIT_B_HDR_CY  256
+#define LY_SPLIT_B_BAR_Y   272
+#define LY_SPLIT_B_ROW1    318
+#define LY_SPLIT_B_ROW2    410
 
 // --- AMS tray visualization zone (below gauge grid) ---
 // Row 2 gauges bottom edge is at y=276 (228+48). Labels extend ~12px below,

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -79,6 +79,25 @@
 #define LY_SPLIT_B_ROW1    318
 #define LY_SPLIT_B_ROW2    410
 
+// --- Landscape split (panel rotated to 480x320) -----------------------------
+// Two full-height 240-wide bands side by side, each a 2x2 gauge grid
+// (gaugeSlots[0..3]). Column centres are band-relative (the renderer adds the
+// right band's x offset). R=44 fits the 120px column pitch with room for labels;
+// rows are spread to fill the 320px height between the header and foot line.
+#define LAYOUT_HAS_SPLIT_LANDSCAPE 1
+#define LY_SPLIT_L_SLOTS    4
+#define LY_SPLIT_L_NCOLS    2
+#define LY_SPLIT_L_GAUGE_R  44
+#define LY_SPLIT_L_GAUGE_T  LY_GAUGE_T
+#define LY_SPLIT_L_BAR_H    6
+#define LY_SPLIT_L_BAR_MARGIN 10
+#define LY_SPLIT_L_BAR_Y    12
+#define LY_SPLIT_L_HDR_CY   30
+#define LY_SPLIT_L_ROW1     112
+#define LY_SPLIT_L_ROW2     232
+#define LY_SPLIT_L_COL1     60
+#define LY_SPLIT_L_COL2     180
+
 // --- AMS tray visualization zone (below gauge grid) ---
 // Row 2 gauges bottom edge is at y=276 (228+48). Labels extend ~12px below,
 // so AMS starts at y=295. Zone is 72 px tall with 42 px bars; ETA begins at

--- a/include/layout_320x480.h
+++ b/include/layout_320x480.h
@@ -93,8 +93,9 @@
 #define LY_SPLIT_L_BAR_MARGIN 10
 #define LY_SPLIT_L_BAR_Y    12
 #define LY_SPLIT_L_HDR_CY   30
-#define LY_SPLIT_L_ROW1     112
-#define LY_SPLIT_L_ROW2     232
+// Rows sit just below the name; the freed lower space holds a larger ETA line.
+#define LY_SPLIT_L_ROW1     92
+#define LY_SPLIT_L_ROW2     192
 #define LY_SPLIT_L_COL1     60
 #define LY_SPLIT_L_COL2     180
 

--- a/include/layout_default.h
+++ b/include/layout_default.h
@@ -33,6 +33,25 @@
 #define LY_ROW1      60      // row 1 center Y
 #define LY_ROW2      148     // row 2 center Y
 
+// --- Split dual-printer screen (top/bottom bands, 3 gauges each) ---
+// Two 120px bands. Each band: header line (name + state dot), thin progress
+// bar, then a single row of 3 gauges reusing the gaugeSlots[0..2] config.
+#define LAYOUT_HAS_SPLIT   1
+#define LY_SPLIT_SLOTS     3      // gauges drawn per band (gaugeSlots[0..2])
+#define LY_SPLIT_DIV_Y     120    // divider line Y (band boundary)
+#define LY_SPLIT_GAUGE_R   30
+#define LY_SPLIT_GAUGE_T   LY_GAUGE_T
+#define LY_SPLIT_BAR_H     4
+#define LY_SPLIT_BAR_MARGIN 8
+// Band A (top, y 0..119)
+#define LY_SPLIT_A_HDR_CY  11
+#define LY_SPLIT_A_BAR_Y   22
+#define LY_SPLIT_A_ROW1    60
+// Band B (bottom, y 120..239)
+#define LY_SPLIT_B_HDR_CY  131
+#define LY_SPLIT_B_BAR_Y   142
+#define LY_SPLIT_B_ROW1    180
+
 // --- AMS tray visualization (replaces gauge row 2 when amsView enabled) ---
 // Row 1 gauges (R=32 at Y=60) end at y=92 with labels to ~95.
 // ETA starts at Y=190. Available band: ~98 px.

--- a/include/layout_default.h
+++ b/include/layout_default.h
@@ -43,13 +43,13 @@
 #define LY_SPLIT_GAUGE_T   LY_GAUGE_T
 #define LY_SPLIT_BAR_H     4
 #define LY_SPLIT_BAR_MARGIN 8
-// Band A (top, y 0..119)
-#define LY_SPLIT_A_HDR_CY  11
-#define LY_SPLIT_A_BAR_Y   22
+// Band A (top, y 0..119): progress bar on top, name row beneath it
+#define LY_SPLIT_A_BAR_Y   6
+#define LY_SPLIT_A_HDR_CY  20
 #define LY_SPLIT_A_ROW1    60
 // Band B (bottom, y 120..239)
-#define LY_SPLIT_B_HDR_CY  131
-#define LY_SPLIT_B_BAR_Y   142
+#define LY_SPLIT_B_BAR_Y   126
+#define LY_SPLIT_B_HDR_CY  140
 #define LY_SPLIT_B_ROW1    180
 
 // --- AMS tray visualization (replaces gauge row 2 when amsView enabled) ---

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -1042,6 +1042,11 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <label for="rotinterval">Rotation interval</label>
       <div class="hstack" style="gap:var(--sp-2)"><input type="number" id="rotinterval" min="10" max="600" value="%ROT_INTERVAL%" style="max-width:120px"><span class="text-dim small">seconds</span></div>
     </div>
+    <label class="check-row">
+      <input type="checkbox" id="rotsplit" value="1" %ROT_SPLIT_CHK%>
+      <label for="rotsplit">Split screen when two printers are printing</label>
+    </label>
+    <div class="hint">Shows both active printers at once (top/bottom), overriding rotation while two are printing or drying. Vertical screens only.</div>
   </div>
 
   <div class="card">
@@ -2064,6 +2069,7 @@ function saveRotation(){
   var p = new URLSearchParams();
   p.append('rotmode', document.getElementById('rotmode').value);
   p.append('rotinterval', document.getElementById('rotinterval').value);
+  p.append('rotsplit', document.getElementById('rotsplit').checked ? '1' : '0');
   p.append('btntype', document.getElementById('btntype').value);
   p.append('btnpin', document.getElementById('btnpin').value);
   p.append('buzzen', document.getElementById('buzzen').value);

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -1047,6 +1047,11 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <label for="rotsplit">Split screen when two printers are printing</label>
     </label>
     <div class="hint">Shows both active printers at once (top/bottom), overriding rotation while two are printing or drying. Vertical screens only.</div>
+    <label class="check-row">
+      <input type="checkbox" id="rotsplitf" value="1" %ROT_SPLITF_CHK%>
+      <label for="rotsplitf">Always show split screen (testing)</label>
+    </label>
+    <div class="hint">Forces the split view of the first two configured printers regardless of activity, so you can test the layout without two live prints.</div>
   </div>
 
   <div class="card">
@@ -2070,6 +2075,7 @@ function saveRotation(){
   p.append('rotmode', document.getElementById('rotmode').value);
   p.append('rotinterval', document.getElementById('rotinterval').value);
   p.append('rotsplit', document.getElementById('rotsplit').checked ? '1' : '0');
+  p.append('rotsplitf', document.getElementById('rotsplitf').checked ? '1' : '0');
   p.append('btntype', document.getElementById('btntype').value);
   p.append('btnpin', document.getElementById('btnpin').value);
   p.append('buzzen', document.getElementById('buzzen').value);

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -525,7 +525,10 @@ static void setGaugeClearedTextColor(lgfx::LovyanGFX& gfx,
 // ---------------------------------------------------------------------------
 //  Text cache — only clear+redraw gauge text when displayed string changes
 // ---------------------------------------------------------------------------
-#define GAUGE_CACHE_SLOTS 12
+// 12 covers every single-printer screen (max 9 gauges). The split screen draws
+// up to 12 tiles (2 printers x 6 on 320x480); 16 leaves headroom so distinct
+// (cx,cy) tiles never evict each other mid-frame.
+#define GAUGE_CACHE_SLOTS 16
 
 struct GaugeTextCache {
   int16_t cx, cy;

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -475,13 +475,25 @@ static void clearGaugeCenter(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy,
 // ---------------------------------------------------------------------------
 static void fitValueFont(lgfx::LovyanGFX& gfx, const char* s,
                          int16_t radius, int16_t thickness, FontID base) {
-  const int16_t innerW = 2 * (radius - thickness - 1) - 2;
+  const int16_t textR = radius - thickness - 1;
   const FontID candidates[] = { base, FONT_LARGE, FONT_BODY, FONT_SMALL };
   for (FontID f : candidates) {
     // Big fonts never fit the tiny R<30 gauges no matter how narrow the string,
     // so skip them there (preserves the prior portrait-9-slot behaviour).
     if (radius < 30 && (f == FONT_LARGE || f == FONT_XLARGE)) continue;
     setFont(gfx, f);
+#if defined(BOARD_IS_JC3248W535)
+    // The opaque text background is a rectangle; its top/bottom corners must
+    // stay inside the cleared inner circle or they paint over the arc ring.
+    // Budget the chord width at the box edge (+ a couple px for the upward
+    // value nudge / AA fringe), not the full diameter.
+    const int16_t halfH = gfx.fontHeight() / 2 + 3;
+    const int16_t usableHalfW = (textR > halfH)
+        ? (int16_t)sqrtf((float)textR * textR - (float)halfH * halfH) : 0;
+    const int16_t innerW = 2 * usableHalfW - 2;
+#else
+    const int16_t innerW = 2 * textR - 2;
+#endif
     if (gfx.textWidth(s) <= innerW) return;
   }
   setFont(gfx, FONT_SMALL);

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -475,28 +475,39 @@ static void clearGaugeCenter(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy,
 // ---------------------------------------------------------------------------
 static void fitValueFont(lgfx::LovyanGFX& gfx, const char* s,
                          int16_t radius, int16_t thickness, FontID base) {
+#if defined(BOARD_IS_JC3248W535)
+  // JC3248W535 draws the value with an opaque background box. The box is a
+  // rectangle; its top/bottom corners must stay inside the cleared inner circle
+  // or they paint over the arc ring. Step the font down (up to the layout base)
+  // until the whole box fits - budgeting the chord width at the box edge
+  // (+ a couple px for the upward value nudge / AA fringe), not the full
+  // diameter. This is what fixes the small split gauges; large gauges where the
+  // base already fits return it on the first iteration, so they are unchanged.
   const int16_t textR = radius - thickness - 1;
   const FontID candidates[] = { base, FONT_LARGE, FONT_BODY, FONT_SMALL };
   for (FontID f : candidates) {
-    // Big fonts never fit the tiny R<30 gauges no matter how narrow the string,
-    // so skip them there (preserves the prior portrait-9-slot behaviour).
     if (radius < 30 && (f == FONT_LARGE || f == FONT_XLARGE)) continue;
     setFont(gfx, f);
-#if defined(BOARD_IS_JC3248W535)
-    // The opaque text background is a rectangle; its top/bottom corners must
-    // stay inside the cleared inner circle or they paint over the arc ring.
-    // Budget the chord width at the box edge (+ a couple px for the upward
-    // value nudge / AA fringe), not the full diameter.
     const int16_t halfH = gfx.fontHeight() / 2 + 3;
     const int16_t usableHalfW = (textR > halfH)
         ? (int16_t)sqrtf((float)textR * textR - (float)halfH * halfH) : 0;
     const int16_t innerW = 2 * usableHalfW - 2;
-#else
-    const int16_t innerW = 2 * textR - 2;
-#endif
     if (gfx.textWidth(s) <= innerW) return;
   }
   setFont(gfx, FONT_SMALL);
+#else
+  // Other panels draw the value transparently (no box), so only the tiny R<30
+  // portrait 9-slot grid needs shrinking; large gauges keep the full base font.
+  // Kept byte-identical to the single-printer behaviour to avoid changing any
+  // normal-view value sizing.
+  if (radius >= 30) { setFont(gfx, base); return; }
+  FontID f = (base == FONT_SMALL) ? FONT_SMALL : FONT_BODY;
+  setFont(gfx, f);
+  if (f != FONT_SMALL) {
+    const int16_t innerW = 2 * (radius - thickness - 1) - 2;
+    if (gfx.textWidth(s) > innerW) setFont(gfx, FONT_SMALL);
+  }
+#endif
 }
 
 // Choose the largest humidity-number font that leaves room for a small "%"

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -461,30 +461,30 @@ static void clearGaugeCenter(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy,
 }
 
 // ---------------------------------------------------------------------------
-//  Helper: choose a center-value font that fits a small gauge.
+//  Helper: choose a center-value font that fits a gauge.
 //
-//  Large gauges (R>=30: standard 2x3, landscape 8-slot, idle/finished, 320x480)
-//  keep the full-size `base` font - behaviour is byte-identical to before. Only
-//  the small R=28 portrait 9-slot gauges shrink: at that size a 3-4 digit
-//  reading (e.g. "220", "100%") in LY_GAUGE_VALUE_FONT overruns the clearable
-//  inner circle (clearGaugeCenter clears radius-thickness-1), so its glyph
-//  background can spill onto the arc ring. Step the font down until the string
-//  fits the inner width. Leaves the chosen font active on gfx.
+//  Picks the largest font, up to the layout's `base`, whose rendered width fits
+//  inside the clearable inner circle (clearGaugeCenter clears radius-thickness-1).
+//  On JC3248W535 the value text is drawn with an opaque background, so a glyph
+//  box wider than the inner circle paints over the arc ring. This bites where a
+//  wide reading (e.g. a 3-digit "220" / "140") meets a smaller-than-usual gauge:
+//  the R=28 portrait 9-slot grid, and the R=38 dual-printer split gauges (whose
+//  base is FONT_XLARGE on 320x480). Stepping down happens only when the base
+//  font actually overflows, so layouts where it already fits are unchanged.
+//  Leaves the chosen font active on gfx.
 // ---------------------------------------------------------------------------
 static void fitValueFont(lgfx::LovyanGFX& gfx, const char* s,
                          int16_t radius, int16_t thickness, FontID base) {
-  if (radius >= 30) { setFont(gfx, base); return; }  // large gauge: unchanged
-  // Small gauges (the R=28 portrait 9-slot grid): LY_GAUGE_VALUE_FONT (Inter
-  // 19pt, ~26px tall) overruns the ~42px inner circle no matter how narrow the
-  // string is, so its glyph background can bleed onto the arc ring. Cap at
-  // FONT_BODY, which fits vertically, and drop to FONT_SMALL only when BODY is
-  // still too wide (e.g. the wide "%" in "100%").
-  FontID f = (base == FONT_SMALL) ? FONT_SMALL : FONT_BODY;
-  setFont(gfx, f);
-  if (f != FONT_SMALL) {
-    const int16_t innerW = 2 * (radius - thickness - 1) - 2;
-    if (gfx.textWidth(s) > innerW) setFont(gfx, FONT_SMALL);
+  const int16_t innerW = 2 * (radius - thickness - 1) - 2;
+  const FontID candidates[] = { base, FONT_LARGE, FONT_BODY, FONT_SMALL };
+  for (FontID f : candidates) {
+    // Big fonts never fit the tiny R<30 gauges no matter how narrow the string,
+    // so skip them there (preserves the prior portrait-9-slot behaviour).
+    if (radius < 30 && (f == FONT_LARGE || f == FONT_XLARGE)) continue;
+    setFont(gfx, f);
+    if (gfx.textWidth(s) <= innerW) return;
   }
+  setFont(gfx, FONT_SMALL);
 }
 
 // Choose the largest humidity-number font that leaves room for a small "%"

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -6,6 +6,7 @@
 
 #include "display_ui.h"      // tft, markFrameDirty, isDisplayForceRedraw, drawAmsBarsGauge
 #include "display_gauges.h"  // arc/temp/fan/... primitives
+#include "icons.h"           // drawIcon16, icon_lock / icon_unlock (door status)
 #include "settings.h"        // dispSettings, GaugeType enum
 #include "bambu_state.h"     // printers[], rotState, BambuState
 #include "fonts.h"           // setFont, FontID
@@ -27,6 +28,7 @@ struct BandGeom {
   int16_t barY;          // progress bar top Y
   int16_t cols[3];       // gauge column center X
   int16_t rows[2];       // gauge row center Y (rows[1] unused when slots <= 3)
+  int16_t footCY;        // bottom info-line center Y
   int16_t r, t;          // gauge radius, arc thickness
   uint8_t slots;         // 3 or 6
 };
@@ -37,6 +39,7 @@ uint8_t    sPrevTypes[2][6] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
 uint32_t   sPrevAirduct[2]  = { 0xFFFFFFFFu, 0xFFFFFFFFu };
 uint8_t    sPrevHdrState[2] = { 0xFF, 0xFF };
 uint8_t    sPrevBarProg[2]  = { 0xFF, 0xFF };
+char       sPrevFootCenter[2][20] = { { 0 }, { 0 } };
 BambuState sPrevState[2];
 
 // Draw the printer name left-aligned at (x, cy), trimming with a ".." suffix if
@@ -271,6 +274,69 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     drawTile(gt, s, slotIndex, cx, cy, g.r, g.t, force || typeChanged);
   }
 
+  // --- Bottom info line: filament swatch + layers/power + door (mirrors the
+  // single-printer bottom bar, compacted into the free space below the gauges) ---
+  {
+    char cbuf[20];
+    const float w = tasmotaGetWattsForSlot(slotIndex);
+    if (tasmotaIsActiveForSlot(slotIndex) && w > 0.5f) {
+      snprintf(cbuf, sizeof(cbuf), "%.0fW", w);
+    } else {
+      snprintf(cbuf, sizeof(cbuf), "%d/%d", s.layerNum, s.totalLayers);
+    }
+    bool footChanged = force
+      || s.doorOpen != prev.doorOpen
+      || s.doorSensorPresent != prev.doorSensorPresent
+      || s.ams.activeTray != prev.ams.activeTray
+      || strcmp(cbuf, sPrevFootCenter[bandIdx]) != 0;
+    if (footChanged) {
+      markFrameDirty();
+      strlcpy(sPrevFootCenter[bandIdx], cbuf, sizeof(sPrevFootCenter[bandIdx]));
+      const int16_t fy = g.footCY;
+      tft.fillRect(0, fy - 8, LY_W, 16, CLR_BG);
+      setFont(tft, FONT_SMALL);
+
+      // Centre string drawn first so the left filament label can clamp to it.
+      const int16_t centerLeft = LY_W / 2 - tft.textWidth(cbuf) / 2;
+      tft.setTextDatum(MC_DATUM);
+      tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
+      tft.drawString(cbuf, LY_W / 2, fy);
+
+      // Left: active filament swatch + type (or nothing if no AMS).
+      const int16_t lx = LY_SPLIT_BAR_MARGIN;
+      uint16_t swColor = 0;
+      const char* swType = nullptr;
+      if (s.ams.present && s.ams.activeTray < AMS_MAX_TRAYS &&
+          s.ams.trays[s.ams.activeTray].present) {
+        swColor = s.ams.trays[s.ams.activeTray].colorRgb565;
+        swType  = s.ams.trays[s.ams.activeTray].type;
+      } else if (s.ams.vtPresent && s.ams.activeTray == 254) {
+        swColor = s.ams.vtColorRgb565;
+        swType  = s.ams.vtType;
+      }
+      if (swType) {
+        tft.drawCircle(lx + 5, fy, 5, CLR_TEXT_DARK);
+        tft.fillCircle(lx + 5, fy, 4, swColor);
+        const int16_t typeMaxW = centerLeft - 3 - (lx + 14);
+        if (typeMaxW > 12) {
+          tft.setTextDatum(ML_DATUM);
+          tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
+          drawClippedName(swType, lx + 14, fy, typeMaxW);
+        }
+      }
+
+      // Right: door status (only when the printer has a door sensor).
+      if (s.doorSensorPresent) {
+        uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
+        tft.setTextDatum(MR_DATUM);
+        tft.setTextColor(clr, CLR_BG);
+        tft.drawString("Door", LY_W - LY_SPLIT_BAR_MARGIN - 18, fy);
+        drawIcon16(tft, LY_W - LY_SPLIT_BAR_MARGIN - 16, fy - 8,
+                   s.doorOpen ? icon_unlock : icon_lock, clr);
+      }
+    }
+  }
+
   sPrevAirduct[bandIdx] = s.airductFuncs;
   memcpy(&prev, &s, sizeof(BambuState));
 }
@@ -296,6 +362,8 @@ void drawSplit() {
   gb.top = LY_SPLIT_DIV_Y; gb.height = LY_H - LY_SPLIT_DIV_Y;
   ga.hdrCY = LY_SPLIT_A_HDR_CY; ga.barY = LY_SPLIT_A_BAR_Y; ga.rows[0] = LY_SPLIT_A_ROW1;
   gb.hdrCY = LY_SPLIT_B_HDR_CY; gb.barY = LY_SPLIT_B_BAR_Y; gb.rows[0] = LY_SPLIT_B_ROW1;
+  ga.footCY = ga.top + ga.height - 12;
+  gb.footCY = gb.top + gb.height - 12;
 #if LY_SPLIT_SLOTS >= 6
   ga.rows[1] = LY_SPLIT_A_ROW2;
   gb.rows[1] = LY_SPLIT_B_ROW2;

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -1,0 +1,303 @@
+#include "display_split.h"
+#include "config.h"
+#include "layout.h"
+
+#if defined(LAYOUT_HAS_SPLIT)
+
+#include "display_ui.h"      // tft, markFrameDirty, isDisplayForceRedraw, drawAmsBarsGauge
+#include "display_gauges.h"  // arc/temp/fan/... primitives
+#include "settings.h"        // dispSettings, GaugeType enum
+#include "bambu_state.h"     // printers[], rotState, BambuState
+#include "fonts.h"           // setFont, FontID
+#include "tasmota.h"         // tasmotaGetWattsForSlot / tasmotaIsActiveForSlot
+#include <string.h>
+
+// Match display_ui.cpp / display_anim.cpp: themed background, not the literal
+// black CLR_BG from config.h.
+#ifdef CLR_BG
+#undef CLR_BG
+#endif
+#define CLR_BG (dispSettings.bgColor)
+
+namespace {
+
+struct BandGeom {
+  int16_t top, height;   // band rect (caller clears on a force frame)
+  int16_t hdrCY;         // header text center Y
+  int16_t barY;          // progress bar top Y
+  int16_t cols[3];       // gauge column center X
+  int16_t rows[2];       // gauge row center Y (rows[1] unused when slots <= 3)
+  int16_t r, t;          // gauge radius, arc thickness
+  uint8_t slots;         // 3 or 6
+};
+
+// Per-band caches (index 0 = top band, 1 = bottom band).
+uint8_t    sPrevTypes[2][6] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+                                { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+uint32_t   sPrevAirduct[2]  = { 0xFFFFFFFFu, 0xFFFFFFFFu };
+uint8_t    sPrevHdrState[2] = { 0xFF, 0xFF };
+uint8_t    sPrevBarProg[2]  = { 0xFF, 0xFF };
+BambuState sPrevState[2];
+
+uint16_t stateColor(uint8_t gid) {
+  switch (gid) {
+    case GCODE_RUNNING: return CLR_GREEN;
+    case GCODE_PAUSE:   return CLR_YELLOW;
+    case GCODE_FAILED:  return CLR_RED;
+    case GCODE_PREPARE: return CLR_BLUE;
+    default:            return CLR_TEXT_DIM;
+  }
+}
+
+// Mirrors the per-type change detection in drawPrinting()'s slot loop so a tile
+// is only redrawn when its underlying value actually changed.
+bool tileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p) {
+  switch (gt) {
+    case GAUGE_PROGRESS:      return s.progress != p.progress || s.remainingMinutes != p.remainingMinutes;
+    case GAUGE_NOZZLE:        return s.nozzleTemp != p.nozzleTemp || s.nozzleTarget != p.nozzleTarget;
+    case GAUGE_NOZZLE_RIGHT:  return s.nozzleTempN[0] != p.nozzleTempN[0] || s.nozzleTargetN[0] != p.nozzleTargetN[0];
+    case GAUGE_NOZZLE_LEFT:   return s.nozzleTempN[1] != p.nozzleTempN[1] || s.nozzleTargetN[1] != p.nozzleTargetN[1];
+    case GAUGE_BED:           return s.bedTemp != p.bedTemp || s.bedTarget != p.bedTarget;
+    case GAUGE_PART_FAN:      return s.coolingFanPct != p.coolingFanPct;
+    case GAUGE_AUX_FAN:       return s.auxFanPct != p.auxFanPct;
+    case GAUGE_AUX_FAN_RIGHT: return s.auxFanRightPct != p.auxFanRightPct;
+    case GAUGE_CHAMBER_FAN:   return s.chamberFanPct != p.chamberFanPct;
+    case GAUGE_EXHAUST_FAN:   return s.exhaustFanPct != p.exhaustFanPct;
+    case GAUGE_CHAMBER_TEMP:  return s.chamberTemp != p.chamberTemp;
+    case GAUGE_HEATBREAK:     return s.heatbreakFanPct != p.heatbreakFanPct;
+    case GAUGE_CLOCK:         return true;   // text cache gates the actual redraw
+    case GAUGE_POWER:         return true;   // watts live outside BambuState
+    case GAUGE_LAYER:         return s.layerNum != p.layerNum || s.totalLayers != p.totalLayers;
+    default: break;
+  }
+  if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
+    uint8_t ui = gt - GAUGE_AMS_HUM_1;
+    const AmsUnit& cu = s.ams.units[ui]; const AmsUnit& pu = p.ams.units[ui];
+    return cu.humidityRaw != pu.humidityRaw || cu.humidity != pu.humidity || cu.present != pu.present;
+  }
+  if (gt >= GAUGE_AMS_TEMP_1 && gt <= GAUGE_AMS_TEMP_4) {
+    uint8_t ui = gt - GAUGE_AMS_TEMP_1;
+    const AmsUnit& cu = s.ams.units[ui]; const AmsUnit& pu = p.ams.units[ui];
+    return cu.temp != pu.temp || cu.present != pu.present;
+  }
+  if ((gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) ||
+      (gt >= GAUGE_AMS_BARS_1 && gt <= GAUGE_AMS_BARS_4)) {
+    const bool isBars = (gt >= GAUGE_AMS_BARS_1);
+    uint8_t ui = isBars ? (gt - GAUGE_AMS_BARS_1) : (gt - GAUGE_AMS_FILAMENT_1);
+    if (s.ams.present != p.ams.present || s.ams.unitCount != p.ams.unitCount) return true;
+    const AmsUnit& cu = s.ams.units[ui]; const AmsUnit& pu = p.ams.units[ui];
+    if (cu.present != pu.present || (!isBars && cu.humidity != pu.humidity) ||
+        cu.trayCount != pu.trayCount) return true;
+    if (isBars && s.ams.activeTray != p.ams.activeTray) return true;
+    for (int tr = 0; tr < AMS_TRAYS_PER_UNIT; tr++) {
+      int idx = ui * AMS_TRAYS_PER_UNIT + tr;
+      const AmsTray& ct = s.ams.trays[idx]; const AmsTray& pt = p.ams.trays[idx];
+      if (ct.present != pt.present || ct.colorRgb565 != pt.colorRgb565 ||
+          ct.remain != pt.remain || (!isBars && strcmp(ct.type, pt.type) != 0)) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+// Reuses the shared gauge primitives. No smoothing pointers (the global smooth
+// structs cannot serve two printers); arcs snap to value. Power uses slotIndex
+// so each band reports its own plug.
+void drawTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
+              int16_t cx, int16_t cy, int16_t r, int16_t t, bool fr) {
+  switch (gt) {
+    case GAUGE_PROGRESS:
+      drawProgressArc(tft, cx, cy, r, t, s.progress, s.progress, s.remainingMinutes, fr);
+      break;
+    case GAUGE_NOZZLE:
+      drawTempGauge(tft, cx, cy, r, s.nozzleTemp, s.nozzleTarget, (float)dispSettings.nozzleScaleMax,
+                    dispSettings.nozzle.arc,
+                    s.dualNozzle ? (s.activeNozzle == 0 ? "Nozzle R" : "Nozzle L") : "Nozzle",
+                    nullptr, fr, &dispSettings.nozzle);
+      break;
+    case GAUGE_NOZZLE_RIGHT:
+      drawTempGauge(tft, cx, cy, r, s.nozzleTempN[0], s.nozzleTargetN[0], (float)dispSettings.nozzleScaleMax,
+                    dispSettings.nozzle.arc, "Nozzle R", nullptr, fr, &dispSettings.nozzle);
+      break;
+    case GAUGE_NOZZLE_LEFT:
+      drawTempGauge(tft, cx, cy, r, s.nozzleTempN[1], s.nozzleTargetN[1], (float)dispSettings.nozzleScaleMax,
+                    dispSettings.nozzle.arc, "Nozzle L", nullptr, fr, &dispSettings.nozzle);
+      break;
+    case GAUGE_BED:
+      drawTempGauge(tft, cx, cy, r, s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
+                    dispSettings.bed.arc, "Bed", nullptr, fr, &dispSettings.bed);
+      break;
+    case GAUGE_PART_FAN:
+      drawFanGauge(tft, cx, cy, r, s.coolingFanPct, dispSettings.partFan.arc, "Part", fr, &dispSettings.partFan);
+      break;
+    case GAUGE_AUX_FAN:
+      drawFanGauge(tft, cx, cy, r, s.auxFanPct, dispSettings.auxFan.arc,
+                   (s.airductFuncs & (1u << 6)) ? "L.Aux" : "Aux", fr, &dispSettings.auxFan);
+      break;
+    case GAUGE_AUX_FAN_RIGHT:
+      drawFanGauge(tft, cx, cy, r, s.auxFanRightPct, dispSettings.auxFanRight.arc, "R.Aux", fr, &dispSettings.auxFanRight);
+      break;
+    case GAUGE_CHAMBER_FAN:
+      drawFanGauge(tft, cx, cy, r, s.chamberFanPct, dispSettings.chamberFan.arc,
+                   (s.airductFuncs & (1u << 2)) ? "Exhaust" : "Chamber", fr, &dispSettings.chamberFan);
+      break;
+    case GAUGE_EXHAUST_FAN:
+      drawFanGauge(tft, cx, cy, r, s.exhaustFanPct, dispSettings.exhaustFan.arc, "Exhaust", fr, &dispSettings.exhaustFan);
+      break;
+    case GAUGE_CHAMBER_TEMP:
+      drawTempGauge(tft, cx, cy, r, s.chamberTemp, 0.0f, (float)dispSettings.chamberScaleMax,
+                    dispSettings.chamberTemp.arc, "Chamber", nullptr, fr, &dispSettings.chamberTemp);
+      break;
+    case GAUGE_HEATBREAK:
+      drawFanGauge(tft, cx, cy, r, s.heatbreakFanPct, dispSettings.heatbreak.arc, "HBreak", fr, &dispSettings.heatbreak);
+      break;
+    case GAUGE_CLOCK:
+      drawClockWidget(tft, cx, cy, r, t, fr);
+      break;
+    case GAUGE_LAYER:
+      drawLayerGauge(tft, cx, cy, r, t, s.layerNum, s.totalLayers, fr);
+      break;
+    case GAUGE_POWER:
+      drawPowerGauge(tft, cx, cy, r, tasmotaGetWattsForSlot(slotIndex),
+                     tasmotaIsActiveForSlot(slotIndex), "Power", fr);
+      break;
+    case GAUGE_EMPTY:
+      if (fr) tft.fillCircle(cx, cy, r + 2, CLR_BG);
+      break;
+    default: {
+      static const char* amsLabel[AMS_MAX_UNITS] = { "AMS 1", "AMS 2", "AMS 3", "AMS 4" };
+      if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
+        uint8_t ui = gt - GAUGE_AMS_HUM_1;
+        const AmsUnit& u = s.ams.units[ui];
+        drawHumidityGauge(tft, cx, cy, r, u.humidityRaw, u.humidity, u.present, amsLabel[ui], fr);
+      } else if (gt >= GAUGE_AMS_TEMP_1 && gt <= GAUGE_AMS_TEMP_4) {
+        uint8_t ui = gt - GAUGE_AMS_TEMP_1;
+        const AmsUnit& u = s.ams.units[ui];
+        drawTempGauge(tft, cx, cy, r, u.present ? u.temp : 0, 0, (float)dispSettings.chamberScaleMax,
+                      dispSettings.chamberTemp.arc, amsLabel[ui], nullptr, fr, &dispSettings.chamberTemp);
+      } else if (gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) {
+        uint8_t ui = gt - GAUGE_AMS_FILAMENT_1;
+        drawAmsFilamentAllGauge(tft, cx, cy, r, t, s.ams, ui, fr);
+      } else if (gt >= GAUGE_AMS_BARS_1 && gt <= GAUGE_AMS_BARS_4) {
+        uint8_t ui = gt - GAUGE_AMS_BARS_1;
+        drawAmsBarsGauge(cx, cy, r, s.ams, ui, fr);
+      } else if (fr) {
+        tft.fillCircle(cx, cy, r + 2, CLR_BG);
+      }
+    } break;
+  }
+}
+
+void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
+              const BandGeom& g, uint8_t bandIdx, bool force) {
+  BambuState& prev = sPrevState[bandIdx];
+
+  // --- Header: printer name (left) + state dot (right) ---
+  if (force || s.gcodeStateId != sPrevHdrState[bandIdx]) {
+    markFrameDirty();
+    // On a force frame the whole screen was just cleared; otherwise wipe the
+    // text strip so the new name/dot does not overprint the old.
+    if (!force) tft.fillRect(0, g.hdrCY - 9, LY_W, 18, CLR_BG);
+    setFont(tft, FONT_BODY);
+    tft.setTextDatum(ML_DATUM);
+    tft.setTextColor(CLR_TEXT, CLR_BG);
+    const char* name = (cfg.name[0] != '\0') ? cfg.name : "Printer";
+    tft.drawString(name, LY_SPLIT_BAR_MARGIN, g.hdrCY);
+    tft.fillCircle(LY_W - LY_SPLIT_BAR_MARGIN - 5, g.hdrCY, 5, stateColor(s.gcodeStateId));
+    sPrevHdrState[bandIdx] = s.gcodeStateId;
+  }
+
+  // --- Thin progress bar under the header ---
+  if (force || s.progress != sPrevBarProg[bandIdx]) {
+    markFrameDirty();
+    const int16_t bx = LY_SPLIT_BAR_MARGIN;
+    const int16_t bw = LY_W - 2 * LY_SPLIT_BAR_MARGIN;
+    const int16_t fw = (int16_t)((int32_t)bw * (s.progress > 100 ? 100 : s.progress) / 100);
+    tft.fillRect(bx, g.barY, bw, LY_SPLIT_BAR_H, tft.color565(40, 40, 40));
+    if (fw > 0) tft.fillRect(bx, g.barY, fw, LY_SPLIT_BAR_H, dispSettings.progress.arc);
+    sPrevBarProg[bandIdx] = s.progress;
+  }
+
+  // --- Gauge row(s) ---
+  for (uint8_t si = 0; si < g.slots; si++) {
+    uint8_t gt = cfg.gaugeSlots[si];
+    if (gt >= GAUGE_TYPE_COUNT) gt = GAUGE_EMPTY;
+    const int16_t cx = g.cols[si % 3];
+    const int16_t cy = g.rows[si / 3];
+
+    const bool typeChanged = (gt != sPrevTypes[bandIdx][si]);
+    if (typeChanged) {
+      // Screen is already clear on a force frame; only clear the tile box +
+      // label band on an in-place type change (same approach as drawPrinting).
+      if (!force) {
+        const int16_t clearSz = g.r * 2 + 4;
+        tft.fillRect(cx - g.r - 2, cy - g.r - 2, clearSz, clearSz, CLR_BG);
+        const bool sm = dispSettings.smallLabels;
+        const int16_t labelY = cy + g.r + (sm ? 3 : -1);
+        const int16_t lh = sm ? 18 : 24;
+        tft.fillRect(cx - g.r - 2, labelY - lh / 2, g.r * 2 + 4, lh, CLR_BG);
+      }
+      sPrevTypes[bandIdx][si] = gt;
+    }
+
+    bool needDraw = force || typeChanged || tileValueChanged(gt, s, prev);
+    // Refresh Chamber/Exhaust + Aux/L.Aux labels when the airduct mask first
+    // lands (it starts 0 and gets bits OR'd in on the first pushall).
+    if (!needDraw && (gt == GAUGE_CHAMBER_FAN || gt == GAUGE_AUX_FAN) &&
+        sPrevAirduct[bandIdx] != s.airductFuncs) {
+      needDraw = true;
+    }
+    if (!needDraw) continue;
+
+    markFrameDirty();
+    drawTile(gt, s, slotIndex, cx, cy, g.r, g.t, force || typeChanged);
+  }
+
+  sPrevAirduct[bandIdx] = s.airductFuncs;
+  memcpy(&prev, &s, sizeof(BambuState));
+}
+
+}  // namespace
+
+void drawSplit() {
+  const bool force = isDisplayForceRedraw();
+
+  uint8_t a = rotState.displayIndex;
+  if (a >= MAX_PRINTERS) a = 0;
+  uint8_t b = rotState.splitIndexB;
+  if (b >= MAX_PRINTERS || b == a) b = (a == 0) ? 1 : 0;
+
+  BandGeom ga, gb;
+  ga.cols[0] = gb.cols[0] = LY_COL1;
+  ga.cols[1] = gb.cols[1] = LY_COL2;
+  ga.cols[2] = gb.cols[2] = LY_COL3;
+  ga.r = gb.r = LY_SPLIT_GAUGE_R;
+  ga.t = gb.t = LY_SPLIT_GAUGE_T;
+  ga.slots = gb.slots = LY_SPLIT_SLOTS;
+  ga.top = 0;             ga.height = LY_SPLIT_DIV_Y;
+  gb.top = LY_SPLIT_DIV_Y; gb.height = LY_H - LY_SPLIT_DIV_Y;
+  ga.hdrCY = LY_SPLIT_A_HDR_CY; ga.barY = LY_SPLIT_A_BAR_Y; ga.rows[0] = LY_SPLIT_A_ROW1;
+  gb.hdrCY = LY_SPLIT_B_HDR_CY; gb.barY = LY_SPLIT_B_BAR_Y; gb.rows[0] = LY_SPLIT_B_ROW1;
+#if LY_SPLIT_SLOTS >= 6
+  ga.rows[1] = LY_SPLIT_A_ROW2;
+  gb.rows[1] = LY_SPLIT_B_ROW2;
+#else
+  ga.rows[1] = LY_SPLIT_A_ROW1;
+  gb.rows[1] = LY_SPLIT_B_ROW1;
+#endif
+
+  // Divider line. The caller (updateDisplay screen-change / triggerDisplayTransition)
+  // has already cleared the screen on a force frame, so draw it only then.
+  if (force) {
+    tft.drawFastHLine(0, LY_SPLIT_DIV_Y - 1, LY_W, tft.color565(40, 40, 40));
+  }
+
+  drawBand(printers[a].state, printers[a].config, a, ga, 0, force);
+  drawBand(printers[b].state, printers[b].config, b, gb, 1, force);
+}
+
+#else  // !LAYOUT_HAS_SPLIT
+
+void drawSplit() {}
+
+#endif  // LAYOUT_HAS_SPLIT

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -68,6 +68,19 @@ uint16_t stateColor(uint8_t gid) {
   }
 }
 
+// Short status word shown next to the state dot in each band header.
+const char* stateLabel(uint8_t gid) {
+  switch (gid) {
+    case GCODE_RUNNING: return "Printing";
+    case GCODE_PAUSE:   return "Paused";
+    case GCODE_PREPARE: return "Preparing";
+    case GCODE_FINISH:  return "Done";
+    case GCODE_FAILED:  return "Failed";
+    case GCODE_IDLE:    return "Idle";
+    default:            return "";   // UNKNOWN / OTHER: dot only, no misleading text
+  }
+}
+
 // Mirrors the per-type change detection in drawPrinting()'s slot loop so a tile
 // is only redrawn when its underlying value actually changed.
 bool tileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p) {
@@ -217,14 +230,29 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     // On a force frame the whole screen was just cleared; otherwise wipe the
     // text strip so the new name/dot does not overprint the old.
     if (!force) tft.fillRect(0, g.hdrCY - 9, LY_W, 18, CLR_BG);
+
+    // Right: state dot + status word ("Printing" / "Idle" / "Preparing" ...).
+    const uint16_t stClr = stateColor(s.gcodeStateId);
+    const int16_t dotCX = LY_W - LY_SPLIT_BAR_MARGIN - 5;
+    tft.fillCircle(dotCX, g.hdrCY, 5, stClr);
+    const char* st = stateLabel(s.gcodeStateId);
+    int16_t stLeft = dotCX - 10;   // name still clears the dot when status is empty
+    if (st[0] != '\0') {
+      setFont(tft, FONT_SMALL);
+      tft.setTextDatum(MR_DATUM);
+      tft.setTextColor(stClr, CLR_BG);
+      const int16_t stRight = dotCX - 9;   // 4px gap left of the dot
+      tft.drawString(st, stRight, g.hdrCY);
+      stLeft = stRight - tft.textWidth(st);
+    }
+
+    // Left: printer name, clipped so it stops before the status word / dot.
     setFont(tft, FONT_BODY);
     tft.setTextDatum(ML_DATUM);
     tft.setTextColor(CLR_TEXT, CLR_BG);
     const char* name = (cfg.name[0] != '\0') ? cfg.name : "Printer";
-    // Name occupies from the left margin up to ~4px left of the state dot.
-    const int16_t nameMaxW = LY_W - 2 * LY_SPLIT_BAR_MARGIN - 14;
+    const int16_t nameMaxW = stLeft - 4 - LY_SPLIT_BAR_MARGIN;
     drawClippedName(name, LY_SPLIT_BAR_MARGIN, g.hdrCY, nameMaxW);
-    tft.fillCircle(LY_W - LY_SPLIT_BAR_MARGIN - 5, g.hdrCY, 5, stateColor(s.gcodeStateId));
     sPrevHdrState[bandIdx] = s.gcodeStateId;
   }
 
@@ -372,11 +400,8 @@ void drawSplit() {
   gb.rows[1] = LY_SPLIT_B_ROW1;
 #endif
 
-  // Divider line. The caller (updateDisplay screen-change / triggerDisplayTransition)
-  // has already cleared the screen on a force frame, so draw it only then.
-  if (force) {
-    tft.drawFastHLine(0, LY_SPLIT_DIV_Y - 1, LY_W, tft.color565(40, 40, 40));
-  }
+  // No divider line: each band's top-anchored progress bar gives enough visual
+  // separation between the two printers.
 
   drawBand(printers[a].state, printers[a].config, a, ga, 0, force);
   drawBand(printers[b].state, printers[b].config, b, gb, 1, force);

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -39,6 +39,22 @@ uint8_t    sPrevHdrState[2] = { 0xFF, 0xFF };
 uint8_t    sPrevBarProg[2]  = { 0xFF, 0xFF };
 BambuState sPrevState[2];
 
+// Draw the printer name left-aligned at (x, cy), trimming with a ".." suffix if
+// it would run into the state dot. Assumes the caller already set the font.
+void drawClippedName(const char* name, int16_t x, int16_t cy, int16_t maxW) {
+  if (tft.textWidth(name) <= maxW) { tft.drawString(name, x, cy); return; }
+  char buf[28];
+  strlcpy(buf, name, sizeof(buf));
+  int n = (int)strlen(buf);
+  while (n > 1) {
+    buf[--n] = '\0';
+    char tmp[30];
+    snprintf(tmp, sizeof(tmp), "%s..", buf);
+    if (tft.textWidth(tmp) <= maxW) { tft.drawString(tmp, x, cy); return; }
+  }
+  tft.drawString(buf, x, cy);
+}
+
 uint16_t stateColor(uint8_t gid) {
   switch (gid) {
     case GCODE_RUNNING: return CLR_GREEN;
@@ -202,7 +218,9 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     tft.setTextDatum(ML_DATUM);
     tft.setTextColor(CLR_TEXT, CLR_BG);
     const char* name = (cfg.name[0] != '\0') ? cfg.name : "Printer";
-    tft.drawString(name, LY_SPLIT_BAR_MARGIN, g.hdrCY);
+    // Name occupies from the left margin up to ~4px left of the state dot.
+    const int16_t nameMaxW = LY_W - 2 * LY_SPLIT_BAR_MARGIN - 14;
+    drawClippedName(name, LY_SPLIT_BAR_MARGIN, g.hdrCY, nameMaxW);
     tft.fillCircle(LY_W - LY_SPLIT_BAR_MARGIN - 5, g.hdrCY, 5, stateColor(s.gcodeStateId));
     sPrevHdrState[bandIdx] = s.gcodeStateId;
   }

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -12,6 +12,7 @@
 #include "fonts.h"           // setFont, FontID
 #include "tasmota.h"         // tasmotaGetWattsForSlot / tasmotaIsActiveForSlot
 #include <string.h>
+#include <time.h>
 
 // Match display_ui.cpp / display_anim.cpp: themed background, not the literal
 // black CLR_BG from config.h.
@@ -38,6 +39,8 @@ struct BandGeom {
   int16_t cols[3];       // gauge column center X (absolute)
   int16_t rows[2];       // gauge row center Y (rows[1] unused when slots <= ncols)
   int16_t footCY;        // bottom info-line center Y
+  int16_t etaCY;         // dedicated ETA line center Y; 0 = fold ETA into the foot
+  FontID  etaFont;       // font for the dedicated ETA line
   int16_t r, t;          // gauge radius, arc thickness
   int16_t barH;          // progress bar height
   int16_t margin;        // left/right inset for header, bar and foot
@@ -52,7 +55,46 @@ uint32_t   sPrevAirduct[2]  = { 0xFFFFFFFFu, 0xFFFFFFFFu };
 uint8_t    sPrevHdrState[2] = { 0xFF, 0xFF };
 uint8_t    sPrevBarProg[2]  = { 0xFF, 0xFF };
 char       sPrevFootCenter[2][20] = { { 0 }, { 0 } };
+char       sPrevEta[2][24] = { { 0 }, { 0 } };
 BambuState sPrevState[2];
+
+// Build the ETA / remaining string the same way the single-printer view does
+// (display_ui.cpp): wall-clock finish time when the user prefers it and NTP is
+// up, otherwise the remaining duration. Returns false when there is nothing to
+// show (not printing / no estimate) so the caller can render a dim placeholder.
+bool buildSplitEta(const BambuState& s, char* buf, size_t n) {
+  if (s.remainingMinutes == 0) return false;
+  time_t nowEpoch = time(nullptr);
+  struct tm now;
+  localtime_r(&nowEpoch, &now);
+  const bool ntpSynced = now.tm_year > (2020 - 1900);
+
+  if (!dispSettings.showTimeRemaining && ntpSynced) {
+    time_t etaEpoch = nowEpoch + (time_t)s.remainingMinutes * 60;
+    struct tm e;
+    localtime_r(&etaEpoch, &e);
+    int eh = e.tm_hour;
+    const char* ampm = "";
+    if (!netSettings.use24h) { ampm = eh < 12 ? "AM" : "PM"; eh %= 12; if (eh == 0) eh = 12; }
+    if (e.tm_yday != now.tm_yday || e.tm_year != now.tm_year) {
+      if (netSettings.use24h)
+        snprintf(buf, n, "ETA: %02d.%02d. %02d:%02d", e.tm_mday, e.tm_mon + 1, eh, e.tm_min);
+      else
+        snprintf(buf, n, "ETA: %02d/%02d %d:%02d%s", e.tm_mon + 1, e.tm_mday, eh, e.tm_min, ampm);
+    } else {
+      if (netSettings.use24h)
+        snprintf(buf, n, "ETA: %02d:%02d", eh, e.tm_min);
+      else
+        snprintf(buf, n, "ETA: %d:%02d %s", eh, e.tm_min, ampm);
+    }
+  } else {
+    // showTimeRemaining set, or NTP not synced yet: show the duration. No
+    // "Remaining:" prefix - the progress gauge already labels this context and
+    // the narrow landscape bands are tight.
+    snprintf(buf, n, "%dh %02dm", s.remainingMinutes / 60, s.remainingMinutes % 60);
+  }
+  return true;
+}
 
 // Draw the printer name left-aligned at (x, cy), trimming with a ".." suffix if
 // it would run into the state dot. Assumes the caller already set the font.
@@ -314,66 +356,107 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     drawTile(gt, s, slotIndex, cx, cy, g.r, g.t, force || typeChanged);
   }
 
-  // --- Bottom info line: filament swatch + layers/power + door (mirrors the
-  // single-printer bottom bar, compacted into the free space below the gauges) ---
+  // --- ETA line + bottom info line ---
   {
-    char cbuf[20];
-    const float w = tasmotaGetWattsForSlot(slotIndex);
-    if (tasmotaIsActiveForSlot(slotIndex) && w > 0.5f) {
-      snprintf(cbuf, sizeof(cbuf), "%.0fW", w);
-    } else {
-      snprintf(cbuf, sizeof(cbuf), "%d/%d", s.layerNum, s.totalLayers);
+    // Active-tray filament swatch (shown in both foot variants).
+    uint16_t swColor = 0;
+    const char* swType = nullptr;
+    if (s.ams.present && s.ams.activeTray < AMS_MAX_TRAYS &&
+        s.ams.trays[s.ams.activeTray].present) {
+      swColor = s.ams.trays[s.ams.activeTray].colorRgb565;
+      swType  = s.ams.trays[s.ams.activeTray].type;
+    } else if (s.ams.vtPresent && s.ams.activeTray == 254) {
+      swColor = s.ams.vtColorRgb565;
+      swType  = s.ams.vtType;
     }
-    bool footChanged = force
-      || s.doorOpen != prev.doorOpen
-      || s.doorSensorPresent != prev.doorSensorPresent
-      || s.ams.activeTray != prev.ams.activeTray
-      || strcmp(cbuf, sPrevFootCenter[bandIdx]) != 0;
-    if (footChanged) {
-      markFrameDirty();
-      strlcpy(sPrevFootCenter[bandIdx], cbuf, sizeof(sPrevFootCenter[bandIdx]));
-      const int16_t fy = g.footCY;
-      const int16_t fcx = g.x + g.w / 2;
-      tft.fillRect(g.x, fy - 8, g.w, 16, CLR_BG);
-      setFont(tft, FONT_SMALL);
 
-      // Centre string drawn first so the left filament label can clamp to it.
-      const int16_t centerLeft = fcx - tft.textWidth(cbuf) / 2;
-      tft.setTextDatum(MC_DATUM);
-      tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
-      tft.drawString(cbuf, fcx, fy);
+    char etaStr[24];
+    const bool hasEta = buildSplitEta(s, etaStr, sizeof(etaStr));
+    if (!hasEta) strlcpy(etaStr, "ETA: --", sizeof(etaStr));
+    const uint16_t etaClr = hasEta ? CLR_GREEN : CLR_TEXT_DIM;
 
-      // Left: active filament swatch + type (or nothing if no AMS).
-      const int16_t lx = g.x + g.margin;
-      uint16_t swColor = 0;
-      const char* swType = nullptr;
-      if (s.ams.present && s.ams.activeTray < AMS_MAX_TRAYS &&
-          s.ams.trays[s.ams.activeTray].present) {
-        swColor = s.ams.trays[s.ams.activeTray].colorRgb565;
-        swType  = s.ams.trays[s.ams.activeTray].type;
-      } else if (s.ams.vtPresent && s.ams.activeTray == 254) {
-        swColor = s.ams.vtColorRgb565;
-        swType  = s.ams.vtType;
+    if (g.etaCY > 0) {
+      // --- Roomy: dedicated ETA line, plus the full foot bar below it. ---
+      if (force || strcmp(etaStr, sPrevEta[bandIdx]) != 0) {
+        markFrameDirty();
+        strlcpy(sPrevEta[bandIdx], etaStr, sizeof(sPrevEta[bandIdx]));
+        setFont(tft, g.etaFont);
+        const int16_t eh = tft.fontHeight();
+        tft.fillRect(g.x, g.etaCY - eh / 2 - 1, g.w, eh + 2, CLR_BG);
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(etaClr, CLR_BG);
+        tft.drawString(etaStr, g.x + g.w / 2, g.etaCY);
       }
-      if (swType) {
-        tft.drawCircle(lx + 5, fy, 5, CLR_TEXT_DARK);
-        tft.fillCircle(lx + 5, fy, 4, swColor);
-        const int16_t typeMaxW = centerLeft - 3 - (lx + 14);
-        if (typeMaxW > 12) {
-          tft.setTextDatum(ML_DATUM);
-          tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
-          drawClippedName(swType, lx + 14, fy, typeMaxW);
+
+      // Foot bar: filament swatch + type (left), layers/power (centre), door (right).
+      char cbuf[20];
+      const float w = tasmotaGetWattsForSlot(slotIndex);
+      if (tasmotaIsActiveForSlot(slotIndex) && w > 0.5f) {
+        snprintf(cbuf, sizeof(cbuf), "%.0fW", w);
+      } else {
+        snprintf(cbuf, sizeof(cbuf), "%d/%d", s.layerNum, s.totalLayers);
+      }
+      bool footChanged = force
+        || s.doorOpen != prev.doorOpen
+        || s.doorSensorPresent != prev.doorSensorPresent
+        || s.ams.activeTray != prev.ams.activeTray
+        || strcmp(cbuf, sPrevFootCenter[bandIdx]) != 0;
+      if (footChanged) {
+        markFrameDirty();
+        strlcpy(sPrevFootCenter[bandIdx], cbuf, sizeof(sPrevFootCenter[bandIdx]));
+        const int16_t fy = g.footCY;
+        const int16_t fcx = g.x + g.w / 2;
+        tft.fillRect(g.x, fy - 8, g.w, 16, CLR_BG);
+        setFont(tft, FONT_SMALL);
+
+        // Centre string drawn first so the left filament label can clamp to it.
+        const int16_t centerLeft = fcx - tft.textWidth(cbuf) / 2;
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
+        tft.drawString(cbuf, fcx, fy);
+
+        const int16_t lx = g.x + g.margin;
+        if (swType) {
+          tft.drawCircle(lx + 5, fy, 5, CLR_TEXT_DARK);
+          tft.fillCircle(lx + 5, fy, 4, swColor);
+          const int16_t typeMaxW = centerLeft - 3 - (lx + 14);
+          if (typeMaxW > 12) {
+            tft.setTextDatum(ML_DATUM);
+            tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
+            drawClippedName(swType, lx + 14, fy, typeMaxW);
+          }
+        }
+
+        if (s.doorSensorPresent) {
+          uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
+          tft.setTextDatum(MR_DATUM);
+          tft.setTextColor(clr, CLR_BG);
+          tft.drawString("Door", g.x + g.w - g.margin - 18, fy);
+          drawIcon16(tft, g.x + g.w - g.margin - 16, fy - 8,
+                     s.doorOpen ? icon_unlock : icon_lock, clr);
         }
       }
-
-      // Right: door status (only when the printer has a door sensor).
-      if (s.doorSensorPresent) {
-        uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
-        tft.setTextDatum(MR_DATUM);
-        tft.setTextColor(clr, CLR_BG);
-        tft.drawString("Door", g.x + g.w - g.margin - 18, fy);
-        drawIcon16(tft, g.x + g.w - g.margin - 16, fy - 8,
-                   s.doorOpen ? icon_unlock : icon_lock, clr);
+    } else {
+      // --- Cramped: foot = colour swatch + ETA only (no type / layers / door),
+      // so a long multi-day ETA gets the full band width. ---
+      bool footChanged = force
+        || s.ams.activeTray != prev.ams.activeTray
+        || strcmp(etaStr, sPrevEta[bandIdx]) != 0;
+      if (footChanged) {
+        markFrameDirty();
+        strlcpy(sPrevEta[bandIdx], etaStr, sizeof(sPrevEta[bandIdx]));
+        const int16_t fy = g.footCY;
+        setFont(tft, g.etaFont);
+        const int16_t eh = tft.fontHeight();
+        tft.fillRect(g.x, fy - eh / 2 - 1, g.w, eh + 2, CLR_BG);
+        if (swType) {
+          const int16_t lx = g.x + g.margin;
+          tft.drawCircle(lx + 5, fy, 5, CLR_TEXT_DARK);
+          tft.fillCircle(lx + 5, fy, 4, swColor);
+        }
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(etaClr, CLR_BG);
+        tft.drawString(etaStr, g.x + g.w / 2, fy);
       }
     }
   }
@@ -424,6 +507,14 @@ void drawSplit() {
     gb.cols[0] = gb.x + LY_SPLIT_L_COL1;  gb.cols[1] = gb.x + LY_SPLIT_L_COL2;
     ga.cols[2] = gb.cols[2] = 0;          // unused (ncols == 2)
     ga.footCY = gb.footCY = H - 12;
+    // Gauges sit just below the name; the freed space below them holds a larger
+    // dedicated ETA line above the foot.
+    ga.etaCY = gb.etaCY = (H - 12) - 28;
+#if defined(DISPLAY_320x480)
+    ga.etaFont = gb.etaFont = FONT_LARGE;
+#else
+    ga.etaFont = gb.etaFont = FONT_BODY;
+#endif
 
     // Vertical divider between the two bands. The screen is already cleared on a
     // force frame, so draw it only then.
@@ -455,6 +546,15 @@ void drawSplit() {
   gb.hdrCY = LY_SPLIT_B_HDR_CY; gb.barY = LY_SPLIT_B_BAR_Y; gb.rows[0] = LY_SPLIT_B_ROW1;
   ga.footCY = ga.top + ga.height - 12;
   gb.footCY = gb.top + gb.height - 12;
+  // Portrait split: one bottom line per band (filament swatch + ETA only, no
+  // type/layers/door) so the ETA stays large and legible. 240x320 has room for
+  // a BODY-size ETA; the tiny 240x240 and the gauge-packed 320x480 stay SMALL.
+  ga.etaCY = gb.etaCY = 0;
+#if defined(DISPLAY_240x320)
+  ga.etaFont = gb.etaFont = FONT_BODY;
+#else
+  ga.etaFont = gb.etaFont = FONT_SMALL;
+#endif
 #if LY_SPLIT_SLOTS >= 6
   ga.rows[1] = LY_SPLIT_A_ROW2;
   gb.rows[1] = LY_SPLIT_B_ROW2;

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -22,15 +22,27 @@
 
 namespace {
 
+#if defined(LAYOUT_HAS_SPLIT_LANDSCAPE)
+// Mirrors display_ui.cpp isLandscape(): rotations 1/3 swap the panel to a wide
+// orientation, which switches the split to two side-by-side bands.
+bool splitIsLandscape() {
+  return dispSettings.rotation == 1 || dispSettings.rotation == 3;
+}
+#endif
+
 struct BandGeom {
+  int16_t x, w;          // band left edge + width (full width portrait, half landscape)
   int16_t top, height;   // band rect (caller clears on a force frame)
   int16_t hdrCY;         // header text center Y
   int16_t barY;          // progress bar top Y
-  int16_t cols[3];       // gauge column center X
-  int16_t rows[2];       // gauge row center Y (rows[1] unused when slots <= 3)
+  int16_t cols[3];       // gauge column center X (absolute)
+  int16_t rows[2];       // gauge row center Y (rows[1] unused when slots <= ncols)
   int16_t footCY;        // bottom info-line center Y
   int16_t r, t;          // gauge radius, arc thickness
-  uint8_t slots;         // 3 or 6
+  int16_t barH;          // progress bar height
+  int16_t margin;        // left/right inset for header, bar and foot
+  uint8_t slots;         // gauges per band (3 / 6 portrait, 4 landscape)
+  uint8_t ncols;         // columns in the gauge grid (3 portrait, 2 landscape)
 };
 
 // Per-band caches (index 0 = top band, 1 = bottom band).
@@ -229,11 +241,11 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     markFrameDirty();
     // On a force frame the whole screen was just cleared; otherwise wipe the
     // text strip so the new name/dot does not overprint the old.
-    if (!force) tft.fillRect(0, g.hdrCY - 9, LY_W, 18, CLR_BG);
+    if (!force) tft.fillRect(g.x, g.hdrCY - 9, g.w, 18, CLR_BG);
 
     // Right: state dot + status word ("Printing" / "Idle" / "Preparing" ...).
     const uint16_t stClr = stateColor(s.gcodeStateId);
-    const int16_t dotCX = LY_W - LY_SPLIT_BAR_MARGIN - 5;
+    const int16_t dotCX = g.x + g.w - g.margin - 5;
     tft.fillCircle(dotCX, g.hdrCY, 5, stClr);
     const char* st = stateLabel(s.gcodeStateId);
     int16_t stLeft = dotCX - 10;   // name still clears the dot when status is empty
@@ -251,19 +263,19 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
     tft.setTextDatum(ML_DATUM);
     tft.setTextColor(CLR_TEXT, CLR_BG);
     const char* name = (cfg.name[0] != '\0') ? cfg.name : "Printer";
-    const int16_t nameMaxW = stLeft - 4 - LY_SPLIT_BAR_MARGIN;
-    drawClippedName(name, LY_SPLIT_BAR_MARGIN, g.hdrCY, nameMaxW);
+    const int16_t nameMaxW = stLeft - 4 - (g.x + g.margin);
+    drawClippedName(name, g.x + g.margin, g.hdrCY, nameMaxW);
     sPrevHdrState[bandIdx] = s.gcodeStateId;
   }
 
   // --- Thin progress bar under the header ---
   if (force || s.progress != sPrevBarProg[bandIdx]) {
     markFrameDirty();
-    const int16_t bx = LY_SPLIT_BAR_MARGIN;
-    const int16_t bw = LY_W - 2 * LY_SPLIT_BAR_MARGIN;
+    const int16_t bx = g.x + g.margin;
+    const int16_t bw = g.w - 2 * g.margin;
     const int16_t fw = (int16_t)((int32_t)bw * (s.progress > 100 ? 100 : s.progress) / 100);
-    tft.fillRect(bx, g.barY, bw, LY_SPLIT_BAR_H, tft.color565(40, 40, 40));
-    if (fw > 0) tft.fillRect(bx, g.barY, fw, LY_SPLIT_BAR_H, dispSettings.progress.arc);
+    tft.fillRect(bx, g.barY, bw, g.barH, tft.color565(40, 40, 40));
+    if (fw > 0) tft.fillRect(bx, g.barY, fw, g.barH, dispSettings.progress.arc);
     sPrevBarProg[bandIdx] = s.progress;
   }
 
@@ -271,8 +283,8 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
   for (uint8_t si = 0; si < g.slots; si++) {
     uint8_t gt = cfg.gaugeSlots[si];
     if (gt >= GAUGE_TYPE_COUNT) gt = GAUGE_EMPTY;
-    const int16_t cx = g.cols[si % 3];
-    const int16_t cy = g.rows[si / 3];
+    const int16_t cx = g.cols[si % g.ncols];
+    const int16_t cy = g.rows[si / g.ncols];
 
     const bool typeChanged = (gt != sPrevTypes[bandIdx][si]);
     if (typeChanged) {
@@ -321,17 +333,18 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
       markFrameDirty();
       strlcpy(sPrevFootCenter[bandIdx], cbuf, sizeof(sPrevFootCenter[bandIdx]));
       const int16_t fy = g.footCY;
-      tft.fillRect(0, fy - 8, LY_W, 16, CLR_BG);
+      const int16_t fcx = g.x + g.w / 2;
+      tft.fillRect(g.x, fy - 8, g.w, 16, CLR_BG);
       setFont(tft, FONT_SMALL);
 
       // Centre string drawn first so the left filament label can clamp to it.
-      const int16_t centerLeft = LY_W / 2 - tft.textWidth(cbuf) / 2;
+      const int16_t centerLeft = fcx - tft.textWidth(cbuf) / 2;
       tft.setTextDatum(MC_DATUM);
       tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
-      tft.drawString(cbuf, LY_W / 2, fy);
+      tft.drawString(cbuf, fcx, fy);
 
       // Left: active filament swatch + type (or nothing if no AMS).
-      const int16_t lx = LY_SPLIT_BAR_MARGIN;
+      const int16_t lx = g.x + g.margin;
       uint16_t swColor = 0;
       const char* swType = nullptr;
       if (s.ams.present && s.ams.activeTray < AMS_MAX_TRAYS &&
@@ -358,8 +371,8 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
         uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
         tft.setTextDatum(MR_DATUM);
         tft.setTextColor(clr, CLR_BG);
-        tft.drawString("Door", LY_W - LY_SPLIT_BAR_MARGIN - 18, fy);
-        drawIcon16(tft, LY_W - LY_SPLIT_BAR_MARGIN - 16, fy - 8,
+        tft.drawString("Door", g.x + g.w - g.margin - 18, fy);
+        drawIcon16(tft, g.x + g.w - g.margin - 16, fy - 8,
                    s.doorOpen ? icon_unlock : icon_lock, clr);
       }
     }
@@ -380,6 +393,56 @@ void drawSplit() {
   if (b >= MAX_PRINTERS || b == a) b = (a == 0) ? 1 : 0;
 
   BandGeom ga, gb;
+
+#if defined(LAYOUT_HAS_SPLIT_LANDSCAPE)
+  if (splitIsLandscape()) {
+    // Left/right split (panel rotated to landscape). Two full-height bands side
+    // by side, each a 2x2 gauge grid reusing gaugeSlots[0..3]. Same per-band
+    // anatomy as portrait: bar on top, name+status beneath, gauges, foot line.
+    const int16_t W = (int16_t)tft.width();
+    const int16_t H = (int16_t)tft.height();
+    const int16_t halfW = W / 2;
+
+    // Left band stops 1px short of the divider; right band starts 1px past it,
+    // so neither band's header/foot clear strip overwrites the divider column.
+    ga.x = 0;         ga.w = halfW;
+    gb.x = halfW + 1; gb.w = W - halfW - 1;
+    ga.top = gb.top = 0;
+    ga.height = gb.height = H;
+    ga.r = gb.r = LY_SPLIT_L_GAUGE_R;
+    ga.t = gb.t = LY_SPLIT_L_GAUGE_T;
+    ga.slots = gb.slots = LY_SPLIT_L_SLOTS;
+    ga.ncols = gb.ncols = LY_SPLIT_L_NCOLS;
+    ga.barH = gb.barH = LY_SPLIT_L_BAR_H;
+    ga.margin = gb.margin = LY_SPLIT_L_BAR_MARGIN;
+    ga.barY = gb.barY = LY_SPLIT_L_BAR_Y;
+    ga.hdrCY = gb.hdrCY = LY_SPLIT_L_HDR_CY;
+    ga.rows[0] = gb.rows[0] = LY_SPLIT_L_ROW1;
+    ga.rows[1] = gb.rows[1] = LY_SPLIT_L_ROW2;
+    // Columns are band-relative; offset the right band by its left edge.
+    ga.cols[0] = LY_SPLIT_L_COL1;         ga.cols[1] = LY_SPLIT_L_COL2;
+    gb.cols[0] = gb.x + LY_SPLIT_L_COL1;  gb.cols[1] = gb.x + LY_SPLIT_L_COL2;
+    ga.cols[2] = gb.cols[2] = 0;          // unused (ncols == 2)
+    ga.footCY = gb.footCY = H - 12;
+
+    // Vertical divider between the two bands. The screen is already cleared on a
+    // force frame, so draw it only then.
+    if (force) {
+      tft.drawFastVLine(halfW, 0, H, tft.color565(40, 40, 40));
+    }
+
+    drawBand(printers[a].state, printers[a].config, a, ga, 0, force);
+    drawBand(printers[b].state, printers[b].config, b, gb, 1, force);
+    return;
+  }
+#endif
+
+  // Portrait: two stacked full-width bands.
+  ga.x = gb.x = 0;
+  ga.w = gb.w = LY_W;
+  ga.ncols = gb.ncols = 3;
+  ga.barH = gb.barH = LY_SPLIT_BAR_H;
+  ga.margin = gb.margin = LY_SPLIT_BAR_MARGIN;
   ga.cols[0] = gb.cols[0] = LY_COL1;
   ga.cols[1] = gb.cols[1] = LY_COL2;
   ga.cols[2] = gb.cols[2] = LY_COL3;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1,5 +1,6 @@
 #include "display_ui.h"
 #include "display_gauges.h"
+#include "display_split.h"
 #include "display_anim.h"
 #include "clock_mode.h"
 #include "clock_pong.h"
@@ -235,6 +236,19 @@ static inline int16_t uiW() { return SCREEN_W; }
 static inline int16_t uiH() { return SCREEN_H; }
 static inline bool landBottomBarFullWidth(uint8_t) { return true; }
 #endif
+
+// Split (dual-printer) screen is only offered on portrait profiles that define
+// LAYOUT_HAS_SPLIT, and only while not in a landscape rotation. Compiled-out
+// boards (e.g. 480x480 SenseCAP) return false so the feature stays inert.
+bool displaySupportsSplit() {
+#if defined(LAYOUT_HAS_SPLIT)
+  return !isLandscape();
+#else
+  return false;
+#endif
+}
+
+bool isDisplayForceRedraw() { return forceRedraw; }
 
 // ---------------------------------------------------------------------------
 //  Init
@@ -1744,9 +1758,12 @@ static void drawAmsTrayBar(int16_t x, int16_t y, int16_t w, int16_t h,
 // the unit's actual trayCount, so an AMS HT (single slot) shows one centered bar
 // instead of three empty ones. Centered in a square 2R x 2R region; "AMS N"
 // label below at the standard gauge-label position.
-static void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
-                             const AmsState& ams, uint8_t unitIndex,
-                             bool forceRedraw) {
+// Exported (declared in display_ui.h) so the split renderer can reuse it. The
+// helper drawAmsTrayBarRounded() it relies on stays private here because
+// drawAmsStrip()/drawAmsZone() also use it.
+void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
+                      const AmsState& ams, uint8_t unitIndex,
+                      bool forceRedraw) {
   uint16_t bg = dispSettings.bgColor;
 
   const bool unitPresent = ams.present
@@ -1948,6 +1965,13 @@ static bool useEnhancedPortraitAms(const AmsState& ams) {
 #endif
 }
 
+#else  // DISPLAY_480x480
+// 480x480 (SenseCAP) does not implement the AMS bar visualizations (the helpers
+// above are excluded). Provide a stub so the unguarded GAUGE_AMS_BARS call site
+// in drawPrinting() and the exported declaration still link; AMS-bars simply
+// isn't drawn on this profile. (This also fixes a pre-existing link break on
+// main where the static drawAmsBarsGauge was referenced but never defined here.)
+void drawAmsBarsGauge(int16_t, int16_t, int16_t, const AmsState&, uint8_t, bool) {}
 #endif // !DISPLAY_480x480 (stateless AMS helpers)
 
 #if defined(LAYOUT_HAS_AMS_STRIP)
@@ -3486,6 +3510,10 @@ void updateDisplay() {
 
     case SCREEN_PRINTING:
       drawPrinting();
+      break;
+
+    case SCREEN_SPLIT:
+      drawSplit();
       break;
 
     case SCREEN_FINISHED:

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -237,11 +237,16 @@ static inline int16_t uiH() { return SCREEN_H; }
 static inline bool landBottomBarFullWidth(uint8_t) { return true; }
 #endif
 
-// Split (dual-printer) screen is only offered on portrait profiles that define
-// LAYOUT_HAS_SPLIT, and only while not in a landscape rotation. Compiled-out
-// boards (e.g. 480x480 SenseCAP) return false so the feature stays inert.
+// Split (dual-printer) screen is offered on profiles that define
+// LAYOUT_HAS_SPLIT. Portrait gives stacked top/bottom bands; layouts that also
+// define LAYOUT_HAS_SPLIT_LANDSCAPE add a side-by-side left/right variant, so
+// the split survives a landscape rotation there. Layouts without the landscape
+// variant keep the portrait-only restriction. Compiled-out boards (e.g. 480x480
+// SenseCAP) return false so the feature stays inert.
 bool displaySupportsSplit() {
-#if defined(LAYOUT_HAS_SPLIT)
+#if defined(LAYOUT_HAS_SPLIT) && defined(LAYOUT_HAS_SPLIT_LANDSCAPE)
+  return true;
+#elif defined(LAYOUT_HAS_SPLIT)
   return !isLandscape();
 #else
   return false;

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -18,8 +18,13 @@ enum ScreenState {
   SCREEN_FINISHED,
   SCREEN_CLOCK,
   SCREEN_OFF,
-  SCREEN_OTA_UPDATE
+  SCREEN_OTA_UPDATE,
+  SCREEN_SPLIT          // two printers side-by-side (top/bottom bands)
 };
+
+// Forward declaration so split-related declarations below can take an AmsState
+// by reference without pulling in bambu_state.h here.
+struct AmsState;
 
 extern lgfx::LovyanGFX* tft_ptr;
 // Macro (NOT a reference) so callers' `tft.method()` always dereferences the
@@ -56,5 +61,19 @@ void applyDisplaySettings();  // re-apply rotation, bg, force redraw
 void triggerDisplayTransition(); // start printer-name overlay on rotation
 void checkNightMode();        // apply scheduled brightness dimming
 uint8_t getEffectiveBrightness(); // current brightness (night or normal)
+
+// True only on portrait layout profiles that define LAYOUT_HAS_SPLIT and are not
+// currently in a landscape rotation. Gates the split (dual-printer) screen so it
+// never engages on 480x480 / landscape boards.
+bool displaySupportsSplit();
+
+// True during a frame that must fully repaint (screen change or
+// triggerDisplayTransition). The split renderer reads this to force both bands.
+bool isDisplayForceRedraw();
+
+// AMS "bars" gauge tile (one rounded bar per loaded tray, no humidity). Defined
+// in display_ui.cpp; exported so the split renderer can draw it inside a band.
+void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
+                      const AmsState& ams, uint8_t unitIndex, bool forceRedraw);
 
 #endif // DISPLAY_UI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,6 +435,32 @@ static void updateDisplayedPrinterScreenState() {
     return;
   }
 
+  // Split (dual-printer) screen: when the checkbox is on and the layout
+  // supports it, show two active printers together instead of rotating. Composes
+  // with the rotation mode - below 2 active printers the normal single-printer
+  // logic runs. Suppressed during a display hold so a fresh finish / manual peek
+  // keeps its single-printer screen for one interval.
+  if (rotState.splitEnabled && displaySupportsSplit() && !displayHold) {
+    uint8_t active[MAX_ACTIVE_PRINTERS];
+    uint8_t activeCount = 0;
+    for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
+      if (isPrinterActiveForDisplay(i)) active[activeCount++] = i;
+    }
+    if (activeCount >= 2) {
+      uint8_t a = active[0], b = active[1];
+      bool pairChanged = (current != SCREEN_SPLIT) ||
+                         (rotState.displayIndex != a) || (rotState.splitIndexB != b);
+      rotState.displayIndex = a;
+      rotState.splitIndexB  = b;
+      if (pairChanged) triggerDisplayTransition();  // clear caches for the new pair
+      setScreenState(SCREEN_SPLIT);
+      setBacklight(getEffectiveBrightness());
+      finishActive = false;
+      idleClockActive = false;
+      return;
+    }
+  }
+
   BambuState& s = displayedPrinter().state;
   if (!s.connected) {
     uint8_t displayed = rotState.displayIndex < MAX_ACTIVE_PRINTERS
@@ -646,6 +672,8 @@ static void rotateWithinSlots(const uint8_t slots[], uint8_t count, unsigned lon
 }
 
 static void handleRotation() {
+  // Split view owns the screen while it is active - never rotate underneath it.
+  if (getScreenState() == SCREEN_SPLIT) return;
   if (rotState.mode == ROTATE_OFF) return;
   if (getActiveConnCount() < 2) return;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,14 +440,27 @@ static void updateDisplayedPrinterScreenState() {
   // with the rotation mode - below 2 active printers the normal single-printer
   // logic runs. Suppressed during a display hold so a fresh finish / manual peek
   // keeps its single-printer screen for one interval.
-  if (rotState.splitEnabled && displaySupportsSplit() && !displayHold) {
-    uint8_t active[MAX_ACTIVE_PRINTERS];
-    uint8_t activeCount = 0;
-    for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
-      if (isPrinterActiveForDisplay(i)) active[activeCount++] = i;
+  if ((rotState.splitEnabled || rotState.splitForce) && displaySupportsSplit() && !displayHold) {
+    uint8_t a = 0, b = 0;
+    bool engage = false;
+    if (rotState.splitForce) {
+      // Testing override: always split the first two configured slots, even
+      // when idle/disconnected, so the layout can be checked without two prints.
+      uint8_t cfg[MAX_ACTIVE_PRINTERS];
+      uint8_t cfgCount = 0;
+      for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
+        if (isPrinterConfigured(i)) cfg[cfgCount++] = i;
+      }
+      if (cfgCount >= 2) { a = cfg[0]; b = cfg[1]; engage = true; }
+    } else {
+      uint8_t active[MAX_ACTIVE_PRINTERS];
+      uint8_t activeCount = 0;
+      for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
+        if (isPrinterActiveForDisplay(i)) active[activeCount++] = i;
+      }
+      if (activeCount >= 2) { a = active[0]; b = active[1]; engage = true; }
     }
-    if (activeCount >= 2) {
-      uint8_t a = active[0], b = active[1];
+    if (engage) {
       bool pairChanged = (current != SCREEN_SPLIT) ||
                          (rotState.displayIndex != a) || (rotState.splitIndexB != b);
       rotState.displayIndex = a;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,8 +453,10 @@ static void updateDisplayedPrinterScreenState() {
       rotState.displayIndex = a;
       rotState.splitIndexB  = b;
       if (pairChanged) triggerDisplayTransition();  // clear caches for the new pair
+      // Wake the panel only on entry (night dimming stays handled by
+      // checkNightMode()); avoids a redundant backlight write every loop.
+      if (current != SCREEN_SPLIT) setBacklight(getEffectiveBrightness());
       setScreenState(SCREEN_SPLIT);
-      setBacklight(getEffectiveBrightness());
       finishActive = false;
       idleClockActive = false;
       return;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -9,7 +9,7 @@
 // Global state
 PrinterSlot printers[MAX_PRINTERS];
 uint8_t activePrinterIndex = 0;
-RotationState rotState = { ROTATE_SMART, ROTATE_INTERVAL_MS, 0, 0, 0 };
+RotationState rotState = { ROTATE_SMART, ROTATE_INTERVAL_MS, 0, 0, 0, false, 1 };
 char wifiSSID[33] = {0};
 char wifiPass[65] = {0};
 uint8_t brightness = 200;
@@ -468,7 +468,9 @@ void loadSettings() {
   rotState.intervalMs = prefs.getULong("rot_intv", ROTATE_INTERVAL_MS);
   if (rotState.intervalMs < ROTATE_MIN_MS) rotState.intervalMs = ROTATE_MIN_MS;
   if (rotState.intervalMs > ROTATE_MAX_MS) rotState.intervalMs = ROTATE_MAX_MS;
+  rotState.splitEnabled = prefs.getBool("rot_split", false);
   rotState.displayIndex = 0;
+  rotState.splitIndexB = 1;
   rotState.lastRotateMs = 0;
 
   // Button settings
@@ -764,6 +766,7 @@ void saveRotationSettings() {
   prefs.begin(NVS_NAMESPACE, false);
   prefs.putUChar("rot_mode", rotState.mode);
   prefs.putULong("rot_intv", rotState.intervalMs);
+  prefs.putBool("rot_split", rotState.splitEnabled);
   prefs.end();
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -469,6 +469,7 @@ void loadSettings() {
   if (rotState.intervalMs < ROTATE_MIN_MS) rotState.intervalMs = ROTATE_MIN_MS;
   if (rotState.intervalMs > ROTATE_MAX_MS) rotState.intervalMs = ROTATE_MAX_MS;
   rotState.splitEnabled = prefs.getBool("rot_split", false);
+  rotState.splitForce = prefs.getBool("rot_splitf", false);
   rotState.displayIndex = 0;
   rotState.splitIndexB = 1;
   rotState.lastRotateMs = 0;
@@ -767,6 +768,7 @@ void saveRotationSettings() {
   prefs.putUChar("rot_mode", rotState.mode);
   prefs.putULong("rot_intv", rotState.intervalMs);
   prefs.putBool("rot_split", rotState.splitEnabled);
+  prefs.putBool("rot_splitf", rotState.splitForce);
   prefs.end();
 }
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -264,6 +264,10 @@ static void handleClearPrinter() {
   if (rotState.displayIndex == slot) {
     rotState.displayIndex = (slot == 0 && isPrinterConfigured(1)) ? 1 : 0;
   }
+  // Keep the split second-slot valid and distinct from the deleted slot.
+  if (rotState.splitIndexB == slot || rotState.splitIndexB >= MAX_ACTIVE_PRINTERS) {
+    rotState.splitIndexB = (rotState.displayIndex == 0) ? 1 : 0;
+  }
 
   server.send(200, "application/json", "{\"status\":\"ok\"}");
 }
@@ -546,6 +550,7 @@ static void handleToggleSetting() {
       // User just disabled 2-printer mode - drop slot 1 from rotation/display
       rotState.displayIndex = 0;
     }
+    if (!on && rotState.splitIndexB == 1) rotState.splitIndexB = 0;
     // Re-evaluate slot 1 active state without reboot; slot 0 stays connected.
     initBambuMqttSlot(1);
   }
@@ -719,6 +724,9 @@ static void handleSaveRotation() {
     if (ms < ROTATE_MIN_MS) ms = ROTATE_MIN_MS;
     if (ms > ROTATE_MAX_MS) ms = ROTATE_MAX_MS;
     rotState.intervalMs = ms;
+  }
+  if (server.hasArg("rotsplit")) {
+    rotState.splitEnabled = (server.arg("rotsplit") == "1");
   }
   saveRotationSettings();
 
@@ -1036,6 +1044,7 @@ static void handleSettingsExport() {
   JsonObject rot = doc["rotation"].to<JsonObject>();
   rot["mode"] = (uint8_t)rotState.mode;
   rot["intervalMs"] = rotState.intervalMs;
+  rot["split"] = rotState.splitEnabled;
 
   // Button
   JsonObject btn = doc["button"].to<JsonObject>();
@@ -1331,6 +1340,7 @@ static void handleSettingsImportFinish() {
   if (rot) {
     if (rot["mode"].is<uint8_t>())      rotState.mode = (RotateMode)rot["mode"].as<uint8_t>();
     if (rot["intervalMs"].is<uint32_t>()) rotState.intervalMs = rot["intervalMs"].as<uint32_t>();
+    if (rot["split"].is<bool>())        rotState.splitEnabled = rot["split"].as<bool>();
   }
 
   // Button

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -728,6 +728,9 @@ static void handleSaveRotation() {
   if (server.hasArg("rotsplit")) {
     rotState.splitEnabled = (server.arg("rotsplit") == "1");
   }
+  if (server.hasArg("rotsplitf")) {
+    rotState.splitForce = (server.arg("rotsplitf") == "1");
+  }
   saveRotationSettings();
 
   // Button settings
@@ -1045,6 +1048,7 @@ static void handleSettingsExport() {
   rot["mode"] = (uint8_t)rotState.mode;
   rot["intervalMs"] = rotState.intervalMs;
   rot["split"] = rotState.splitEnabled;
+  rot["splitForce"] = rotState.splitForce;
 
   // Button
   JsonObject btn = doc["button"].to<JsonObject>();
@@ -1341,6 +1345,7 @@ static void handleSettingsImportFinish() {
     if (rot["mode"].is<uint8_t>())      rotState.mode = (RotateMode)rot["mode"].as<uint8_t>();
     if (rot["intervalMs"].is<uint32_t>()) rotState.intervalMs = rot["intervalMs"].as<uint32_t>();
     if (rot["split"].is<bool>())        rotState.splitEnabled = rot["split"].as<bool>();
+    if (rot["splitForce"].is<bool>())   rotState.splitForce = rot["splitForce"].as<bool>();
   }
 
   // Button

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -346,6 +346,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
   if (strcmp(name, "RMODE_AUTO") == 0)  { out = rotState.mode == ROTATE_AUTO ? "selected" : ""; return true; }
   if (strcmp(name, "RMODE_SMART") == 0) { out = rotState.mode == ROTATE_SMART ? "selected" : ""; return true; }
   if (strcmp(name, "ROT_INTERVAL") == 0){ out = String(rotState.intervalMs / 1000); return true; }
+  if (strcmp(name, "ROT_SPLIT_CHK") == 0){ out = rotState.splitEnabled ? "checked" : ""; return true; }
 
   // --- Gauge full-scale ranges ---
   if (strcmp(name, "NOZ_MAX") == 0) { out = String(dispSettings.nozzleScaleMax); return true; }

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -347,6 +347,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
   if (strcmp(name, "RMODE_SMART") == 0) { out = rotState.mode == ROTATE_SMART ? "selected" : ""; return true; }
   if (strcmp(name, "ROT_INTERVAL") == 0){ out = String(rotState.intervalMs / 1000); return true; }
   if (strcmp(name, "ROT_SPLIT_CHK") == 0){ out = rotState.splitEnabled ? "checked" : ""; return true; }
+  if (strcmp(name, "ROT_SPLITF_CHK") == 0){ out = rotState.splitForce ? "checked" : ""; return true; }
 
   // --- Gauge full-scale ranges ---
   if (strcmp(name, "NOZ_MAX") == 0) { out = String(dispSettings.nozzleScaleMax); return true; }


### PR DESCRIPTION
## Split dual-printer dashboard

Shows two printers at once instead of rotating between them, with a portrait (top/bottom) and a landscape (left/right) layout. Off by default; composes with the existing rotation modes.

### How it works
- New `Split screen when two printers are printing` checkbox (Advanced). Below two active printers the chosen rotation mode runs normally; at two or more active (printing or drying) the screen splits.
- Added an `Always show split screen (testing)` checkbox that forces the split of the first two configured printers regardless of activity, so the layout can be checked without two live prints.

### Layouts
- **Portrait** (240x240, 240x320, 320x480): two stacked full-width bands. Each band: progress bar on top, printer name + status word + state dot, the printer's top gauges, and a bottom line.
- **Landscape** (320x480, 240x320): two side-by-side full-height bands with a 2x2 gauge grid each and a vertical divider. Enabled on non-low-RAM boards only (the single-printer CYD / TZT builds are excluded).

### ETA
Each band shows the wall-clock finish time (or remaining duration when "show time remaining" is set, or before NTP sync), matching the single-printer view.
- Landscape: dedicated, enlarged ETA line below the gauges.
- Portrait: the bottom line is filament colour swatch + ETA only, so a long multi-day ETA fits.

### Notes
- Bands reuse each printer's existing `gaugeSlots[]` (top 3/4/6 by profile).
- Value-text fit on the JC3248W535 (opaque text background) was corrected so the value box stays inside the arc on the small split gauges; behaviour on all other panels is unchanged.
- Also fixes a pre-existing link break on the 480x480 (SenseCAP) profile.
- Verified on hardware: ESP32-S3 240x240, Waveshare 240x320, Guition 320x480 (portrait + landscape). Community 320x480 / 480x480 envs build but are untested here.
