### PR TITLE
Camera live view for P1/A1 printers (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When using Bambu Cloud, BambuHelper connects through Bambu Lab's cloud MQTT serv
 | Preview | Board | Notes |
 |---|---|---|
 | ![ESP32-S3 Super Mini dashboard](img/interface1.jpg) | **ESP32-S3 Super Mini + 1.54" ST7789** | Base implementation this project started from. Uses an ESP32-S3 Super Mini with a `1.54"` TFT SPI ST7789 (`240x240`) display. Use the `esp32s3` firmware build. Supports **up to 2 printers** (no PSRAM). |
-| ![Guition JC3248W535](img/jc3248w535.jpg) | **Guition JC3248W535** | `320x480` IPS all-in-one board with **AXS15231B QSPI** display driver, ESP32-S3-N16R8 (`16MB` flash / `8MB` PSRAM), and capacitive touch (AXS15231B touch controller on I2C). Use the `jc3248w535` firmware build. Supports **up to 2 printers** (up to 4 with the experimental opt-in - see Multi-Printer Monitoring). Initial port contributed by Niels ([@theNailz](https://github.com/theNailz)). AliExpress: [pl.aliexpress.com/item/1005007566315926.html](https://pl.aliexpress.com/item/1005007566315926.html) |
+| ![Guition JC3248W535](img/jc3248w535.jpg) | **Guition JC3248W535** | `320x480` IPS all-in-one board with **AXS15231B QSPI** display driver, ESP32-S3-N16R8 (`16MB` flash / `8MB` PSRAM), and capacitive touch (AXS15231B touch controller on I2C). Use the `jc3248w535` firmware build. Supports **up to 2 printers** (up to 4 with the experimental opt-in - see Multi-Printer Monitoring). Includes an onboard **NS4168 I2S speaker** for notifications and a **battery indicator** (GPIO5 BAT divider), and supports portrait and landscape (480x320) layouts. Initial port contributed by Niels ([@theNailz](https://github.com/theNailz)). AliExpress: [pl.aliexpress.com/item/1005007566315926.html](https://pl.aliexpress.com/item/1005007566315926.html) |
 | ![Waveshare 2 inch](img/waveshare2inch.png) | **Waveshare ESP32-S3-Touch-LCD-2** | `240x320` ST7789 version with ESP32-S3, sold as a more plug-and-play option. Use the `ws_lcd_200` firmware build. Supports **up to 2 printers** (no PSRAM), like the main ESP32-S3 DIY version. Product page: [waveshare.com/esp32-s3-touch-lcd-2.htm](https://www.waveshare.com/esp32-s3-touch-lcd-2.htm) Case (Horizontal and vertical): [MakerWorld model](https://makerworld.com/en/models/2773835) |
 | ![Waveshare 1.54 inch](img/waveshare1.54inch.png) | **Waveshare ESP32-S3-Touch-LCD-1.54** | `240x240` ST7789 with ESP32-S3, touchscreen, battery holder, and 3 built-in buttons. Use the `ws_lcd_154` firmware build. Supports **up to 2 printers** (no PSRAM). The left button (BOOT) works as a screen switcher alongside the touchscreen. **Battery power:** press and hold the center PWR button to power on. To power off, hold the left (BOOT) and right buttons simultaneously for 1.5 seconds. Product page: [waveshare.com/esp32-s3-touch-lcd-1.54.htm](https://www.waveshare.com/esp32-s3-touch-lcd-1.54.htm) |
 | ![ESP32-C3 board](img/ESP32c3Board.png) | **ESP32-C3 Super Mini** | DIY version, just like the main ESP32-S3 build, using the same `240x240` ST7789 display. Use the `esp32c3` firmware build. Due to RAM limits, this board supports **1 printer only**. |
@@ -70,11 +70,15 @@ When using Bambu Cloud, BambuHelper connects through Bambu Lab's cloud MQTT serv
 - **Auto AP mode** - creates WiFi hotspot on first boot or when WiFi is lost
 - **Smart redraw** - only redraws changed UI elements for smooth performance
 - **Customizable gauge colors** - per-gauge arc/label/value colors with preset themes
+- **Configurable gauge behavior** - adjustable arc full-scale ranges (nozzle, bed, chamber/AMS, power), arc smoothing speed, and an optional warning color when a gauge runs hot
+- **Power gauge** - optional arc gauge showing live smart-plug wattage (W/kW) in a gauge slot
+- **Per-nozzle temperature gauges** - fixed left/right nozzle arcs for dual-nozzle printers (H2 series)
+- **Split dual-printer dashboard** - show two printers at once (stacked in portrait, side-by-side in landscape) with progress bar, status, ETA, and drying view per band
 - **Multi-printer support** - monitor 2 printers simultaneously on full-RAM ESP32-S3 boards; PSRAM-equipped boards (Guition JC3248W535, ESP32-S3-Zero, ws_lcd_350, SenseCAP Indicator) add an experimental opt-in for up to 4; CYD, TZT, and ESP32-C3 have an experimental opt-in 2-printer mode but default to 1 printer
 - **Smart rotation** - automatically shows the printing printer; cycles between both when both are printing
 - **Physical button / touchscreen** - cycle printers and wake display via optional push button or TTP223, board-built-in buttons (Waveshare 1.54"), or the built-in capacitive touchscreens on CYD / TZT / Waveshare 2" / Waveshare 1.54"
 - **Optional LED** - PWM-driven status LED on a user-configurable pin; hold the button/touch to dim
-- **Optional buzzer** - passive buzzer notifications for print finished, connected, and error events; Waveshare 1.54" uses its built-in ES8311 audio codec instead
+- **Optional buzzer** - passive buzzer notifications for print finished, connected, and error events; Waveshare 1.54" uses its built-in ES8311 audio codec and Guition JC3248W535 its onboard NS4168 I2S speaker instead
 - **OTA updates** - update firmware from the device's web interface (manual upload or one-click from GitHub Releases)
 - **Battery support (Waveshare 2" and 1.54")** - on-screen battery indicator, charging detection, hold-to-power-off
 - **Exponential backoff** - reconnect attempts to offline printers gradually slow down to conserve resources
@@ -190,7 +194,7 @@ Supports the 10 most common boards (ESP32-S3 SuperMini, ESP32-S3-Zero, ESP32-C3 
 
 ### Manual: Generic ESP Web Flasher
 
-1. Download the latest firmware from [Releases](../../releases). **If you are flashing a new device for the first time**, use the file ending with **-Full** (for example `BambuHelper-esp32s3-v3.3-Full.bin`). The regular `-ota.bin` file is for OTA updates on devices that already have BambuHelper installed.
+1. Download the latest firmware from [Releases](../../releases). **If you are flashing a new device for the first time**, use the file ending with **-Full** (for example `BambuHelper-esp32s3-v3.7-Full.bin`). The regular `-ota.bin` file is for OTA updates on devices that already have BambuHelper installed.
 2. Open [ESP Web Flasher](https://espressif.github.io/esptool-js/) in Chrome or Edge
 3. If you are flashing a **CYD** or **TZT L1435-2.4**, set **Baudrate** to **115200** before clicking **Connect**. Two or more attempts may be needed - the first one will fail. This applies to both CYD-shaped boards (they use a CH340 USB-Serial chip that does not tolerate high baud rates on first contact).
 4. Connect your ESP32 via USB
@@ -214,16 +218,16 @@ The device reboots automatically once the update is written; the web page reload
 
 | Board | Use this `Full` file for first flash / recovery |
 |---|---|
-| ESP32-S3 Super Mini | `BambuHelper-esp32s3-v3.3-Full.bin` |
-| Guition JC3248W535 | `BambuHelper-jc3248w535-v3.3-Full.bin` |
-| Waveshare ESP32-S3-Zero | `BambuHelper-esp32s3_zero-v3.3-Full.bin` |
-| CYD / ESP32-2432S028 | `BambuHelper-cyd-v3.3-Full.bin` |
-| TZT L1435-2.4 | `BambuHelper-tzt_2432-v3.3-Full.bin` |
-| Waveshare ESP32-S3-Touch-LCD-2 | `BambuHelper-ws_lcd_200-v3.3-Full.bin` |
-| Waveshare ESP32-S3-Touch-LCD-1.54 | `BambuHelper-ws_lcd_154-v3.3-Full.bin` |
-| Waveshare ESP32-S3-Touch-LCD-2.8 | `BambuHelper-ws_lcd_280-v3.3-Full.bin` |
-| Waveshare ESP32-S3-Touch-LCD-3.5 | `BambuHelper-ws_lcd_350-v3.3-Full.bin` |
-| ESP32-C3 Super Mini | `BambuHelper-esp32c3-v3.3-Full.bin` |
+| ESP32-S3 Super Mini | `BambuHelper-esp32s3-v3.7-Full.bin` |
+| Guition JC3248W535 | `BambuHelper-jc3248w535-v3.7-Full.bin` |
+| Waveshare ESP32-S3-Zero | `BambuHelper-esp32s3_zero-v3.7-Full.bin` |
+| CYD / ESP32-2432S028 | `BambuHelper-cyd-v3.7-Full.bin` |
+| TZT L1435-2.4 | `BambuHelper-tzt_2432-v3.7-Full.bin` |
+| Waveshare ESP32-S3-Touch-LCD-2 | `BambuHelper-ws_lcd_200-v3.7-Full.bin` |
+| Waveshare ESP32-S3-Touch-LCD-1.54 | `BambuHelper-ws_lcd_154-v3.7-Full.bin` |
+| Waveshare ESP32-S3-Touch-LCD-2.8 | `BambuHelper-ws_lcd_280-v3.7-Full.bin` |
+| Waveshare ESP32-S3-Touch-LCD-3.5 | `BambuHelper-ws_lcd_350-v3.7-Full.bin` |
+| ESP32-C3 Super Mini | `BambuHelper-esp32c3-v3.7-Full.bin` |
 
 > Community boards (ESP32-S3-Zero with 2.0" 240x320 panel, SenseCAP Indicator) are not part of the automated release pipeline - build them locally with `pio.exe run -e <env>` and flash the resulting `.pio/build/<env>/firmware.bin`.
 
@@ -363,6 +367,15 @@ The built-in web interface (accessible at the device's IP address) provides the 
   - Aux fan
   - Chamber fan
 
+### Gauge Scales & Behavior
+- **Gauge scales** - full-scale value each arc represents; lower a scale so the arc sweeps fuller for your printer's normal range:
+  - Nozzle full-scale (default 300 degC)
+  - Bed full-scale (default 120 degC)
+  - Chamber / AMS temp full-scale (default 60 degC)
+  - Power gauge full-scale (default 1000 W)
+- **Arc smoothing** - how quickly temperature arcs animate toward the live value
+- **Warning color** - nozzle, bed, and chamber arcs (and their value text) switch to this color once the reading reaches a chosen share of the gauge's full scale
+
 ### Buzzer
 - **Buzzer (optional)** - enable or disable passive buzzer notifications
 - **GPIO Pin** - choose which ESP32 pin drives the buzzer
@@ -417,6 +430,10 @@ BambuHelper monitors 2 printers simultaneously on full-RAM ESP32-S3 boards, each
 | **Smart** (default) | Shows the printing printer. If both are printing, cycles between them. If neither is printing, shows last active. |
 | **Auto-rotate** | Cycles through all connected printers at a configurable interval (10s - 10min). |
 | **Off** | Manually switch between printers using the physical button only. |
+
+### Split-Screen Mode
+
+Instead of rotating between printers one at a time, you can show two printers at once. Enable **Split screen when two printers are printing** in the Multi-Printer section. When both configured printers are printing, the dashboard divides into two bands - stacked top/bottom in portrait, or left/right in landscape - each with its own progress bar, status label, ETA, and drying view. When only one printer is active it falls back to the normal full-screen dashboard. A **Always show split screen (testing)** toggle forces the split layout regardless of activity so you can preview it without two live prints.
 
 ### Physical Button
 

--- a/include/config.h
+++ b/include/config.h
@@ -113,6 +113,17 @@
 #endif
 
 // =============================================================================
+//  Camera live view (issue #120)
+// =============================================================================
+// A P1/A1 LAN camera needs a 2nd TLS socket + a full-JPEG PSRAM buffer + touch.
+// Only these two boards qualify (8 MB PSRAM + touch); BOARD_HAS_PSRAM is too
+// broad (it also covers esp32s3_zero/_320/sensecap). Every camera code path is
+// compiled behind BOARD_HAS_CAMERA; other boards link no-op stubs.
+#if defined(BOARD_IS_JC3248W535) || defined(BOARD_IS_WS350)
+#define BOARD_HAS_CAMERA      1
+#endif
+
+// =============================================================================
 //  Display rotation (multi-printer)
 // =============================================================================
 #define ROTATE_INTERVAL_MS    60000   // default auto-rotate: 1 min

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -1666,9 +1666,10 @@ var gaugeTypes = [
   {name:'AMS 4 Bars',         group:'AMS filament (bars)'},/* 28 */
   {name:'Nozzle R Temp',      group:'Temperatures'},      /* 29 */
   {name:'Nozzle L Temp',      group:'Temperatures'},      /* 30 */
-  {name:'Power',              group:'Other'}              /* 31 */
+  {name:'Power',              group:'Other'},             /* 31 */
+  {name:'Camera (P1/A1 LAN)', group:'Other'}              /* 32 */
 ];
-var GAUGE_REQUIRES = { 23: 'hasAuxFanRight', 24: 'hasExhaustFan', 29: 'hasDualNozzle', 30: 'hasDualNozzle', 31: 'hasTasmota' };
+var GAUGE_REQUIRES = { 23: 'hasAuxFanRight', 24: 'hasExhaustFan', 29: 'hasDualNozzle', 30: 'hasDualNozzle', 31: 'hasTasmota', 32: 'hasLanCamera' };
 var gaugeCaps = {}, persistedGauges = {};
 function gaugeAllowed(idx){
   if (persistedGauges[idx]) return true;

--- a/src/camera_client.cpp
+++ b/src/camera_client.cpp
@@ -15,16 +15,18 @@
 #include "settings.h"
 
 // --- tunables --------------------------------------------------------------
-static const uint16_t CAM_PORT          = 6000;
-static const uint32_t CAM_BUF_SIZE      = 200 * 1024;  // max single JPEG (PSRAM)
-static const uint32_t CAM_CONNECT_EVERY = 2000;        // ms between connect tries
-static const uint8_t  CAM_TLS_TIMEOUT_S = 5;
-static const int      CAM_READ_BUDGET   = 16 * 1024;   // max bytes drained / loop
-static const size_t   CAM_CHUNK         = 1460;
+static const uint16_t CAM_PORT           = 6000;
+static const uint32_t CAM_BUF_SIZE       = 200 * 1024; // max single JPEG (PSRAM)
+static const uint32_t CAM_CONNECT_MIN_MS = 2000;       // first retry gap after a failed connect
+static const uint32_t CAM_CONNECT_MAX_MS = 16000;      // backoff cap (connect() blocks ~timeout)
+static const uint8_t  CAM_TLS_TIMEOUT_S  = 3;          // keep a blocking connect short
+static const int      CAM_READ_BUDGET    = 16 * 1024;  // max bytes drained / loop
+static const size_t   CAM_CHUNK          = 1460;
 
 // --- state -----------------------------------------------------------------
 static bool              g_active = false;
 static WiFiClientSecure* g_tls    = nullptr;
+static uint32_t          g_connectBackoffMs = CAM_CONNECT_MIN_MS;
 
 static uint8_t* g_inflight = nullptr;   // accumulates until a full SOI..EOI
 static uint32_t g_inflightLen = 0;
@@ -63,13 +65,33 @@ bool cameraCanStreamDisplayedPrinter() {
 
 bool cameraDisplayedHasCameraTile() {
   PrinterConfig& c = displayedPrinter().config;
+  // Standard 2x3 slots are always on screen.
   for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++)
     if (c.gaugeSlots[i] == GAUGE_CAMERA) return true;
-  for (uint8_t i = 0; i < LANDSCAPE_EXTRA_COUNT; i++)
-    if (c.landscapeExtras[i] == GAUGE_CAMERA) return true;
-  for (uint8_t i = 0; i < PORTRAIT_EXTRA_COUNT; i++)
-    if (c.portraitExtras[i] == GAUGE_CAMERA) return true;
+  // Extra slots only render in their active layout, so only count them there -
+  // a camera placed in an inactive extra grid must not open the socket or grab
+  // tap-to-fullscreen when no CAM tile is actually visible.
+  const bool landscape = (dispSettings.rotation == 1 || dispSettings.rotation == 3);
+  if (landscape && dispSettings.landscape8Slots) {
+    for (uint8_t i = 0; i < LANDSCAPE_EXTRA_COUNT; i++)
+      if (c.landscapeExtras[i] == GAUGE_CAMERA) return true;
+  }
+  if (!landscape && dispSettings.portrait9Slots) {
+    for (uint8_t i = 0; i < PORTRAIT_EXTRA_COUNT; i++)
+      if (c.portraitExtras[i] == GAUGE_CAMERA) return true;
+  }
   return false;
+}
+
+// True when the camera is not streaming, or is streaming the IP that matches the
+// currently displayed printer. The loop stops a mismatched stream (rotation can
+// move displayIndex while a socket is open) so the tile/fullscreen never shows a
+// previous printer's frames.
+bool cameraStreamingDisplayed() {
+  if (!g_active) return true;
+  PrinterSlot& p = displayedPrinter();
+  const char* ip = p.config.ip[0] ? p.config.ip : p.state.localIp;
+  return ip[0] && strcmp(ip, g_ip) == 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +187,7 @@ void cameraBegin() {
   g_publishedLen = 0;
   g_frameId = 0;
   g_lastConnectMs = 0;
+  g_connectBackoffMs = CAM_CONNECT_MIN_MS;
   g_active = true;
 }
 
@@ -181,7 +204,10 @@ void cameraService() {
 
   if (!g_tls || !g_tls->connected()) {
     unsigned long now = millis();
-    if (now - g_lastConnectMs < CAM_CONNECT_EVERY) return;  // rate-limit blocking connect
+    // connect() is blocking (up to the TLS timeout). Space attempts by a growing
+    // backoff so an unreachable port 6000 cannot stall the loop every couple of
+    // seconds; the gap always exceeds the connect timeout.
+    if (now - g_lastConnectMs < g_connectBackoffMs) return;
     g_lastConnectMs = now;
     if (ESP.getFreeHeap() < BAMBU_MIN_FREE_HEAP) return;
     if (!g_tls) {
@@ -191,9 +217,15 @@ void cameraService() {
       g_tls->setTimeout(CAM_TLS_TIMEOUT_S);
     }
     esp_task_wdt_reset();
-    if (!g_tls->connect(g_ip, CAM_PORT)) { teardownSocket(); return; }
+    if (!g_tls->connect(g_ip, CAM_PORT)) {
+      teardownSocket();
+      g_connectBackoffMs *= 2;
+      if (g_connectBackoffMs > CAM_CONNECT_MAX_MS) g_connectBackoffMs = CAM_CONNECT_MAX_MS;
+      return;
+    }
     sendAuth();
     g_inflightLen = 0;
+    g_connectBackoffMs = CAM_CONNECT_MIN_MS;  // reset on success
   }
 
   int budget = CAM_READ_BUDGET;
@@ -224,6 +256,7 @@ bool cameraGetLatestFrame(const uint8_t** buf, size_t* len, uint32_t* frameId) {
 
 bool cameraCanStreamDisplayedPrinter() { return false; }
 bool cameraDisplayedHasCameraTile() { return false; }
+bool cameraStreamingDisplayed() { return true; }
 void cameraBegin() {}
 void cameraStop() {}
 bool cameraActive() { return false; }

--- a/src/camera_client.cpp
+++ b/src/camera_client.cpp
@@ -1,0 +1,233 @@
+// ===========================================================================
+//  camera_client.cpp  -  Bambu P1/A1 LAN camera (issue #120). See header.
+//  Real impl is BOARD_HAS_CAMERA only; stubs elsewhere keep all envs linking.
+// ===========================================================================
+#include "camera_client.h"
+#include "config.h"
+
+#if defined(BOARD_HAS_CAMERA)
+
+#include <WiFiClientSecure.h>
+#include <esp_heap_caps.h>
+#include <esp_task_wdt.h>
+#include "bambu_state.h"
+#include "bambu_mqtt.h"
+#include "settings.h"
+
+// --- tunables --------------------------------------------------------------
+static const uint16_t CAM_PORT          = 6000;
+static const uint32_t CAM_BUF_SIZE      = 200 * 1024;  // max single JPEG (PSRAM)
+static const uint32_t CAM_CONNECT_EVERY = 2000;        // ms between connect tries
+static const uint8_t  CAM_TLS_TIMEOUT_S = 5;
+static const int      CAM_READ_BUDGET   = 16 * 1024;   // max bytes drained / loop
+static const size_t   CAM_CHUNK         = 1460;
+
+// --- state -----------------------------------------------------------------
+static bool              g_active = false;
+static WiFiClientSecure* g_tls    = nullptr;
+
+static uint8_t* g_inflight = nullptr;   // accumulates until a full SOI..EOI
+static uint32_t g_inflightLen = 0;
+static uint8_t* g_published = nullptr;  // last complete frame (stable for draw)
+static uint32_t g_publishedLen = 0;
+static uint32_t g_frameId = 0;
+
+static char g_ip[16]         = {0};
+static char g_accessCode[12] = {0};
+static unsigned long g_lastConnectMs = 0;
+
+// ---------------------------------------------------------------------------
+//  Gates
+// ---------------------------------------------------------------------------
+// P1S=01P, P1P=01S, A1=039, A1mini=030 (per Bambu serial-prefix table).
+static bool isP1A1Serial(const char* s) {
+  if (!s || strlen(s) < 3) return false;
+  return strncmp(s, "01P", 3) == 0 || strncmp(s, "01S", 3) == 0 ||
+         strncmp(s, "039", 3) == 0 || strncmp(s, "030", 3) == 0;
+}
+
+bool cameraCanStreamDisplayedPrinter() {
+  // Camera is a 2nd/3rd TLS socket. The spike proved 2 MQTT + camera (3 TLS)
+  // coexist fine on the 8MB PSRAM boards, so allow up to 2 live connections
+  // (= max 3 TLS, the proven ceiling); cap there to avoid the untested 4-printer
+  // + camera case. cameraService() also heap-gates each connect as a backstop.
+  if (getActiveConnCount() > 2) return false;
+  PrinterSlot& p = displayedPrinter();
+  if (!p.state.connected) return false;
+  if (p.config.mode != CONN_LOCAL) return false;
+  const char* ip = p.config.ip[0] ? p.config.ip : p.state.localIp;
+  if (!ip[0] || !p.config.accessCode[0]) return false;
+  if (!isP1A1Serial(p.config.serial)) return false;
+  return true;
+}
+
+bool cameraDisplayedHasCameraTile() {
+  PrinterConfig& c = displayedPrinter().config;
+  for (uint8_t i = 0; i < GAUGE_SLOT_COUNT; i++)
+    if (c.gaugeSlots[i] == GAUGE_CAMERA) return true;
+  for (uint8_t i = 0; i < LANDSCAPE_EXTRA_COUNT; i++)
+    if (c.landscapeExtras[i] == GAUGE_CAMERA) return true;
+  for (uint8_t i = 0; i < PORTRAIT_EXTRA_COUNT; i++)
+    if (c.portraitExtras[i] == GAUGE_CAMERA) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+//  Buffers
+// ---------------------------------------------------------------------------
+static void freeBuffers() {
+  if (g_inflight)  { heap_caps_free(g_inflight);  g_inflight  = nullptr; }
+  if (g_published) { heap_caps_free(g_published); g_published = nullptr; }
+  g_inflightLen = 0;
+  g_publishedLen = 0;
+}
+
+static bool allocBuffers() {
+  if (g_inflight && g_published) return true;
+  g_inflight  = (uint8_t*)heap_caps_malloc(CAM_BUF_SIZE, MALLOC_CAP_SPIRAM);
+  g_published = (uint8_t*)heap_caps_malloc(CAM_BUF_SIZE, MALLOC_CAP_SPIRAM);
+  if (!g_inflight || !g_published) { freeBuffers(); return false; }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+//  Protocol
+// ---------------------------------------------------------------------------
+// 80-byte bblp auth: 4x uint32 LE {0x40, 0x3000, 0, 0} + "bblp" padded to 32 +
+// access code padded to 32. (Source: bambu-connect CameraClient.py; verified on
+// a real P1S during the issue-#120 spike.)
+static void sendAuth() {
+  uint8_t pkt[80];
+  memset(pkt, 0, sizeof(pkt));
+  uint32_t hdr[4] = { 0x40, 0x3000, 0, 0 };
+  memcpy(pkt, hdr, 16);
+  memcpy(pkt + 16, "bblp", 4);
+  size_t acl = strlen(g_accessCode);
+  if (acl > 32) acl = 32;
+  memcpy(pkt + 48, g_accessCode, acl);
+  g_tls->write(pkt, sizeof(pkt));
+}
+
+// Find 2-byte JPEG marker (0xFF, second) in buf[from..len); index or -1.
+static int findMarker(const uint8_t* buf, uint32_t len, uint32_t from, uint8_t second) {
+  if (len < 2) return -1;
+  for (uint32_t i = from; i + 1 < len; i++)
+    if (buf[i] == 0xFF && buf[i + 1] == second) return (int)i;
+  return -1;
+}
+
+static void publishFrame(uint32_t frameLen) {
+  memcpy(g_published, g_inflight, frameLen);
+  g_publishedLen = frameLen;
+  g_frameId++;
+}
+
+// Pull complete JPEGs out of g_inflight, keeping it anchored at an SOI.
+static void sliceFrames() {
+  for (;;) {
+    int soi = findMarker(g_inflight, g_inflightLen, 0, 0xD8);  // FFD8
+    if (soi < 0) {
+      if (g_inflightLen > 0 && g_inflight[g_inflightLen - 1] == 0xFF) {
+        g_inflight[0] = 0xFF; g_inflightLen = 1;  // keep split marker
+      } else {
+        g_inflightLen = 0;
+      }
+      return;
+    }
+    if (soi > 0) { memmove(g_inflight, g_inflight + soi, g_inflightLen - soi); g_inflightLen -= soi; }
+    int eoi = findMarker(g_inflight, g_inflightLen, 2, 0xD9);  // FFD9
+    if (eoi < 0) return;  // wait for more bytes
+    uint32_t frameLen = (uint32_t)eoi + 2;
+    publishFrame(frameLen);
+    uint32_t rem = g_inflightLen - frameLen;
+    if (rem) memmove(g_inflight, g_inflight + frameLen, rem);
+    g_inflightLen = rem;
+  }
+}
+
+static void teardownSocket() {
+  if (g_tls) { g_tls->stop(); delete g_tls; g_tls = nullptr; }
+  g_inflightLen = 0;
+}
+
+// ---------------------------------------------------------------------------
+//  Lifecycle
+// ---------------------------------------------------------------------------
+void cameraBegin() {
+  if (g_active) return;
+  if (!cameraCanStreamDisplayedPrinter()) return;
+  PrinterSlot& p = displayedPrinter();
+  const char* ip = p.config.ip[0] ? p.config.ip : p.state.localIp;
+  if (!allocBuffers()) return;
+  strlcpy(g_ip, ip, sizeof(g_ip));
+  strlcpy(g_accessCode, p.config.accessCode, sizeof(g_accessCode));
+  g_inflightLen = 0;
+  g_publishedLen = 0;
+  g_frameId = 0;
+  g_lastConnectMs = 0;
+  g_active = true;
+}
+
+void cameraStop() {
+  g_active = false;
+  teardownSocket();
+  freeBuffers();
+}
+
+bool cameraActive() { return g_active; }
+
+void cameraService() {
+  if (!g_active) return;
+
+  if (!g_tls || !g_tls->connected()) {
+    unsigned long now = millis();
+    if (now - g_lastConnectMs < CAM_CONNECT_EVERY) return;  // rate-limit blocking connect
+    g_lastConnectMs = now;
+    if (ESP.getFreeHeap() < BAMBU_MIN_FREE_HEAP) return;
+    if (!g_tls) {
+      g_tls = new (std::nothrow) WiFiClientSecure();
+      if (!g_tls) return;
+      g_tls->setInsecure();
+      g_tls->setTimeout(CAM_TLS_TIMEOUT_S);
+    }
+    esp_task_wdt_reset();
+    if (!g_tls->connect(g_ip, CAM_PORT)) { teardownSocket(); return; }
+    sendAuth();
+    g_inflightLen = 0;
+  }
+
+  int budget = CAM_READ_BUDGET;
+  uint8_t chunk[CAM_CHUNK];
+  while (budget > 0 && g_tls->available()) {
+    int want = g_tls->available();
+    if (want > (int)CAM_CHUNK) want = CAM_CHUNK;
+    if (want > budget) want = budget;
+    int n = g_tls->read(chunk, want);
+    if (n <= 0) break;
+    budget -= n;
+    if (g_inflightLen + (uint32_t)n > CAM_BUF_SIZE) g_inflightLen = 0;  // desync reset
+    memcpy(g_inflight + g_inflightLen, chunk, n);
+    g_inflightLen += (uint32_t)n;
+    sliceFrames();
+  }
+}
+
+bool cameraGetLatestFrame(const uint8_t** buf, size_t* len, uint32_t* frameId) {
+  if (!g_publishedLen) return false;
+  *buf = g_published;
+  *len = g_publishedLen;
+  *frameId = g_frameId;
+  return true;
+}
+
+#else  // ---- non-camera boards: no-op stubs ---------------------------------
+
+bool cameraCanStreamDisplayedPrinter() { return false; }
+bool cameraDisplayedHasCameraTile() { return false; }
+void cameraBegin() {}
+void cameraStop() {}
+bool cameraActive() { return false; }
+void cameraService() {}
+bool cameraGetLatestFrame(const uint8_t**, size_t*, uint32_t*) { return false; }
+
+#endif

--- a/src/camera_client.h
+++ b/src/camera_client.h
@@ -1,0 +1,40 @@
+// ===========================================================================
+//  camera_client.h  -  Bambu P1/A1 LAN camera (issue #120)
+// ---------------------------------------------------------------------------
+//  Streams the chamber-image MJPEG from a LAN-mode P1/A1 printer (port 6000,
+//  TLS, "bblp" auth, FFD8..FFD9 frames) and exposes the latest complete JPEG
+//  for the UI to decode with tft.drawJpg.
+//
+//  Real implementation is gated to BOARD_HAS_CAMERA (jc3248w535 / ws_lcd_350,
+//  i.e. PSRAM + touch). Every other board gets no-op stubs so all envs link.
+// ===========================================================================
+#ifndef CAMERA_CLIENT_H
+#define CAMERA_CLIENT_H
+
+#include <Arduino.h>
+#include <stddef.h>
+
+// --- Gates -----------------------------------------------------------------
+// True only when a 2nd TLS socket to a P1/A1 camera is sane: camera board,
+// exactly one live MQTT connection (TLS/heap budget), displayed printer is a
+// LAN-mode P1/A1 with an access code. Called by every draw/service path.
+bool cameraCanStreamDisplayedPrinter();
+
+// True when the displayed printer has a GAUGE_CAMERA tile in any slot.
+bool cameraDisplayedHasCameraTile();
+
+// --- Lifecycle -------------------------------------------------------------
+void cameraBegin();    // start streaming the displayed printer (no-op if gate fails)
+void cameraStop();     // tear down socket + free buffers (returns heap to baseline)
+bool cameraActive();
+
+// Per-loop bounded, non-blocking socket service. No-op when inactive.
+void cameraService();
+
+// Read-only pointer to the latest fully published JPEG frame. Stable until the
+// next cameraService() publishes a new one (single-loop model: draw and service
+// never overlap). frameId is monotonic so renderers can detect a new frame.
+// Returns false if no frame yet.
+bool cameraGetLatestFrame(const uint8_t** buf, size_t* len, uint32_t* frameId);
+
+#endif // CAMERA_CLIENT_H

--- a/src/camera_client.h
+++ b/src/camera_client.h
@@ -15,13 +15,19 @@
 #include <stddef.h>
 
 // --- Gates -----------------------------------------------------------------
-// True only when a 2nd TLS socket to a P1/A1 camera is sane: camera board,
-// exactly one live MQTT connection (TLS/heap budget), displayed printer is a
-// LAN-mode P1/A1 with an access code. Called by every draw/service path.
+// True only when a 2nd/3rd TLS socket to a P1/A1 camera is sane: camera board,
+// at most 2 live MQTT connections (3 TLS, the proven ceiling), displayed printer
+// is a LAN-mode P1/A1 with an access code. Called by every draw/service path.
 bool cameraCanStreamDisplayedPrinter();
 
-// True when the displayed printer has a GAUGE_CAMERA tile in any slot.
+// True when the displayed printer has a GAUGE_CAMERA tile in a slot that is
+// actually visible in the current layout (standard grid always; extras only in
+// their active 8/9-slot mode).
 bool cameraDisplayedHasCameraTile();
+
+// True if not streaming, or streaming the IP of the currently displayed printer.
+// The loop stops a mismatched stream so frames never belong to a stale printer.
+bool cameraStreamingDisplayed();
 
 // --- Lifecycle -------------------------------------------------------------
 void cameraBegin();    // start streaming the displayed printer (no-op if gate fails)

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -510,6 +510,16 @@ static FontID fitHumidityValueFont(lgfx::LovyanGFX& gfx, const char* value,
 // needed.
 static void setGaugeClearedTextColor(lgfx::LovyanGFX& gfx,
                                      uint16_t fg, uint16_t bg) {
+#if defined(BOARD_IS_JC3248W535)
+  // Transparent value text fixed the smaller dual-printer gauges in PORTRAIT,
+  // but the rotated (landscape) JC sprite renders transparent antialiased text
+  // black. Keep the explicit background in landscape, where the opaque box was
+  // always fine; stay transparent in portrait.
+  if (dispSettings.rotation == 1 || dispSettings.rotation == 3) {
+    gfx.setTextColor(fg, bg);
+    return;
+  }
+#endif
   (void)bg;
   gfx.setTextColor(fg);
 }

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -169,6 +169,7 @@ bool tileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p) {
     case GAUGE_HEATBREAK:     return s.heatbreakFanPct != p.heatbreakFanPct;
     case GAUGE_CLOCK:         return true;   // text cache gates the actual redraw
     case GAUGE_POWER:         return true;   // watts live outside BambuState
+    case GAUGE_CAMERA:        return false;  // never streams in split (multi-printer); placeholder only
     case GAUGE_LAYER:         return s.layerNum != p.layerNum || s.totalLayers != p.totalLayers;
     default: break;
   }
@@ -262,6 +263,9 @@ void drawTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
     case GAUGE_POWER:
       drawPowerGauge(tft, cx, cy, r, tasmotaGetWattsForSlot(slotIndex),
                      tasmotaIsActiveForSlot(slotIndex), "Power", fr);
+      break;
+    case GAUGE_CAMERA:
+      drawCameraGauge(cx, cy, r, fr);  // inert placeholder in split (camera disabled with 2+ printers)
       break;
     case GAUGE_EMPTY:
       if (fr) tft.fillCircle(cx, cy, r + 2, CLR_BG);

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2381,14 +2381,14 @@ void drawCameraGauge(int16_t cx, int16_t cy, int16_t radius, bool forceRedraw) {
     tft.drawRect(x0, y0, box, box, dispSettings.trackColor);
     setFont(tft, FONT_SMALL);
     tft.setTextDatum(MC_DATUM);
-    tft.setTextColor(dispSettings.trackColor, dispSettings.bgColor);
+    tft.setTextColor(CLR_TEXT, dispSettings.bgColor);  // bright CAM label (hardcoded)
     tft.drawString(cameraActive() ? "..." : "CAM", cx, cy);
   }
 
   const bool sm = dispSettings.smallLabels;
   setFont(tft, sm ? FONT_SMALL : FONT_BODY);
   tft.setTextDatum(MC_DATUM);
-  tft.setTextColor(dispSettings.trackColor, dispSettings.bgColor);
+  tft.setTextColor(CLR_TEXT, dispSettings.bgColor);  // bright CAM label (hardcoded)
   tft.drawString("CAM", cx, cy + radius + (sm ? 3 : -1));
 }
 

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -13,6 +13,7 @@
 #include "tasmota.h"
 #include "fonts.h"
 #include "battery.h"
+#include "camera_client.h"
 #include <WiFi.h>
 #include <time.h>
 #if defined(BOARD_IS_SENSECAP) || defined(BOARD_IS_WS350)
@@ -2342,6 +2343,74 @@ static void computeSlotGrid(SlotGrid& g, const PrinterConfig& cfg, bool landscap
 //  Screen: Printing (main dashboard)
 //  Layout: LED bar | header | 2x3 gauge grid | info line
 // ---------------------------------------------------------------------------
+#if defined(BOARD_HAS_CAMERA)
+// ===========================================================================
+//  Camera (#120): thumbnail tile + fullscreen. Source = P1/A1 chamber image
+//  (~1280x720, 16:9). Tile shows a periodic still; fullscreen is live.
+// ===========================================================================
+static const float         CAM_SRC_W = 1280.0f;
+static const float         CAM_SRC_H = 720.0f;
+static const unsigned long CAM_TILE_INTERVAL_MS = 3000;  // periodic-still cadence
+static unsigned long s_camTileLastMs  = 0;
+static uint32_t      s_camTileLastFid = 0xFFFFFFFFu;
+
+// Tile wants a redraw when a new still is due (cadence-throttled).
+static bool cameraTileNeedsRedraw() {
+  if (!cameraActive()) return false;
+  const uint8_t* b; size_t l; uint32_t fid;
+  if (!cameraGetLatestFrame(&b, &l, &fid)) return false;
+  if (fid == s_camTileLastFid) return false;
+  return (millis() - s_camTileLastMs) >= CAM_TILE_INTERVAL_MS;
+}
+
+void drawCameraGauge(int16_t cx, int16_t cy, int16_t radius, bool forceRedraw) {
+  const int16_t box = radius * 2;
+  const int16_t x0 = cx - radius, y0 = cy - radius;
+  if (forceRedraw) tft.fillRect(x0 - 2, y0 - 2, box + 4, box + 4, dispSettings.bgColor);
+
+  const uint8_t* buf; size_t len; uint32_t fid;
+  if (cameraActive() && cameraGetLatestFrame(&buf, &len, &fid)) {
+    const float sc = (float)box / CAM_SRC_W;          // contain by width (16:9)
+    const int dw = (int)(CAM_SRC_W * sc), dh = (int)(CAM_SRC_H * sc);
+    tft.fillRect(x0, y0, box, box, TFT_BLACK);        // viewport letterbox
+    tft.drawJpg(buf, (uint32_t)len, cx - dw / 2, cy - dh / 2, 0, 0, 0, 0, sc, sc);
+    s_camTileLastMs = millis();
+    s_camTileLastFid = fid;
+  } else {
+    tft.fillRect(x0, y0, box, box, dispSettings.bgColor);
+    tft.drawRect(x0, y0, box, box, dispSettings.trackColor);
+    setFont(tft, FONT_SMALL);
+    tft.setTextDatum(MC_DATUM);
+    tft.setTextColor(dispSettings.trackColor, dispSettings.bgColor);
+    tft.drawString(cameraActive() ? "..." : "CAM", cx, cy);
+  }
+
+  const bool sm = dispSettings.smallLabels;
+  setFont(tft, sm ? FONT_SMALL : FONT_BODY);
+  tft.setTextDatum(MC_DATUM);
+  tft.setTextColor(dispSettings.trackColor, dispSettings.bgColor);
+  tft.drawString("CAM", cx, cy + radius + (sm ? 3 : -1));
+}
+
+// Fullscreen live view: rotation-aware contain-fit, redraw on new frame only.
+static void drawCameraFullscreen() {
+  static uint32_t lastFid = 0xFFFFFFFFu;
+  const uint8_t* buf; size_t len; uint32_t fid;
+  if (!cameraGetLatestFrame(&buf, &len, &fid)) return;
+  if (fid == lastFid) return;
+  lastFid = fid;
+  const float sw = tft.width(), sh = tft.height();
+  float sc = sw / CAM_SRC_W;
+  if (sh / CAM_SRC_H < sc) sc = sh / CAM_SRC_H;  // contain = min(wfit, hfit)
+  const int dw = (int)(CAM_SRC_W * sc), dh = (int)(CAM_SRC_H * sc);
+  tft.fillScreen(TFT_BLACK);
+  tft.drawJpg(buf, (uint32_t)len, ((int)sw - dw) / 2, ((int)sh - dh) / 2, 0, 0, 0, 0, sc, sc);
+  markFrameDirty();
+}
+#else
+void drawCameraGauge(int16_t, int16_t, int16_t, bool) {}
+#endif
+
 static void drawPrinting() {
   PrinterSlot& p = displayedPrinter();
   BambuState& s = p.state;
@@ -2635,6 +2704,9 @@ static void drawPrinting() {
           case GAUGE_HEATBREAK:     needDraw = animating || s.heatbreakFanPct != prevState.heatbreakFanPct; break;
           case GAUGE_CLOCK:       needDraw = true; break;  // text cache handles actual redraw
           case GAUGE_POWER:       needDraw = true; break;  // watts live in tasmota runtime; text cache + incremental arc gate the redraw
+#if defined(BOARD_HAS_CAMERA)
+          case GAUGE_CAMERA:      needDraw = cameraTileNeedsRedraw(); break;
+#endif
           case GAUGE_LAYER:       needDraw = s.layerNum != prevState.layerNum || s.totalLayers != prevState.totalLayers; break;
           default:
             // AMS humidity / temperature / filament gauges — index derived from enum value
@@ -2757,6 +2829,9 @@ static void drawPrinting() {
           drawPowerGauge(tft, cx, cy, gR,
                          tasmotaGetWattsForSlot(rotState.displayIndex),
                          tasmotaIsActiveForSlot(rotState.displayIndex), "Power", fr);
+          break;
+        case GAUGE_CAMERA:
+          drawCameraGauge(cx, cy, gR, fr);
           break;
         case GAUGE_EMPTY:
           if (fr) tft.fillCircle(cx, cy, gR + 2, dispSettings.bgColor);
@@ -3515,6 +3590,12 @@ void updateDisplay() {
 
     case SCREEN_SPLIT:
       drawSplit();
+      break;
+
+    case SCREEN_CAMERA:
+#if defined(BOARD_HAS_CAMERA)
+      drawCameraFullscreen();
+#endif
       break;
 
     case SCREEN_FINISHED:

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -19,7 +19,8 @@ enum ScreenState {
   SCREEN_CLOCK,
   SCREEN_OFF,
   SCREEN_OTA_UPDATE,
-  SCREEN_SPLIT          // two printers side-by-side (top/bottom bands)
+  SCREEN_SPLIT,         // two printers side-by-side (top/bottom bands)
+  SCREEN_CAMERA         // fullscreen P1/A1 chamber image (#120); tap to exit
 };
 
 // Forward declaration so split-related declarations below can take an AmsState
@@ -75,5 +76,10 @@ bool isDisplayForceRedraw();
 // in display_ui.cpp; exported so the split renderer can draw it inside a band.
 void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
                       const AmsState& ams, uint8_t unitIndex, bool forceRedraw);
+
+// Camera thumbnail tile (#120). Draws the latest chamber-image still into the
+// slot, or a placeholder when not streaming. Exported so the split renderer can
+// draw the inert placeholder inside a band. No-op visual on non-camera boards.
+void drawCameraGauge(int16_t cx, int16_t cy, int16_t radius, bool forceRedraw);
 
 #endif // DISPLAY_UI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "led.h"
 #include "tasmota.h"
 #include "battery.h"
+#include "camera_client.h"
 #include <esp_sleep.h>
 #include <driver/gpio.h>
 
@@ -194,6 +195,22 @@ static void doTapActions() {
     }
     return;
   }
+
+#if defined(BOARD_HAS_CAMERA)
+  // Camera tap toggle (#120): tap the camera fullscreen to exit; tap the
+  // printing screen (when it carries a camera tile and the printer can stream)
+  // to enter fullscreen. No-conflict with printer-cycle below: that needs 2+
+  // connections, which the camera gate forbids.
+  if (cur == SCREEN_CAMERA) {
+    setScreenState(SCREEN_PRINTING);
+    return;
+  }
+  if (cur == SCREEN_PRINTING && cameraDisplayedHasCameraTile() &&
+      cameraCanStreamDisplayedPrinter()) {
+    setScreenState(SCREEN_CAMERA);
+    return;
+  }
+#endif
 
   if (getActiveConnCount() >= 2) {
     cycleDisplayedPrinterFromButton();
@@ -405,6 +422,17 @@ static void updateDisplayedPrinterScreenState() {
     }
     return;
   }
+
+#if defined(BOARD_HAS_CAMERA)
+  // Camera fullscreen (#120) is sticky: entered/exited only by tap. Hold it
+  // until the user taps out or the printer can no longer stream, then drop back
+  // to the normal flow (which re-derives the screen next loop).
+  if (current == SCREEN_CAMERA) {
+    if (cameraCanStreamDisplayedPrinter()) return;
+    setScreenState(SCREEN_PRINTING);
+    return;
+  }
+#endif
 
   // Global drying-wake: if any fresh printer state is drying, leave sleep-sticky
   // screens regardless of which slot is currently displayed. Point displayIndex
@@ -803,6 +831,22 @@ void loop() {
   Battery::tick();
   ledTick();
   checkNightMode();
+
+#if defined(BOARD_HAS_CAMERA)
+  // Camera (#120): open the 2nd TLS socket only while the camera UI is on
+  // screen (fullscreen, or printing screen carrying a camera tile) and the
+  // printer can stream; close it otherwise so heap returns to baseline.
+  // Serviced (bounded, non-blocking) before the draw so the frame is fresh.
+  {
+    bool wantCamera = cameraCanStreamDisplayedPrinter() &&
+        (getScreenState() == SCREEN_CAMERA ||
+         (getScreenState() == SCREEN_PRINTING && cameraDisplayedHasCameraTile()));
+    if (wantCamera && !cameraActive())      cameraBegin();
+    else if (!wantCamera && cameraActive()) cameraStop();
+    cameraService();
+  }
+#endif
+
   updateDisplay();
 
   // MQTT and rotation after display update - TLS reconnect can block for

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,12 +197,13 @@ static void doTapActions() {
   }
 
 #if defined(BOARD_HAS_CAMERA)
-  // Camera tap toggle (#120): tap the camera fullscreen to exit; tap the
-  // printing screen (when it carries a camera tile and the printer can stream)
-  // to enter fullscreen. No-conflict with printer-cycle below: that needs 2+
-  // connections, which the camera gate forbids.
+  // Camera tap toggle (#120). On a multi-printer setup the camera sits in the
+  // tap cycle for the printer that carries the tile: tapping that printer opens
+  // fullscreen, and tapping out advances to the next printer (so the cycle keeps
+  // moving instead of stranding the user here until the next auto-rotate).
   if (cur == SCREEN_CAMERA) {
     setScreenState(SCREEN_PRINTING);
+    if (getActiveConnCount() >= 2) cycleDisplayedPrinterFromButton();
     return;
   }
   if (cur == SCREEN_PRINTING && cameraDisplayedHasCameraTile() &&
@@ -833,17 +834,17 @@ void loop() {
   checkNightMode();
 
 #if defined(BOARD_HAS_CAMERA)
-  // Camera (#120): open the 2nd TLS socket only while the camera UI is on
-  // screen (fullscreen, or printing screen carrying a camera tile) and the
-  // printer can stream; close it otherwise so heap returns to baseline.
-  // Serviced (bounded, non-blocking) before the draw so the frame is fresh.
+  // Camera (#120) lifecycle (cheap, non-blocking): open the 2nd TLS socket only
+  // while the camera UI is on screen (fullscreen, or printing screen with a
+  // visible camera tile) and the printer can stream; close it otherwise so heap
+  // returns to baseline, or if rotation moved the displayed printer out from
+  // under an open stream. The blocking socket work runs in the tail below.
   {
     bool wantCamera = cameraCanStreamDisplayedPrinter() &&
         (getScreenState() == SCREEN_CAMERA ||
          (getScreenState() == SCREEN_PRINTING && cameraDisplayedHasCameraTile()));
-    if (wantCamera && !cameraActive())      cameraBegin();
-    else if (!wantCamera && cameraActive()) cameraStop();
-    cameraService();
+    if (cameraActive() && (!wantCamera || !cameraStreamingDisplayed())) cameraStop();
+    if (wantCamera && !cameraActive())                                  cameraBegin();
   }
 #endif
 
@@ -855,8 +856,16 @@ void loop() {
   // and a concurrent second TLS session to Bambu Cloud is unsupported.
   if (isWiFiConnected() && !isAPMode() && isAnyPrinterConfigured() && !isOtaAutoInProgress()) {
     handleBambuMqtt();
-    handleRotation();
+    // Freeze auto-rotation while the camera fullscreen is up so the displayed
+    // printer (and its stream) does not drift out from under the view.
+    if (getScreenState() != SCREEN_CAMERA) handleRotation();
   }
+
+#if defined(BOARD_HAS_CAMERA)
+  // Blocking camera socket work (connect can stall up to the TLS timeout) - run
+  // last, alongside the MQTT tail, so a stalled connect never delays UI or MQTT.
+  cameraService();
+#endif
 
   // Commit the framebuffer sprite to the panel. On JC3248W535 this is a
   // ~20ms QSPI push (300 KB @ 32MHz QIO); on all other boards it's a no-op

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -861,14 +861,16 @@ void loop() {
     if (getScreenState() != SCREEN_CAMERA) handleRotation();
   }
 
-#if defined(BOARD_HAS_CAMERA)
-  // Blocking camera socket work (connect can stall up to the TLS timeout) - run
-  // last, alongside the MQTT tail, so a stalled connect never delays UI or MQTT.
-  cameraService();
-#endif
-
   // Commit the framebuffer sprite to the panel. On JC3248W535 this is a
   // ~20ms QSPI push (300 KB @ 32MHz QIO); on all other boards it's a no-op
   // since draws go directly to the panel.
   flushFrame();
+
+#if defined(BOARD_HAS_CAMERA)
+  // Blocking camera socket work (connect can stall up to the TLS timeout) runs
+  // dead last - AFTER flushFrame() - so on the framebuffer board (JC3248W535,
+  // where draws are only visible once pushed) a stalled connect never delays the
+  // already-rendered frame, only the start of the next loop.
+  cameraService();
+#endif
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -38,6 +38,7 @@ enum GaugeType : uint8_t {
   GAUGE_NOZZLE_RIGHT   = 29,    // dual-nozzle (H2D/H2C/X2D): right extruder (id 0), fixed side
   GAUGE_NOZZLE_LEFT    = 30,    // dual-nozzle: left extruder (id 1), fixed side
   GAUGE_POWER          = 31,    // Tasmota smart-plug live power draw (W / kW)
+  GAUGE_CAMERA         = 32,    // P1/A1 LAN chamber-image thumbnail (PSRAM+touch boards)
   GAUGE_TYPE_COUNT  // sentinel - always last
 };
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -660,6 +660,19 @@ static void handlePrinterConfig() {
   doc["hasExhaustFan"]  = (st.airductFuncs & (1u << 2)) != 0;  // X2D + H2C
   doc["hasDualNozzle"]  = st.dualNozzle;                       // H2D/H2C/X2D per-nozzle temp gauges
   doc["hasTasmota"]     = tasmotaConfiguredForSlot(slot);      // gates the Power gauge option
+#if defined(BOARD_HAS_CAMERA)
+  // Camera gauge: only LAN-mode P1/A1 with an access code serve the port-6000
+  // chamber image. (P1S=01P, P1P=01S, A1=039, A1mini=030.)
+  {
+    const char* cs = cfg.serial;
+    bool p1a1 = strlen(cs) >= 3 &&
+                (strncmp(cs, "01P", 3) == 0 || strncmp(cs, "01S", 3) == 0 ||
+                 strncmp(cs, "039", 3) == 0 || strncmp(cs, "030", 3) == 0);
+    doc["hasLanCamera"] = (cfg.mode == CONN_LOCAL) && cfg.accessCode[0] && p1a1;
+  }
+#else
+  doc["hasLanCamera"] = false;
+#endif
   JsonArray slots = doc["gaugeSlots"].to<JsonArray>();
   for (uint8_t g = 0; g < GAUGE_SLOT_COUNT; g++) slots.add(cfg.gaugeSlots[g]);
   JsonArray lext = doc["landscapeExtras"].to<JsonArray>();


### PR DESCRIPTION
## Summary

Adds an optional **Camera** view for Bambu **P1/A1** printers on the PSRAM + touch boards (jc3248w535, ws_lcd_350): a thumbnail tile on the printing screen plus a tap-to-fullscreen live view of the chamber image. Refs #120 (kept open until release bins ship).

The camera is served over the printer's LAN port-6000 TLS MJPEG stream (the only ESP32-decodable Bambu camera transport). X1/H2/H2C use H.264 and are not decodable on the ESP32; cloud-mode printers do not expose the stream on the LAN. The feature is gated accordingly.

## What it does

- **Tile (`GAUGE_CAMERA`)**: periodic-still thumbnail on the printing screen; inert placeholder in split view and when not streaming.
- **Fullscreen (`SCREEN_CAMERA`)**: rotation-aware contain-fit live view (~1-2 fps). Binary tap toggles in and out; on multi-printer setups exiting advances to the next printer. The orchestrator keeps it sticky, freezes auto-rotation while open, and tears the socket down on every exit.
- **Web UI**: the Camera gauge option appears only for LAN-mode P1/A1 slots that have an access code (`hasLanCamera` capability in `/printer/config`).

## Implementation

- New `camera_client.{h,cpp}`: lazy 2nd `WiFiClientSecure` (`setInsecure`), 80-byte bblp auth, `FFD8..FFD9` frame slicing into a PSRAM double buffer, bounded non-blocking reads, heap-gated connect with a growing backoff, serviced after `flushFrame()` so a stalled connect never delays visible UI. Decode is via LovyanGFX `drawJpg`, downscaled while decoding.
- Compiled behind a dedicated `BOARD_HAS_CAMERA` macro (not the broader `BOARD_HAS_PSRAM`); every other env links no-op stubs.
- Streaming allowed with up to 2 live MQTT connections (3 concurrent TLS, the ceiling verified on hardware); the heap gate is the backstop. The stream is stopped/rebound if rotation moves the displayed printer.

## Boards / testing

- **jc3248w535**: hardware-verified on a real P1S (tile, tap-to-fullscreen, tap-to-exit, multi-printer tap cycle, heap stays well above the gate with MQTT connected).
- **ws_lcd_350**: builds, camera enabled; not hardware-tested (community board).
- Non-PSRAM build (esp32c3) verified to link the stubs; daily-driver ws_lcd_200 flashed to confirm no regression on a non-camera board.

## Note on commit range

The branch also carries two already-reviewed commits that the remote `main` was behind on: the v3.7 README docs and the landscape gauge-digit fix. The camera work is the `feat(camera)` / `fix(camera)` commits.