### PR TITLE
feat(gauges): custom labels for all gauges

### DIFF
--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -81,7 +81,8 @@ function saveWifi(){
 //              clk_size, clk_hidedate, noz_max, bed_max, cht_max, pwr_max,
 //              gsmooth, warn_thr, warn_clr,
 //              clr_bg, clr_track, clr_pbar, bulk_a/l/v,
-//              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk + _a/_l/_v
+//              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk/pwr/lyr + _a/_l/_v,
+//              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk/pwr/lyr/clk/ams/nzr/nzl + _lbl
 //    Hardware: rotmode, rotinterval, btntype, btnpin, buzzen (DOUBLE Z!),
 //              buzpin, buzqs, buzqe, buzclick, buzbeden, buzbedtemp, leden,
 //              ledpin, ledbr, ledfxmd, ledfxsec, ledfxbr, ledauto, ledpause,
@@ -519,11 +520,21 @@ button, input, select, textarea { font-family: inherit; font-size: inherit; colo
 .row-divider::before, .row-divider::after { content: ""; flex: 1; height: 1px; background: var(--line-soft); }
 
 /* ============ Gauge color sub-rows ============ */
-.gauge-color-row { display: grid; grid-template-columns: minmax(120px, 1fr) auto auto auto; gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--line-soft); font-size: 12.5px; }
+/* name | custom-label input (fills the gap) | Arc | Label | Value */
+.gauge-color-row { display: grid; grid-template-columns: auto minmax(90px, 1fr) auto auto auto; gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--line-soft); font-size: 12.5px; }
 .gauge-color-row:last-child { border-bottom: none; }
-.gauge-color-row .name { color: var(--text); font-weight: 500; }
+.gauge-color-row .name { color: var(--text); font-weight: 500; white-space: nowrap; }
 .gauge-color-row .alv { display: flex; align-items: center; gap: 4px; }
 .gauge-color-row .alv span { font-size: 11px; color: var(--text-dim); }
+/* Custom-label input sits next to the gauge name. Fixed ~12-char width
+   (justify-self:start) so it doesn't stretch; the 1fr column absorbs the slack
+   and keeps the colour pickers right-aligned. */
+.gauge-color-row .lbl { grid-column: 2; grid-row: 1; max-width: 14ch; justify-self: start; font-size: 12.5px; padding: 6px 10px; }
+/* Label-only rows (Clock, AMS, Nozzle L/R): name + text input, no colour pickers. */
+.gauge-label-row { display: grid; grid-template-columns: auto minmax(90px, 1fr); gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--line-soft); font-size: 12.5px; }
+.gauge-label-row:last-child { border-bottom: none; }
+.gauge-label-row .name { color: var(--text); font-weight: 500; white-space: nowrap; }
+.gauge-label-row .lbl { max-width: 14ch; justify-self: start; font-size: 12.5px; padding: 6px 10px; }
 
 /* ============ Bulk color picker row (Gauge Colors) ============ */
 .bulk-color-row { display: flex; flex-wrap: wrap; gap: var(--sp-5); align-items: center; margin-bottom: var(--sp-3); }
@@ -572,6 +583,11 @@ button, input, select, textarea { font-family: inherit; font-size: inherit; colo
   .main { padding: var(--sp-5); }
   .section-title { display: none; }
   .row, .row-3 { grid-template-columns: 1fr; }
+  /* Gauge rows: name + colours on line 1, label input full-width on line 2. */
+  .gauge-color-row { grid-template-columns: minmax(110px, 1fr) auto auto auto; }
+  .gauge-color-row .lbl { grid-column: 1 / -1; grid-row: auto; max-width: none; justify-self: stretch; margin-top: 4px; }
+  .gauge-label-row { grid-template-columns: minmax(110px, 1fr) 1.4fr; }
+  .gauge-label-row .lbl { max-width: none; justify-self: stretch; }
 }
 
 /* ============ Utility ============ */
@@ -969,7 +985,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
 
   <details class="card card-collapsible">
     <summary>
-      <div><h3>Gauge Colors</h3><p>Pick a preset or paint individual gauges. Bulk pickers update the form only - click Apply to save.</p></div>
+      <div><h3>Gauge Appearance</h3><p>Pick a preset or paint individual gauges, and rename any gauge label. Bulk pickers update the form only - click Apply to save.</p></div>
     </summary>
     <div class="card-body">
       <div class="swatch-row">
@@ -994,23 +1010,28 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
 
       <div class="gauge-color-list">
         <div class="subhead">Per-gauge fine tuning</div>
-        <div class="gauge-color-row"><span class="name">Progress</span><div class="alv"><span>Arc</span><input type="color" id="prg_a" value="%PRG_A%"></div><div class="alv"><span>Label</span><input type="color" id="prg_l" value="%PRG_L%"></div><div class="alv"><span>Value</span><input type="color" id="prg_v" value="%PRG_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Nozzle</span><div class="alv"><span>Arc</span><input type="color" id="noz_a" value="%NOZ_A%"></div><div class="alv"><span>Label</span><input type="color" id="noz_l" value="%NOZ_L%"></div><div class="alv"><span>Value</span><input type="color" id="noz_v" value="%NOZ_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Bed</span><div class="alv"><span>Arc</span><input type="color" id="bed_a" value="%BED_A%"></div><div class="alv"><span>Label</span><input type="color" id="bed_l" value="%BED_L%"></div><div class="alv"><span>Value</span><input type="color" id="bed_v" value="%BED_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Part Fan</span><div class="alv"><span>Arc</span><input type="color" id="pfn_a" value="%PFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="pfn_l" value="%PFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="pfn_v" value="%PFN_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Aux Fan</span><div class="alv"><span>Arc</span><input type="color" id="afn_a" value="%AFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="afn_l" value="%AFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="afn_v" value="%AFN_V%"></div></div>
-        <div class="gauge-color-row gauge-x2d"><span class="name">Aux Fan Right (X2D)</span><div class="alv"><span>Arc</span><input type="color" id="afr_a" value="%AFR_A%"></div><div class="alv"><span>Label</span><input type="color" id="afr_l" value="%AFR_L%"></div><div class="alv"><span>Value</span><input type="color" id="afr_v" value="%AFR_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Chamber Fan</span><div class="alv"><span>Arc</span><input type="color" id="cfn_a" value="%CFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="cfn_l" value="%CFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="cfn_v" value="%CFN_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Exhaust Fan</span><div class="alv"><span>Arc</span><input type="color" id="exh_a" value="%EXH_A%"></div><div class="alv"><span>Label</span><input type="color" id="exh_l" value="%EXH_L%"></div><div class="alv"><span>Value</span><input type="color" id="exh_v" value="%EXH_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Chamber Temp</span><div class="alv"><span>Arc</span><input type="color" id="cht_a" value="%CHT_A%"></div><div class="alv"><span>Label</span><input type="color" id="cht_l" value="%CHT_L%"></div><div class="alv"><span>Value</span><input type="color" id="cht_v" value="%CHT_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Heatbreak Fan</span><div class="alv"><span>Arc</span><input type="color" id="hbk_a" value="%HBK_A%"></div><div class="alv"><span>Label</span><input type="color" id="hbk_l" value="%HBK_L%"></div><div class="alv"><span>Value</span><input type="color" id="hbk_v" value="%HBK_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Power</span><div class="alv"><span>Arc</span><input type="color" id="pwr_a" value="%PWR_A%"></div><div class="alv"><span>Label</span><input type="color" id="pwr_l" value="%PWR_L%"></div><div class="alv"><span>Value</span><input type="color" id="pwr_v" value="%PWR_V%"></div></div>
-        <div class="gauge-color-row"><span class="name">Layer</span><div class="alv"><span>Arc</span><input type="color" id="lyr_a" value="%LYR_A%"></div><div class="alv"><span>Label</span><input type="color" id="lyr_l" value="%LYR_L%"></div><div class="alv"><span>Value</span><input type="color" id="lyr_v" value="%LYR_V%"></div></div>
+        <div class="gauge-color-row"><span class="name">Progress</span><div class="alv"><span>Arc</span><input type="color" id="prg_a" value="%PRG_A%"></div><div class="alv"><span>Label</span><input type="color" id="prg_l" value="%PRG_L%"></div><div class="alv"><span>Value</span><input type="color" id="prg_v" value="%PRG_V%"></div><input type="text" class="lbl" id="prg_lbl" maxlength="12" value="%PRG_LBL%" placeholder="Progress"></div>
+        <div class="gauge-color-row"><span class="name">Nozzle</span><div class="alv"><span>Arc</span><input type="color" id="noz_a" value="%NOZ_A%"></div><div class="alv"><span>Label</span><input type="color" id="noz_l" value="%NOZ_L%"></div><div class="alv"><span>Value</span><input type="color" id="noz_v" value="%NOZ_V%"></div><input type="text" class="lbl" id="noz_lbl" maxlength="12" value="%NOZ_LBL%" placeholder="Nozzle"></div>
+        <div class="gauge-color-row"><span class="name">Bed</span><div class="alv"><span>Arc</span><input type="color" id="bed_a" value="%BED_A%"></div><div class="alv"><span>Label</span><input type="color" id="bed_l" value="%BED_L%"></div><div class="alv"><span>Value</span><input type="color" id="bed_v" value="%BED_V%"></div><input type="text" class="lbl" id="bed_lbl" maxlength="12" value="%BED_LBL%" placeholder="Bed"></div>
+        <div class="gauge-color-row"><span class="name">Part Fan</span><div class="alv"><span>Arc</span><input type="color" id="pfn_a" value="%PFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="pfn_l" value="%PFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="pfn_v" value="%PFN_V%"></div><input type="text" class="lbl" id="pfn_lbl" maxlength="12" value="%PFN_LBL%" placeholder="Part"></div>
+        <div class="gauge-color-row"><span class="name">Aux Fan</span><div class="alv"><span>Arc</span><input type="color" id="afn_a" value="%AFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="afn_l" value="%AFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="afn_v" value="%AFN_V%"></div><input type="text" class="lbl" id="afn_lbl" maxlength="12" value="%AFN_LBL%" placeholder="Aux"></div>
+        <div class="gauge-color-row gauge-x2d"><span class="name">Aux Fan Right (X2D)</span><div class="alv"><span>Arc</span><input type="color" id="afr_a" value="%AFR_A%"></div><div class="alv"><span>Label</span><input type="color" id="afr_l" value="%AFR_L%"></div><div class="alv"><span>Value</span><input type="color" id="afr_v" value="%AFR_V%"></div><input type="text" class="lbl" id="afr_lbl" maxlength="12" value="%AFR_LBL%" placeholder="R.Aux"></div>
+        <div class="gauge-color-row"><span class="name">Chamber Fan</span><div class="alv"><span>Arc</span><input type="color" id="cfn_a" value="%CFN_A%"></div><div class="alv"><span>Label</span><input type="color" id="cfn_l" value="%CFN_L%"></div><div class="alv"><span>Value</span><input type="color" id="cfn_v" value="%CFN_V%"></div><input type="text" class="lbl" id="cfn_lbl" maxlength="12" value="%CFN_LBL%" placeholder="Chamber"></div>
+        <div class="gauge-color-row"><span class="name">Exhaust Fan</span><div class="alv"><span>Arc</span><input type="color" id="exh_a" value="%EXH_A%"></div><div class="alv"><span>Label</span><input type="color" id="exh_l" value="%EXH_L%"></div><div class="alv"><span>Value</span><input type="color" id="exh_v" value="%EXH_V%"></div><input type="text" class="lbl" id="exh_lbl" maxlength="12" value="%EXH_LBL%" placeholder="Exhaust"></div>
+        <div class="gauge-color-row"><span class="name">Chamber Temp</span><div class="alv"><span>Arc</span><input type="color" id="cht_a" value="%CHT_A%"></div><div class="alv"><span>Label</span><input type="color" id="cht_l" value="%CHT_L%"></div><div class="alv"><span>Value</span><input type="color" id="cht_v" value="%CHT_V%"></div><input type="text" class="lbl" id="cht_lbl" maxlength="12" value="%CHT_LBL%" placeholder="Chamber"></div>
+        <div class="gauge-color-row"><span class="name">Heatbreak Fan</span><div class="alv"><span>Arc</span><input type="color" id="hbk_a" value="%HBK_A%"></div><div class="alv"><span>Label</span><input type="color" id="hbk_l" value="%HBK_L%"></div><div class="alv"><span>Value</span><input type="color" id="hbk_v" value="%HBK_V%"></div><input type="text" class="lbl" id="hbk_lbl" maxlength="12" value="%HBK_LBL%" placeholder="HBreak"></div>
+        <div class="gauge-color-row"><span class="name">Power</span><div class="alv"><span>Arc</span><input type="color" id="pwr_a" value="%PWR_A%"></div><div class="alv"><span>Label</span><input type="color" id="pwr_l" value="%PWR_L%"></div><div class="alv"><span>Value</span><input type="color" id="pwr_v" value="%PWR_V%"></div><input type="text" class="lbl" id="pwr_lbl" maxlength="12" value="%PWR_LBL%" placeholder="Power"></div>
+        <div class="gauge-color-row"><span class="name">Layer</span><div class="alv"><span>Arc</span><input type="color" id="lyr_a" value="%LYR_A%"></div><div class="alv"><span>Label</span><input type="color" id="lyr_l" value="%LYR_L%"></div><div class="alv"><span>Value</span><input type="color" id="lyr_v" value="%LYR_V%"></div><input type="text" class="lbl" id="lyr_lbl" maxlength="12" value="%LYR_LBL%" placeholder="Layer"></div>
+        <div class="gauge-label-row"><span class="name">Clock</span><input type="text" class="lbl" id="clk_lbl" maxlength="12" value="%CLK_LBL%" placeholder="Clock"></div>
+        <div class="gauge-label-row"><span class="name">AMS</span><input type="text" class="lbl" id="ams_lbl" maxlength="12" value="%AMS_LBL%" placeholder="AMS" title="Shown as 'Name 1'..'Name 4'"></div>
+        <div class="gauge-label-row"><span class="name">Nozzle R</span><input type="text" class="lbl" id="nzr_lbl" maxlength="12" value="%NZR_LBL%" placeholder="Nozzle R" title="Dual-nozzle right; empty = Nozzle name + R"></div>
+        <div class="gauge-label-row"><span class="name">Nozzle L</span><input type="text" class="lbl" id="nzl_lbl" maxlength="12" value="%NZL_LBL%" placeholder="Nozzle L" title="Dual-nozzle left; empty = Nozzle name + L"></div>
       </div>
 
       <div class="action-bar">
         <button type="button" class="btn btn-ghost btn-sm" onclick="randomGaugeColors()">Random</button>
         <button type="button" class="btn btn-ghost btn-sm" onclick="resetGaugeColors()">Reset to defaults</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="clearGaugeLabels()">Clear labels</button>
       </div>
     </div>
   </details>
@@ -2203,6 +2224,8 @@ function savePower(){
 
 /* ============ Display ============ */
 var GAUGE_KEYS = ['prg','noz','bed','pfn','afn','afr','cfn','exh','cht','hbk','pwr','lyr'];
+// Label override keys = the 12 colour gauges + Clock + AMS + Nozzle L/R (label-only rows).
+var GAUGE_LABEL_KEYS = GAUGE_KEYS.concat(['clk','ams','nzr','nzl']);
 var themes = {
   default:{bg:'#081018',track:'#182028',clkt:'#FFFFFF',clkd:'#C0C0C0',prg:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},noz:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},bed:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},pfn:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},afn:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},afr:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},cfn:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},exh:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},cht:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},hbk:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},pwr:{a:'#FFD600',l:'#FFD600',v:'#FFFFFF'},lyr:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'}},
   mono_green:{bg:'#000800',track:'#0A1A0A',clkt:'#00FF41',clkd:'#00CC33',prg:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},noz:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},bed:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},pfn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},afn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},afr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},cfn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},exh:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},cht:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},hbk:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},pwr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},lyr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'}},
@@ -2240,6 +2263,12 @@ function resetGaugeColors(){
     document.getElementById(k + '_v').value = c.v;
   }
   document.getElementById('clr_pbar').value = document.getElementById('prg_a').value;
+  applyDisplay();
+}
+function clearGaugeLabels(){
+  for (var i = 0; i < GAUGE_LABEL_KEYS.length; i++){
+    document.getElementById(GAUGE_LABEL_KEYS[i] + '_lbl').value = '';
+  }
   applyDisplay();
 }
 function randomGaugeColors(){
@@ -2308,6 +2337,10 @@ function applyDisplay(){
     p.append(k + '_a', document.getElementById(k + '_a').value);
     p.append(k + '_l', document.getElementById(k + '_l').value);
     p.append(k + '_v', document.getElementById(k + '_v').value);
+  }
+  for (var j = 0; j < GAUGE_LABEL_KEYS.length; j++){
+    var lk = GAUGE_LABEL_KEYS[j];
+    p.append(lk + '_lbl', document.getElementById(lk + '_lbl').value);
   }
   fetch('/apply',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
     .then(function(r){ if (r.ok) showToast('Applied!'); else showToast('Error'); })

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -82,7 +82,7 @@ function saveWifi(){
 //              gsmooth, warn_thr, warn_clr,
 //              clr_bg, clr_track, clr_pbar, bulk_a/l/v,
 //              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk/pwr/lyr + _a/_l/_v,
-//              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk/pwr/lyr/clk/ams/nzr/nzl + _lbl
+//              prg/noz/bed/pfn/afn/afr/cfn/exh/cht/hbk/pwr/lyr/clk/ams/nzr/nzl/dor + _lbl
 //    Hardware: rotmode, rotinterval, btntype, btnpin, buzzen (DOUBLE Z!),
 //              buzpin, buzqs, buzqe, buzclick, buzbeden, buzbedtemp, leden,
 //              ledpin, ledbr, ledfxmd, ledfxsec, ledfxbr, ledauto, ledpause,
@@ -1026,6 +1026,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
         <div class="gauge-label-row"><span class="name">AMS</span><input type="text" class="lbl" id="ams_lbl" maxlength="12" value="%AMS_LBL%" placeholder="AMS" title="Shown as 'Name 1'..'Name 4'"></div>
         <div class="gauge-label-row"><span class="name">Nozzle R</span><input type="text" class="lbl" id="nzr_lbl" maxlength="12" value="%NZR_LBL%" placeholder="Nozzle R" title="Dual-nozzle right; empty = Nozzle name + R"></div>
         <div class="gauge-label-row"><span class="name">Nozzle L</span><input type="text" class="lbl" id="nzl_lbl" maxlength="12" value="%NZL_LBL%" placeholder="Nozzle L" title="Dual-nozzle left; empty = Nozzle name + L"></div>
+        <div class="gauge-label-row"><span class="name">Door</span><input type="text" class="lbl" id="dor_lbl" maxlength="12" value="%DOR_LBL%" placeholder="empty = icon only" title="Status-bar door label. Leave empty to show just the padlock icon."></div>
       </div>
 
       <div class="action-bar">
@@ -2225,7 +2226,7 @@ function savePower(){
 /* ============ Display ============ */
 var GAUGE_KEYS = ['prg','noz','bed','pfn','afn','afr','cfn','exh','cht','hbk','pwr','lyr'];
 // Label override keys = the 12 colour gauges + Clock + AMS + Nozzle L/R (label-only rows).
-var GAUGE_LABEL_KEYS = GAUGE_KEYS.concat(['clk','ams','nzr','nzl']);
+var GAUGE_LABEL_KEYS = GAUGE_KEYS.concat(['clk','ams','nzr','nzl','dor']);
 var themes = {
   default:{bg:'#081018',track:'#182028',clkt:'#FFFFFF',clkd:'#C0C0C0',prg:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},noz:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},bed:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},pfn:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},afn:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},afr:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},cfn:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},exh:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'},cht:{a:'#00FFFF',l:'#00FFFF',v:'#FFFFFF'},hbk:{a:'#FFA500',l:'#FFA500',v:'#FFFFFF'},pwr:{a:'#FFD600',l:'#FFD600',v:'#FFFFFF'},lyr:{a:'#00FF00',l:'#00FF00',v:'#FFFFFF'}},
   mono_green:{bg:'#000800',track:'#0A1A0A',clkt:'#00FF41',clkd:'#00CC33',prg:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},noz:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},bed:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},pfn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},afn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},afr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},cfn:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},exh:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},cht:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},hbk:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},pwr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'},lyr:{a:'#00FF41',l:'#00CC33',v:'#00FF41'}},

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -512,9 +512,15 @@ void drawGaugeLabel(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius
   char buf[48];
   const char* draw = ellipsizeToWidth(gfx, label, maxW, buf, sizeof(buf));
 
+  const int16_t ly = cy + radius + (sm ? 3 : -1);
+  // Clear the full label band first so a previous, wider label (e.g. "Prawa" ->
+  // "Lewa" on a nozzle-side flip) leaves no ghost. All labels fit within maxW.
+  const int16_t fh = gfx.fontHeight();
+  gfx.fillRect(cx - maxW / 2, ly - fh / 2 - 1, maxW, fh + 2, bg);
+
   gfx.setTextDatum(MC_DATUM);
   gfx.setTextColor(lblColor, bg);
-  gfx.drawString(draw, cx, cy + radius + (sm ? 3 : -1));
+  gfx.drawString(draw, cx, ly);
 }
 
 // Choose the largest humidity-number font that leaves room for a small "%"

--- a/src/display_gauges.cpp
+++ b/src/display_gauges.cpp
@@ -480,6 +480,43 @@ static void fitValueFont(lgfx::LovyanGFX& gfx, const char* s,
   }
 }
 
+// Truncate s to fit maxW px at the CURRENT font, appending ".." when cut (VLW
+// fonts are ASCII-only, no real ellipsis glyph). Writes into out; returns out.
+const char* ellipsizeToWidth(lgfx::LovyanGFX& gfx, const char* s, int16_t maxW,
+                             char* out, size_t outLen) {
+  strlcpy(out, s, outLen);
+  if (gfx.textWidth(out) <= maxW) return out;
+  size_t n = strlen(out);
+  while (n > 1) {
+    n--;
+    if (n + 2 >= outLen) continue;
+    out[n] = '.'; out[n + 1] = '.'; out[n + 2] = '\0';
+    if (gfx.textWidth(out) <= maxW) break;
+  }
+  return out;
+}
+
+// Draw a centered gauge label below the arc. Honors the global smallLabels
+// preference, auto-shrinks an over-wide (custom) label to FONT_SMALL, then
+// ellipsizes so it can't bleed into neighboring slots. Exported so AMS tiles in
+// display_ui.cpp render labels identically.
+void drawGaugeLabel(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius,
+                    const char* label, uint16_t lblColor, uint16_t bg) {
+  // maxW matches the per-slot clear band (gR*2+4) so a fitted label never bleeds
+  // into a neighbor or leaves residue outside the cleared region.
+  const int16_t maxW = radius * 2 + 4;
+  bool sm = dispSettings.smallLabels;
+  setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
+  if (!sm && gfx.textWidth(label) > maxW) { sm = true; setFont(gfx, FONT_SMALL); }
+
+  char buf[48];
+  const char* draw = ellipsizeToWidth(gfx, label, maxW, buf, sizeof(buf));
+
+  gfx.setTextDatum(MC_DATUM);
+  gfx.setTextColor(lblColor, bg);
+  gfx.drawString(draw, cx, cy + radius + (sm ? 3 : -1));
+}
+
 // Choose the largest humidity-number font that leaves room for a small "%"
 // suffix inside the clearable center disc. Compact R=28 gauges start at BODY
 // for vertical fit; larger layouts retain their normal value font when it fits.
@@ -629,10 +666,7 @@ void drawProgressArc(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radiu
     gfx.drawString(timeBuf, cx, cy + (compact ? 10 : 18));
 
     if (compact) {
-      bool sm = dispSettings.smallLabels;
-      setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-      gfx.setTextColor(gc.label, bg);
-      gfx.drawString("Progress", cx, cy + radius + (sm ? 3 : -1));
+      drawGaugeLabel(gfx, cx, cy, radius, gaugeLabelOr(gaugeLabels.progress, "Progress"), gc.label, bg);
     }
   }
 }
@@ -707,10 +741,7 @@ void drawTempGauge(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius,
       gfx.drawString(targetBuf, cx, cy + 10);
     }
 
-    bool sm = dispSettings.smallLabels;
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(lblColor, bg);
-    gfx.drawString(label, cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, label, lblColor, bg);
   }
 }
 
@@ -758,10 +789,7 @@ void drawFanGauge(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius,
     setGaugeClearedTextColor(gfx, valColor, bg);
     gfx.drawString(buf, cx, cy);
 
-    bool sm = dispSettings.smallLabels;
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(lblColor, bg);
-    gfx.drawString(label, cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, label, lblColor, bg);
   }
 }
 
@@ -849,11 +877,7 @@ void drawPowerGauge(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius
       gfx.drawString(buf, cx, cy);
     }
 
-    bool sm = dispSettings.smallLabels;
-    gfx.setTextDatum(MC_DATUM);
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(labelColor, bg);
-    gfx.drawString(label, cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, label, labelColor, bg);
   }
 }
 
@@ -936,11 +960,7 @@ void drawHumidityGauge(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t rad
       gfx.drawString(buf, cx, cy);
     }
 
-    bool sm = dispSettings.smallLabels;
-    gfx.setTextDatum(MC_DATUM);
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(arcColor, bg);
-    gfx.drawString(label, cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, label, arcColor, bg);
   }
 }
 
@@ -997,10 +1017,7 @@ void drawLayerGauge(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius
       gfx.drawString(totalBuf, cx, cy + (useSmall ? 8 : 10));
     }
 
-    bool sm = dispSettings.smallLabels;
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(dispSettings.layer.label, bg);
-    gfx.drawString("Layer", cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, gaugeLabelOr(gaugeLabels.layer, "Layer"), dispSettings.layer.label, bg);
   }
 }
 
@@ -1044,10 +1061,7 @@ void drawClockWidget(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radiu
     setGaugeClearedTextColor(gfx, dispSettings.clockTimeColor, bg);
     gfx.drawString(timeBuf, cx, cy);
 
-    bool sm = dispSettings.smallLabels;
-    setFont(gfx, sm ? FONT_SMALL : FONT_BODY);
-    gfx.setTextColor(dispSettings.clockDateColor, bg);
-    gfx.drawString("Clock", cx, cy + radius + (sm ? 3 : -1));
+    drawGaugeLabel(gfx, cx, cy, radius, gaugeLabelOr(gaugeLabels.clock, "Clock"), dispSettings.clockDateColor, bg);
   }
 }
 

--- a/src/display_gauges.h
+++ b/src/display_gauges.h
@@ -11,6 +11,14 @@ void drawLedProgressBar(lgfx::LovyanGFX& gfx, int16_t y, uint8_t progress);
 // Shimmer animation tick — call from loop(), runs at its own cadence
 void tickProgressShimmer(lgfx::LovyanGFX& gfx, int16_t y, uint8_t progress, bool printing);
 
+// Truncate s to fit maxW px at the current font, appending ".." when cut.
+const char* ellipsizeToWidth(lgfx::LovyanGFX& gfx, const char* s, int16_t maxW,
+                             char* out, size_t outLen);
+
+// Draw a centered gauge label below the arc (auto-shrinks over-wide labels).
+void drawGaugeLabel(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius,
+                    const char* label, uint16_t lblColor, uint16_t bg);
+
 // Draw progress arc with percentage and time in center
 void drawProgressArc(lgfx::LovyanGFX& gfx, int16_t cx, int16_t cy, int16_t radius,
                      int16_t thickness, uint8_t progress, uint8_t prevProgress,

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -215,44 +215,48 @@ void drawTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
     case GAUGE_NOZZLE:
       drawTempGauge(tft, cx, cy, r, s.nozzleTemp, s.nozzleTarget, (float)dispSettings.nozzleScaleMax,
                     dispSettings.nozzle.arc,
-                    s.dualNozzle ? (s.activeNozzle == 0 ? "Nozzle R" : "Nozzle L") : "Nozzle",
+                    nozzleSideLabel(s.dualNozzle ? (s.activeNozzle == 0 ? 'R' : 'L') : 0),
                     nullptr, fr, &dispSettings.nozzle);
       break;
     case GAUGE_NOZZLE_RIGHT:
       drawTempGauge(tft, cx, cy, r, s.nozzleTempN[0], s.nozzleTargetN[0], (float)dispSettings.nozzleScaleMax,
-                    dispSettings.nozzle.arc, "Nozzle R", nullptr, fr, &dispSettings.nozzle);
+                    dispSettings.nozzle.arc, nozzleSideLabel('R'), nullptr, fr, &dispSettings.nozzle);
       break;
     case GAUGE_NOZZLE_LEFT:
       drawTempGauge(tft, cx, cy, r, s.nozzleTempN[1], s.nozzleTargetN[1], (float)dispSettings.nozzleScaleMax,
-                    dispSettings.nozzle.arc, "Nozzle L", nullptr, fr, &dispSettings.nozzle);
+                    dispSettings.nozzle.arc, nozzleSideLabel('L'), nullptr, fr, &dispSettings.nozzle);
       break;
     case GAUGE_BED:
       drawTempGauge(tft, cx, cy, r, s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                    dispSettings.bed.arc, "Bed", nullptr, fr, &dispSettings.bed);
+                    dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, fr, &dispSettings.bed);
       break;
     case GAUGE_PART_FAN:
-      drawFanGauge(tft, cx, cy, r, s.coolingFanPct, dispSettings.partFan.arc, "Part", fr, &dispSettings.partFan);
+      drawFanGauge(tft, cx, cy, r, s.coolingFanPct, dispSettings.partFan.arc,
+                   gaugeLabelOr(gaugeLabels.partFan, "Part"), fr, &dispSettings.partFan);
       break;
     case GAUGE_AUX_FAN:
       drawFanGauge(tft, cx, cy, r, s.auxFanPct, dispSettings.auxFan.arc,
-                   (s.airductFuncs & (1u << 6)) ? "L.Aux" : "Aux", fr, &dispSettings.auxFan);
+                   gaugeLabelOr(gaugeLabels.auxFan, (s.airductFuncs & (1u << 6)) ? "L.Aux" : "Aux"), fr, &dispSettings.auxFan);
       break;
     case GAUGE_AUX_FAN_RIGHT:
-      drawFanGauge(tft, cx, cy, r, s.auxFanRightPct, dispSettings.auxFanRight.arc, "R.Aux", fr, &dispSettings.auxFanRight);
+      drawFanGauge(tft, cx, cy, r, s.auxFanRightPct, dispSettings.auxFanRight.arc,
+                   gaugeLabelOr(gaugeLabels.auxFanRight, "R.Aux"), fr, &dispSettings.auxFanRight);
       break;
     case GAUGE_CHAMBER_FAN:
       drawFanGauge(tft, cx, cy, r, s.chamberFanPct, dispSettings.chamberFan.arc,
-                   (s.airductFuncs & (1u << 2)) ? "Exhaust" : "Chamber", fr, &dispSettings.chamberFan);
+                   gaugeLabelOr(gaugeLabels.chamberFan, (s.airductFuncs & (1u << 2)) ? "Exhaust" : "Chamber"), fr, &dispSettings.chamberFan);
       break;
     case GAUGE_EXHAUST_FAN:
-      drawFanGauge(tft, cx, cy, r, s.exhaustFanPct, dispSettings.exhaustFan.arc, "Exhaust", fr, &dispSettings.exhaustFan);
+      drawFanGauge(tft, cx, cy, r, s.exhaustFanPct, dispSettings.exhaustFan.arc,
+                   gaugeLabelOr(gaugeLabels.exhaustFan, "Exhaust"), fr, &dispSettings.exhaustFan);
       break;
     case GAUGE_CHAMBER_TEMP:
       drawTempGauge(tft, cx, cy, r, s.chamberTemp, 0.0f, (float)dispSettings.chamberScaleMax,
-                    dispSettings.chamberTemp.arc, "Chamber", nullptr, fr, &dispSettings.chamberTemp);
+                    dispSettings.chamberTemp.arc, gaugeLabelOr(gaugeLabels.chamberTemp, "Chamber"), nullptr, fr, &dispSettings.chamberTemp);
       break;
     case GAUGE_HEATBREAK:
-      drawFanGauge(tft, cx, cy, r, s.heatbreakFanPct, dispSettings.heatbreak.arc, "HBreak", fr, &dispSettings.heatbreak);
+      drawFanGauge(tft, cx, cy, r, s.heatbreakFanPct, dispSettings.heatbreak.arc,
+                   gaugeLabelOr(gaugeLabels.heatbreak, "HBreak"), fr, &dispSettings.heatbreak);
       break;
     case GAUGE_CLOCK:
       drawClockWidget(tft, cx, cy, r, t, fr);
@@ -262,7 +266,7 @@ void drawTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
       break;
     case GAUGE_POWER:
       drawPowerGauge(tft, cx, cy, r, tasmotaGetWattsForSlot(slotIndex),
-                     tasmotaIsActiveForSlot(slotIndex), "Power", fr);
+                     tasmotaIsActiveForSlot(slotIndex), gaugeLabelOr(gaugeLabels.power, "Power"), fr);
       break;
     case GAUGE_CAMERA:
       drawCameraGauge(cx, cy, r, fr);  // inert placeholder in split (camera disabled with 2+ printers)
@@ -271,16 +275,18 @@ void drawTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
       if (fr) tft.fillCircle(cx, cy, r + 2, CLR_BG);
       break;
     default: {
-      static const char* amsLabel[AMS_MAX_UNITS] = { "AMS 1", "AMS 2", "AMS 3", "AMS 4" };
+      char amsLbl[16];
       if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
         uint8_t ui = gt - GAUGE_AMS_HUM_1;
         const AmsUnit& u = s.ams.units[ui];
-        drawHumidityGauge(tft, cx, cy, r, u.humidityRaw, u.humidity, u.present, amsLabel[ui], fr);
+        formatAmsNumberLabel(amsLbl, sizeof(amsLbl), ui);
+        drawHumidityGauge(tft, cx, cy, r, u.humidityRaw, u.humidity, u.present, amsLbl, fr);
       } else if (gt >= GAUGE_AMS_TEMP_1 && gt <= GAUGE_AMS_TEMP_4) {
         uint8_t ui = gt - GAUGE_AMS_TEMP_1;
         const AmsUnit& u = s.ams.units[ui];
+        formatAmsNumberLabel(amsLbl, sizeof(amsLbl), ui);
         drawTempGauge(tft, cx, cy, r, u.present ? u.temp : 0, 0, (float)dispSettings.chamberScaleMax,
-                      dispSettings.chamberTemp.arc, amsLabel[ui], nullptr, fr, &dispSettings.chamberTemp);
+                      dispSettings.chamberTemp.arc, amsLbl, nullptr, fr, &dispSettings.chamberTemp);
       } else if (gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) {
         uint8_t ui = gt - GAUGE_AMS_FILAMENT_1;
         drawAmsFilamentAllGauge(tft, cx, cy, r, t, s.ams, ui, fr);
@@ -475,17 +481,15 @@ void drawDryingBand(const BambuState& s, const PrinterConfig& cfg,
     // AMS unit name on the foot line. HT units report id >= 128.
     const bool isHT = (u.id >= 128);
     const uint8_t num = isHT ? (uint8_t)(u.id - 128 + 1) : (uint8_t)(u.id + 1);
-    char unitName[28];
-    if (dc > 1)
-      snprintf(unitName, sizeof(unitName), "%s %d  (%d/%d)",
-               isHT ? "AMS HT" : "AMS", num, sDryIdx[bandIdx] + 1, dc);
-    else
-      snprintf(unitName, sizeof(unitName), "%s %d", isHT ? "AMS HT" : "AMS", num);
+    char unitName[32];
+    formatAmsDryName(unitName, sizeof(unitName), isHT, num, sDryIdx[bandIdx], dc);
     tft.fillRect(g.x, nameY - 9, g.w, 18, CLR_BG);
     tft.setTextDatum(MC_DATUM);
     setFont(tft, FONT_SMALL);
     tft.setTextColor(CLR_ORANGE, CLR_BG);
-    tft.drawString(unitName, g.x + g.w / 2, nameY);
+    char eb[40];
+    ellipsizeToWidth(tft, unitName, g.w - 4, eb, sizeof(eb));
+    tft.drawString(eb, g.x + g.w / 2, nameY);
 
     sPrevDryTemp[bandIdx]   = tempShown;
     sPrevDryMin[bandIdx]    = u.dryRemainMin;

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -671,7 +671,7 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
           uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
           tft.setTextDatum(MR_DATUM);
           tft.setTextColor(clr, CLR_BG);
-          tft.drawString("Door", g.x + g.w - g.margin - 18, fy);
+          if (gaugeLabels.door[0]) tft.drawString(gaugeLabels.door, g.x + g.w - g.margin - 18, fy);
           drawIcon16(tft, g.x + g.w - g.margin - 16, fy - 8,
                      s.doorOpen ? icon_unlock : icon_lock, clr);
         }

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -21,6 +21,27 @@
 #endif
 #include <new>   // placement new for CYD panel variant selection
 
+// --- AMS label formatters (honor gaugeLabels.amsBase override) --------------
+// Centralized so every AMS draw site (grid, bars, sidebar captions, drying,
+// split bands) renders the same custom base with a consistent suffix.
+void formatAmsNumberLabel(char* out, size_t len, uint8_t unitIndex) {
+  snprintf(out, len, "%s %u", gaugeLabelOr(gaugeLabels.amsBase, "AMS"), unitIndex + 1);
+}
+void formatAmsLetterLabel(char* out, size_t len, uint8_t unitIndex) {
+  snprintf(out, len, "%s %c", gaugeLabelOr(gaugeLabels.amsBase, "AMS"), 'A' + unitIndex);
+}
+void formatAmsDryName(char* out, size_t len, bool isHT, uint8_t displayNum,
+                      uint8_t dryDisplayIdx, uint8_t dryCount) {
+  const char* base = gaugeLabelOr(gaugeLabels.amsBase, "AMS");
+  char pfx[GAUGE_LABEL_LEN + 4];
+  if (isHT) snprintf(pfx, sizeof(pfx), "%s HT", base);
+  else      strlcpy(pfx, base, sizeof(pfx));
+  if (dryCount > 1)
+    snprintf(out, len, "%s %u  (%u/%u)", pfx, displayNum, dryDisplayIdx + 1, dryCount);
+  else
+    snprintf(out, len, "%s %u", pfx, displayNum);
+}
+
 // LovyanGFX board-specific configurations - the 12 LGFX device classes and the
 // per-board `_tft_instance` - live in their own header to keep this file
 // focused on UI logic. Included exactly once, here. See src/lgfx_boards.h.
@@ -518,9 +539,27 @@ ScreenState getScreenState() {
 // ---------------------------------------------------------------------------
 //  Nozzle label helper (dual nozzle H2D/H2C)
 // ---------------------------------------------------------------------------
+// Nozzle label honoring custom overrides. side: 'R', 'L', or 0 (single/combined).
+// Per-side override wins; else the combined "Nozzle" override (or default) plus
+// the R/L suffix. Returns a static buffer (synchronous draw, one label at a time).
+const char* nozzleSideLabel(char side) {
+  static char buf[GAUGE_LABEL_LEN + 4];
+  const char* base = gaugeLabelOr(gaugeLabels.nozzle, "Nozzle");
+  if (side == 'R') {
+    if (gaugeLabels.nozzleRight[0]) { strlcpy(buf, gaugeLabels.nozzleRight, sizeof(buf)); return buf; }
+    snprintf(buf, sizeof(buf), "%s R", base); return buf;
+  }
+  if (side == 'L') {
+    if (gaugeLabels.nozzleLeft[0]) { strlcpy(buf, gaugeLabels.nozzleLeft, sizeof(buf)); return buf; }
+    snprintf(buf, sizeof(buf), "%s L", base); return buf;
+  }
+  strlcpy(buf, base, sizeof(buf));
+  return buf;
+}
+
 static const char* nozzleLabel(const BambuState& s) {
-  if (!s.dualNozzle) return "Nozzle";
-  return s.activeNozzle == 0 ? "Nozzle R" : "Nozzle L";
+  if (!s.dualNozzle) return nozzleSideLabel(0);
+  return nozzleSideLabel(s.activeNozzle == 0 ? 'R' : 'L');
 }
 
 // ---------------------------------------------------------------------------
@@ -998,18 +1037,16 @@ static void drawIdleDrying(PrinterSlot& p) {
   if (unitChanged) {
     bool isHT = (u.id >= 128);
     uint8_t displayNum = isHT ? (u.id - 128 + 1) : (u.id + 1);
-    const char* prefix = isHT ? "AMS HT" : "AMS";
-    char unitName[24];
-    if (dryCount > 1)
-      snprintf(unitName, sizeof(unitName), "%s %d  (%d/%d)", prefix, displayNum, dryDisplayIdx + 1, dryCount);
-    else
-      snprintf(unitName, sizeof(unitName), "%s %d", prefix, displayNum);
+    char unitName[32];
+    formatAmsDryName(unitName, sizeof(unitName), isHT, displayNum, dryDisplayIdx, dryCount);
 
     tft.fillRect(0, 30, scrW, 20, CLR_BG);
     tft.setTextDatum(MC_DATUM);
     setFont(tft, FONT_BODY);
     tft.setTextColor(CLR_ORANGE, CLR_BG);
-    tft.drawString(unitName, cx, 40);
+    char eb[40];
+    ellipsizeToWidth(tft, unitName, scrW - 4, eb, sizeof(eb));
+    tft.drawString(eb, cx, 40);
   }
 
 #if defined(LAYOUT_HAS_LANDSCAPE)
@@ -1448,7 +1485,7 @@ static void drawIdle() {
     // Bed temp gauge
     drawTempGauge(tft, cx + lyIdleGOffset, lyIdleGaugeY, lyIdleGaugeR,
                   s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                  dispSettings.bed.arc, "Bed", nullptr, forceRedraw,
+                  dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, forceRedraw,
                   &dispSettings.bed, smoothBedTemp);
   }
 
@@ -1830,13 +1867,9 @@ void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
     drawAmsTrayBarRounded(bx, startY, barW, barH, tray, active);
   }
 
-  static const char* amsLabel[AMS_MAX_UNITS] = { "AMS 1", "AMS 2", "AMS 3", "AMS 4" };
-  bool sm = dispSettings.smallLabels;
-  int16_t labelY = cy + radius + (sm ? 3 : -1);
-  tft.setTextDatum(MC_DATUM);
-  setFont(tft, sm ? FONT_SMALL : FONT_BODY);
-  tft.setTextColor(CLR_TEXT_DIM, bg);
-  tft.drawString(amsLabel[unitIndex], cx, labelY);
+  char amsLabel[16];
+  formatAmsNumberLabel(amsLabel, sizeof(amsLabel), unitIndex);
+  drawGaugeLabel(tft, cx, cy, radius, amsLabel, CLR_TEXT_DIM, bg);
 }
 
 // Portrait AMS strip: horizontal row of tray bars, usable from printing/idle/finished.
@@ -1941,13 +1974,15 @@ static void drawAmsStrip(const AmsState& ams,
     }
 
     if (!singleAms) {
-      char label[6];
-      snprintf(label, sizeof(label), "AMS %c", 'A' + u);
+      char label[16];
+      formatAmsLetterLabel(label, sizeof(label), u);
       tft.setTextDatum(TC_DATUM);
       bool sm = dispSettings.smallLabels;
       setFont(tft, sm ? FONT_SMALL : FONT_BODY);
       tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
-      tft.drawString(label, groupX + groupW / 2, labelY + (showFilamentTypes ? 0 : 2));
+      char eb[20];
+      ellipsizeToWidth(tft, label, groupW - 2, eb, sizeof(eb));
+      tft.drawString(eb, groupX + groupW / 2, labelY + (showFilamentTypes ? 0 : 2));
     }
   }
 }
@@ -2139,13 +2174,15 @@ static void drawAmsZone(const BambuState& s, bool force) {
       }
 
       // AMS label below bars
-      char label[6];
-      snprintf(label, sizeof(label), "AMS %c", 'A' + u);
+      char label[16];
+      formatAmsLetterLabel(label, sizeof(label), u);
       tft.setTextDatum(TC_DATUM);
       bool sm = dispSettings.smallLabels;
       setFont(tft, sm ? FONT_SMALL : FONT_BODY);
       tft.setTextColor(CLR_TEXT_DIM, CLR_BG);
-      tft.drawString(label, LY_LAND_AMS_X + LY_LAND_AMS_W / 2, gy + barH + 1);
+      char eb[20];
+      ellipsizeToWidth(tft, label, LY_LAND_AMS_W - 2, eb, sizeof(eb));
+      tft.drawString(eb, LY_LAND_AMS_X + LY_LAND_AMS_W / 2, gy + barH + 1);
     }
 
   } else if (enhanced) {
@@ -2761,32 +2798,34 @@ static void drawPrinting() {
           break;
         case GAUGE_NOZZLE_RIGHT:
           drawTempGauge(tft, cx, cy, gR, s.nozzleTempN[0], s.nozzleTargetN[0], (float)dispSettings.nozzleScaleMax,
-                        dispSettings.nozzle.arc, "Nozzle R", nullptr, fr,
+                        dispSettings.nozzle.arc, nozzleSideLabel('R'), nullptr, fr,
                         &dispSettings.nozzle, smoothNozzleTempN[0]);
           break;
         case GAUGE_NOZZLE_LEFT:
           drawTempGauge(tft, cx, cy, gR, s.nozzleTempN[1], s.nozzleTargetN[1], (float)dispSettings.nozzleScaleMax,
-                        dispSettings.nozzle.arc, "Nozzle L", nullptr, fr,
+                        dispSettings.nozzle.arc, nozzleSideLabel('L'), nullptr, fr,
                         &dispSettings.nozzle, smoothNozzleTempN[1]);
           break;
         case GAUGE_BED:
           drawTempGauge(tft, cx, cy, gR, s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                        dispSettings.bed.arc, "Bed", nullptr, fr,
+                        dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, fr,
                         &dispSettings.bed, smoothBedTemp);
           break;
         case GAUGE_PART_FAN:
-          drawFanGauge(tft, cx, cy, gR, s.coolingFanPct, dispSettings.partFan.arc, "Part", fr,
+          drawFanGauge(tft, cx, cy, gR, s.coolingFanPct, dispSettings.partFan.arc,
+                       gaugeLabelOr(gaugeLabels.partFan, "Part"), fr,
                        &dispSettings.partFan, smoothPartFan);
           break;
         case GAUGE_AUX_FAN:
           // Re-label to "L.Aux" only when the printer actually has a right-aux
           // counterpart (func=6). Otherwise it's the only aux fan, so keep "Aux".
           drawFanGauge(tft, cx, cy, gR, s.auxFanPct, dispSettings.auxFan.arc,
-                       (s.airductFuncs & (1u << 6)) ? "L.Aux" : "Aux", fr,
+                       gaugeLabelOr(gaugeLabels.auxFan, (s.airductFuncs & (1u << 6)) ? "L.Aux" : "Aux"), fr,
                        &dispSettings.auxFan, smoothAuxFan);
           break;
         case GAUGE_AUX_FAN_RIGHT:
-          drawFanGauge(tft, cx, cy, gR, s.auxFanRightPct, dispSettings.auxFanRight.arc, "R.Aux", fr,
+          drawFanGauge(tft, cx, cy, gR, s.auxFanRightPct, dispSettings.auxFanRight.arc,
+                       gaugeLabelOr(gaugeLabels.auxFanRight, "R.Aux"), fr,
                        &dispSettings.auxFanRight, smoothAuxRightFan);
           break;
         case GAUGE_CHAMBER_FAN:
@@ -2796,20 +2835,22 @@ static void drawPrinting() {
           // displayed name matches reality on those models. X1C/P/A and other non-airduct
           // models keep the "Chamber" label that matches Bambu's own UI terminology.
           drawFanGauge(tft, cx, cy, gR, s.chamberFanPct, dispSettings.chamberFan.arc,
-                       (s.airductFuncs & (1u << 2)) ? "Exhaust" : "Chamber", fr,
+                       gaugeLabelOr(gaugeLabels.chamberFan, (s.airductFuncs & (1u << 2)) ? "Exhaust" : "Chamber"), fr,
                        &dispSettings.chamberFan, smoothChamberFan);
           break;
         case GAUGE_EXHAUST_FAN:
-          drawFanGauge(tft, cx, cy, gR, s.exhaustFanPct, dispSettings.exhaustFan.arc, "Exhaust", fr,
+          drawFanGauge(tft, cx, cy, gR, s.exhaustFanPct, dispSettings.exhaustFan.arc,
+                       gaugeLabelOr(gaugeLabels.exhaustFan, "Exhaust"), fr,
                        &dispSettings.exhaustFan, smoothExhaustFan);
           break;
         case GAUGE_CHAMBER_TEMP:
           drawTempGauge(tft, cx, cy, gR, s.chamberTemp, 0.0f, (float)dispSettings.chamberScaleMax,
-                        dispSettings.chamberTemp.arc, "Chamber", nullptr, fr,
+                        dispSettings.chamberTemp.arc, gaugeLabelOr(gaugeLabels.chamberTemp, "Chamber"), nullptr, fr,
                         &dispSettings.chamberTemp, smoothChamberTemp);
           break;
         case GAUGE_HEATBREAK:
-          drawFanGauge(tft, cx, cy, gR, s.heatbreakFanPct, dispSettings.heatbreak.arc, "HBreak", fr,
+          drawFanGauge(tft, cx, cy, gR, s.heatbreakFanPct, dispSettings.heatbreak.arc,
+                       gaugeLabelOr(gaugeLabels.heatbreak, "HBreak"), fr,
                        &dispSettings.heatbreak, smoothHeatbreakFan);
           break;
         case GAUGE_CLOCK:
@@ -2821,7 +2862,8 @@ static void drawPrinting() {
         case GAUGE_POWER:
           drawPowerGauge(tft, cx, cy, gR,
                          tasmotaGetWattsForSlot(rotState.displayIndex),
-                         tasmotaIsActiveForSlot(rotState.displayIndex), "Power", fr);
+                         tasmotaIsActiveForSlot(rotState.displayIndex),
+                         gaugeLabelOr(gaugeLabels.power, "Power"), fr);
           break;
         case GAUGE_CAMERA:
           drawCameraGauge(cx, cy, gR, fr);
@@ -2831,16 +2873,18 @@ static void drawPrinting() {
           break;
         default: {
           // AMS humidity / temperature / filament gauges — index derived from enum value
-          static const char* amsLabel[AMS_MAX_UNITS] = { "AMS 1", "AMS 2", "AMS 3", "AMS 4" };
+          char amsLbl[16];
           if (gt >= GAUGE_AMS_HUM_1 && gt <= GAUGE_AMS_HUM_4) {
             uint8_t ui = gt - GAUGE_AMS_HUM_1;
             const AmsUnit& u = s.ams.units[ui];
-            drawHumidityGauge(tft, cx, cy, gR, u.humidityRaw, u.humidity, u.present, amsLabel[ui], fr);
+            formatAmsNumberLabel(amsLbl, sizeof(amsLbl), ui);
+            drawHumidityGauge(tft, cx, cy, gR, u.humidityRaw, u.humidity, u.present, amsLbl, fr);
           } else if (gt >= GAUGE_AMS_TEMP_1 && gt <= GAUGE_AMS_TEMP_4) {
             uint8_t ui = gt - GAUGE_AMS_TEMP_1;
             const AmsUnit& u = s.ams.units[ui];
+            formatAmsNumberLabel(amsLbl, sizeof(amsLbl), ui);
             drawTempGauge(tft, cx, cy, gR, u.present ? u.temp : 0, 0, (float)dispSettings.chamberScaleMax,
-                          dispSettings.chamberTemp.arc, amsLabel[ui], nullptr, fr, &dispSettings.chamberTemp);
+                          dispSettings.chamberTemp.arc, amsLbl, nullptr, fr, &dispSettings.chamberTemp);
           } else if (gt >= GAUGE_AMS_FILAMENT_1 && gt <= GAUGE_AMS_FILAMENT_4) {
             uint8_t ui = gt - GAUGE_AMS_FILAMENT_1;
             drawAmsFilamentAllGauge(tft, cx, cy, gR, gT, s.ams, ui, fr);
@@ -3243,7 +3287,7 @@ static void drawFinished() {
 
     drawTempGauge(tft, gaugeRight, gaugeY, gR,
                   s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                  dispSettings.bed.arc, "Bed", nullptr, forceRedraw,
+                  dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, forceRedraw,
                   &dispSettings.bed, smoothBedTemp);
   }
 

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1602,7 +1602,7 @@ static void drawIdle() {
       uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
       tft.setTextDatum(MR_DATUM);
       tft.setTextColor(clr, CLR_BG);
-      tft.drawString("Door", scrW - 20, botCY);
+      if (gaugeLabels.door[0]) tft.drawString(gaugeLabels.door, scrW - 20, botCY);
       drawIcon16(tft, scrW - 18, botCY - 8,
                  s.doorOpen ? icon_unlock : icon_lock, clr);
     }
@@ -3176,7 +3176,7 @@ static void drawPrinting() {
       uint16_t clr = s.doorOpen ? CLR_ORANGE : CLR_GREEN;
       tft.setTextDatum(MR_DATUM);
       tft.setTextColor(clr, CLR_BG);
-      tft.drawString("Door", botW - 20, eff_botCY);
+      if (gaugeLabels.door[0]) tft.drawString(gaugeLabels.door, botW - 20, eff_botCY);
       drawIcon16(tft, botW - 18, eff_botCY - 8,
                  s.doorOpen ? icon_unlock : icon_lock, clr);
     } else {
@@ -3457,7 +3457,7 @@ static void drawFinished() {
       tft.setTextDatum(MR_DATUM);
       setFont(tft, FONT_SMALL);
       tft.setTextColor(clr, CLR_BG);
-      tft.drawString("Door", scrW - 20, eff_finWifiY);
+      if (gaugeLabels.door[0]) tft.drawString(gaugeLabels.door, scrW - 20, eff_finWifiY);
       drawIcon16(tft, scrW - 18, eff_finWifiY - 8,
                  s.doorOpen ? icon_unlock : icon_lock, clr);
     }

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -82,4 +82,16 @@ void drawAmsBarsGauge(int16_t cx, int16_t cy, int16_t radius,
 // draw the inert placeholder inside a band. No-op visual on non-camera boards.
 void drawCameraGauge(int16_t cx, int16_t cy, int16_t radius, bool forceRedraw);
 
+// Nozzle label honoring custom overrides + R/L side ('R'/'L'/0). Exported so the
+// split renderer formats nozzle labels identically. Returns a static buffer.
+const char* nozzleSideLabel(char side);
+
+// AMS label formatters. All honor the custom gaugeLabels.amsBase override
+// (default "AMS"), keeping the numeric/letter/HT suffix. Exported so the split
+// renderer formats AMS labels identically. Each writes a NUL-terminated string.
+void formatAmsNumberLabel(char* out, size_t len, uint8_t unitIndex);   // "<base> 1".."4"
+void formatAmsLetterLabel(char* out, size_t len, uint8_t unitIndex);   // "<base> A".."D"
+void formatAmsDryName(char* out, size_t len, bool isHT, uint8_t displayNum,
+                      uint8_t dryDisplayIdx, uint8_t dryCount);        // "<base>[ HT] N  (x/y)"
+
 #endif // DISPLAY_UI_H

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -14,6 +14,7 @@ char wifiSSID[33] = {0};
 char wifiPass[65] = {0};
 uint8_t brightness = 200;
 DisplaySettings dispSettings;
+GaugeLabels gaugeLabels;
 NetworkSettings netSettings;
 DisplayPowerSettings dpSettings;
 char cloudEmail[64] = {0};
@@ -242,6 +243,38 @@ static void loadGaugeColors(const char* prefix, GaugeColors& gc, const GaugeColo
 }
 
 // ---------------------------------------------------------------------------
+//  Custom gauge labels
+// ---------------------------------------------------------------------------
+// Copy a user label into a fixed buffer, dropping anything unsafe to emit raw
+// into an HTML value="..." attribute, plus (for now) non-ASCII bytes that the
+// VLW fonts can't render. Leading/trailing spaces are trimmed so an all-spaces
+// field doesn't become an invisible override. The ONE place the >127 rule lives.
+void sanitizeGaugeLabel(const char* in, char* out, size_t outLen) {
+  if (!out || outLen == 0) return;
+  size_t w = 0;
+  if (in) {
+    for (const char* p = in; *p && w < outLen - 1; ++p) {
+      uint8_t c = (uint8_t)*p;
+      if (c < 0x20 || c > 0x7E) continue;   // control chars + non-ASCII (UTF-8 toggle)
+      if (c == '"' || c == '<' || c == '>' || c == '&') continue;  // HTML-unsafe
+      if (c == ' ' && w == 0) continue;     // drop leading spaces (even after dropped chars)
+      out[w++] = (char)c;
+    }
+  }
+  while (w > 0 && out[w - 1] == ' ') w--;   // trim trailing spaces
+  out[w] = '\0';
+}
+
+static void saveGaugeLabel(const char* key, const char* label) {
+  prefs.putString(key, label);
+}
+
+static void loadGaugeLabel(const char* key, char* out, size_t outLen) {
+  String raw = prefs.getString(key, "");
+  sanitizeGaugeLabel(raw.c_str(), out, outLen);  // defend against corrupt NVS
+}
+
+// ---------------------------------------------------------------------------
 //  Load settings
 // ---------------------------------------------------------------------------
 void loadSettings() {
@@ -395,6 +428,24 @@ void loadSettings() {
   loadGaugeColors("gc_hbk", dispSettings.heatbreak, def.heatbreak);
   loadGaugeColors("gc_pwr", dispSettings.power, def.power);
   loadGaugeColors("gc_lyr", dispSettings.layer, def.layer);
+
+  // Custom gauge labels (empty default = use built-in label)
+  loadGaugeLabel("gl_prg", gaugeLabels.progress,    sizeof(gaugeLabels.progress));
+  loadGaugeLabel("gl_noz", gaugeLabels.nozzle,      sizeof(gaugeLabels.nozzle));
+  loadGaugeLabel("gl_nzr", gaugeLabels.nozzleRight, sizeof(gaugeLabels.nozzleRight));
+  loadGaugeLabel("gl_nzl", gaugeLabels.nozzleLeft,  sizeof(gaugeLabels.nozzleLeft));
+  loadGaugeLabel("gl_bed", gaugeLabels.bed,         sizeof(gaugeLabels.bed));
+  loadGaugeLabel("gl_pfn", gaugeLabels.partFan,     sizeof(gaugeLabels.partFan));
+  loadGaugeLabel("gl_afn", gaugeLabels.auxFan,      sizeof(gaugeLabels.auxFan));
+  loadGaugeLabel("gl_afr", gaugeLabels.auxFanRight, sizeof(gaugeLabels.auxFanRight));
+  loadGaugeLabel("gl_cfn", gaugeLabels.chamberFan,  sizeof(gaugeLabels.chamberFan));
+  loadGaugeLabel("gl_exh", gaugeLabels.exhaustFan,  sizeof(gaugeLabels.exhaustFan));
+  loadGaugeLabel("gl_cht", gaugeLabels.chamberTemp, sizeof(gaugeLabels.chamberTemp));
+  loadGaugeLabel("gl_hbk", gaugeLabels.heatbreak,   sizeof(gaugeLabels.heatbreak));
+  loadGaugeLabel("gl_pwr", gaugeLabels.power,       sizeof(gaugeLabels.power));
+  loadGaugeLabel("gl_lyr", gaugeLabels.layer,       sizeof(gaugeLabels.layer));
+  loadGaugeLabel("gl_clk", gaugeLabels.clock,       sizeof(gaugeLabels.clock));
+  loadGaugeLabel("gl_ams", gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase));
 
   // Top progress bar color. Before this setting existed the bar reused the
   // Progress gauge arc color, so migrate absent keys to that value to avoid a
@@ -658,6 +709,24 @@ void saveSettings() {
   saveGaugeColors("gc_hbk", dispSettings.heatbreak);
   saveGaugeColors("gc_pwr", dispSettings.power);
   saveGaugeColors("gc_lyr", dispSettings.layer);
+
+  // Custom gauge labels
+  saveGaugeLabel("gl_prg", gaugeLabels.progress);
+  saveGaugeLabel("gl_noz", gaugeLabels.nozzle);
+  saveGaugeLabel("gl_nzr", gaugeLabels.nozzleRight);
+  saveGaugeLabel("gl_nzl", gaugeLabels.nozzleLeft);
+  saveGaugeLabel("gl_bed", gaugeLabels.bed);
+  saveGaugeLabel("gl_pfn", gaugeLabels.partFan);
+  saveGaugeLabel("gl_afn", gaugeLabels.auxFan);
+  saveGaugeLabel("gl_afr", gaugeLabels.auxFanRight);
+  saveGaugeLabel("gl_cfn", gaugeLabels.chamberFan);
+  saveGaugeLabel("gl_exh", gaugeLabels.exhaustFan);
+  saveGaugeLabel("gl_cht", gaugeLabels.chamberTemp);
+  saveGaugeLabel("gl_hbk", gaugeLabels.heatbreak);
+  saveGaugeLabel("gl_pwr", gaugeLabels.power);
+  saveGaugeLabel("gl_lyr", gaugeLabels.layer);
+  saveGaugeLabel("gl_clk", gaugeLabels.clock);
+  saveGaugeLabel("gl_ams", gaugeLabels.amsBase);
 
   // Network settings
   prefs.putBool("net_dhcp", netSettings.useDHCP);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -446,6 +446,10 @@ void loadSettings() {
   loadGaugeLabel("gl_lyr", gaugeLabels.layer,       sizeof(gaugeLabels.layer));
   loadGaugeLabel("gl_clk", gaugeLabels.clock,       sizeof(gaugeLabels.clock));
   loadGaugeLabel("gl_ams", gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase));
+  // Door: default "Door" only on first run (key absent). An explicit empty value
+  // means "hide the text, show just the padlock icon" - not "use default".
+  if (prefs.isKey("gl_dor")) loadGaugeLabel("gl_dor", gaugeLabels.door, sizeof(gaugeLabels.door));
+  else strlcpy(gaugeLabels.door, "Door", sizeof(gaugeLabels.door));
 
   // Top progress bar color. Before this setting existed the bar reused the
   // Progress gauge arc color, so migrate absent keys to that value to avoid a
@@ -727,6 +731,7 @@ void saveSettings() {
   saveGaugeLabel("gl_lyr", gaugeLabels.layer);
   saveGaugeLabel("gl_clk", gaugeLabels.clock);
   saveGaugeLabel("gl_ams", gaugeLabels.amsBase);
+  saveGaugeLabel("gl_dor", gaugeLabels.door);
 
   // Network settings
   prefs.putBool("net_dhcp", netSettings.useDHCP);

--- a/src/settings.h
+++ b/src/settings.h
@@ -133,6 +133,7 @@ struct GaugeLabels {
   char layer[GAUGE_LABEL_LEN];
   char clock[GAUGE_LABEL_LEN];
   char amsBase[GAUGE_LABEL_LEN];    // "AMS" word; rendered as "<base> 1".."<base> HT"
+  char door[GAUGE_LABEL_LEN];       // status-bar "Door" indicator
 };
 
 // Return the override if non-empty, else the default. Single decision point used

--- a/src/settings.h
+++ b/src/settings.h
@@ -109,6 +109,44 @@ struct DisplaySettings {
   GaugeColors layer;        // layer-progress gauge
 };
 
+// Per-gauge custom label overrides. Empty string = keep the built-in default
+// (including dynamic defaults like "L.Aux"/"Exhaust"). ASCII-only for now: the
+// bundled VLW fonts carry only 0x20-0x7F glyphs. To support accented labels
+// later, bump GAUGE_LABEL_LEN, relax the >127 strip in sanitizeGaugeLabel(),
+// and regenerate the fonts with an extended CHARSET.
+static const uint8_t GAUGE_LABEL_LEN = 13;  // 12 visible ASCII chars + NUL
+
+struct GaugeLabels {
+  char progress[GAUGE_LABEL_LEN];
+  char nozzle[GAUGE_LABEL_LEN];     // single nozzle, or base for L/R when those are unset
+  char nozzleRight[GAUGE_LABEL_LEN];// dual-nozzle right; empty = "<nozzle> R"
+  char nozzleLeft[GAUGE_LABEL_LEN]; // dual-nozzle left;  empty = "<nozzle> L"
+  char bed[GAUGE_LABEL_LEN];
+  char partFan[GAUGE_LABEL_LEN];
+  char auxFan[GAUGE_LABEL_LEN];
+  char auxFanRight[GAUGE_LABEL_LEN];
+  char chamberFan[GAUGE_LABEL_LEN];
+  char exhaustFan[GAUGE_LABEL_LEN];
+  char chamberTemp[GAUGE_LABEL_LEN];
+  char heatbreak[GAUGE_LABEL_LEN];
+  char power[GAUGE_LABEL_LEN];
+  char layer[GAUGE_LABEL_LEN];
+  char clock[GAUGE_LABEL_LEN];
+  char amsBase[GAUGE_LABEL_LEN];    // "AMS" word; rendered as "<base> 1".."<base> HT"
+};
+
+// Return the override if non-empty, else the default. Single decision point used
+// at every gauge draw site.
+inline const char* gaugeLabelOr(const char* override_, const char* def) {
+  return (override_ && override_[0]) ? override_ : def;
+}
+
+// Copy a user-supplied label into a fixed buffer, stripping anything unsafe to
+// emit raw into HTML (control chars, " < > &) and, for now, non-ASCII bytes.
+// Trims leading/trailing spaces. The single sanitize point - used by the web
+// form, JSON import, and after NVS load.
+void sanitizeGaugeLabel(const char* in, char* out, size_t outLen);
+
 // Network settings
 struct NetworkSettings {
   bool useDHCP;           // true = DHCP, false = static
@@ -204,6 +242,7 @@ extern char wifiSSID[33];
 extern char wifiPass[65];
 extern uint8_t brightness;
 extern DisplaySettings dispSettings;
+extern GaugeLabels gaugeLabels;
 extern NetworkSettings netSettings;
 extern DisplayPowerSettings dpSettings;
 extern ButtonType buttonType;

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -58,6 +58,12 @@ static void readGaugeColorsFromForm(const char* prefix, GaugeColors& gc) {
   if (server.hasArg(key)) gc.value = htmlToRgb565(server.arg(key).c_str());
 }
 
+// Read one custom gauge label from the form, sanitizing while copying (so an
+// overlong raw value can't drop valid chars after truncation).
+static void readGaugeLabelFromForm(const char* arg, char* dst, size_t len) {
+  if (server.hasArg(arg)) sanitizeGaugeLabel(server.arg(arg).c_str(), dst, len);
+}
+
 // ---------------------------------------------------------------------------
 //  Read display settings from form args
 // ---------------------------------------------------------------------------
@@ -99,6 +105,24 @@ static void readDisplayFromForm() {
   readGaugeColorsFromForm("hbk", dispSettings.heatbreak);
   readGaugeColorsFromForm("pwr", dispSettings.power);
   readGaugeColorsFromForm("lyr", dispSettings.layer);
+
+  // Custom gauge labels (empty = keep built-in default)
+  readGaugeLabelFromForm("prg_lbl", gaugeLabels.progress,    sizeof(gaugeLabels.progress));
+  readGaugeLabelFromForm("noz_lbl", gaugeLabels.nozzle,      sizeof(gaugeLabels.nozzle));
+  readGaugeLabelFromForm("nzr_lbl", gaugeLabels.nozzleRight, sizeof(gaugeLabels.nozzleRight));
+  readGaugeLabelFromForm("nzl_lbl", gaugeLabels.nozzleLeft,  sizeof(gaugeLabels.nozzleLeft));
+  readGaugeLabelFromForm("bed_lbl", gaugeLabels.bed,         sizeof(gaugeLabels.bed));
+  readGaugeLabelFromForm("pfn_lbl", gaugeLabels.partFan,     sizeof(gaugeLabels.partFan));
+  readGaugeLabelFromForm("afn_lbl", gaugeLabels.auxFan,      sizeof(gaugeLabels.auxFan));
+  readGaugeLabelFromForm("afr_lbl", gaugeLabels.auxFanRight, sizeof(gaugeLabels.auxFanRight));
+  readGaugeLabelFromForm("cfn_lbl", gaugeLabels.chamberFan,  sizeof(gaugeLabels.chamberFan));
+  readGaugeLabelFromForm("exh_lbl", gaugeLabels.exhaustFan,  sizeof(gaugeLabels.exhaustFan));
+  readGaugeLabelFromForm("cht_lbl", gaugeLabels.chamberTemp, sizeof(gaugeLabels.chamberTemp));
+  readGaugeLabelFromForm("hbk_lbl", gaugeLabels.heatbreak,   sizeof(gaugeLabels.heatbreak));
+  readGaugeLabelFromForm("pwr_lbl", gaugeLabels.power,       sizeof(gaugeLabels.power));
+  readGaugeLabelFromForm("lyr_lbl", gaugeLabels.layer,       sizeof(gaugeLabels.layer));
+  readGaugeLabelFromForm("clk_lbl", gaugeLabels.clock,       sizeof(gaugeLabels.clock));
+  readGaugeLabelFromForm("ams_lbl", gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase));
 
   if (server.hasArg("fmins")) {
     dpSettings.finishDisplayMins = server.arg("fmins").toInt();
@@ -1069,6 +1093,25 @@ static void handleSettingsExport() {
   JsonObject gPwr = gauges["power"].to<JsonObject>();     gaugeColorsToJson(gPwr, dispSettings.power);
   JsonObject gLyr = gauges["layer"].to<JsonObject>();     gaugeColorsToJson(gLyr, dispSettings.layer);
 
+  // Custom gauge labels
+  JsonObject glbl = disp["gaugeLabels"].to<JsonObject>();
+  glbl["progress"]    = gaugeLabels.progress;
+  glbl["nozzle"]      = gaugeLabels.nozzle;
+  glbl["nozzleRight"] = gaugeLabels.nozzleRight;
+  glbl["nozzleLeft"]  = gaugeLabels.nozzleLeft;
+  glbl["bed"]         = gaugeLabels.bed;
+  glbl["partFan"]     = gaugeLabels.partFan;
+  glbl["auxFan"]      = gaugeLabels.auxFan;
+  glbl["auxFanRight"] = gaugeLabels.auxFanRight;
+  glbl["chamberFan"]  = gaugeLabels.chamberFan;
+  glbl["exhaustFan"]  = gaugeLabels.exhaustFan;
+  glbl["chamberTemp"] = gaugeLabels.chamberTemp;
+  glbl["heatbreak"]   = gaugeLabels.heatbreak;
+  glbl["power"]       = gaugeLabels.power;
+  glbl["layer"]       = gaugeLabels.layer;
+  glbl["clock"]       = gaugeLabels.clock;
+  glbl["amsBase"]     = gaugeLabels.amsBase;
+
   // Display power
   JsonObject dp = doc["displayPower"].to<JsonObject>();
   dp["finishDisplayMins"] = dpSettings.finishDisplayMins;
@@ -1210,7 +1253,7 @@ static void handleSettingsImportUpload() {
     settingsImportOverflow = false;
   } else if (upload.status == UPLOAD_FILE_WRITE) {
     if (settingsImportOverflow) return;
-    if (settingsImportBuf.length() + upload.currentSize > 8192) {
+    if (settingsImportBuf.length() + upload.currentSize > 12288) {
       settingsImportOverflow = true;
       settingsImportBuf = "";  // free memory, rest of upload is ignored
       return;
@@ -1224,7 +1267,7 @@ static void handleSettingsImportFinish() {
   if (settingsImportOverflow) {
     settingsImportOverflow = false;
     server.send(400, "application/json",
-      "{\"status\":\"error\",\"message\":\"Settings file too large (max 8 KB)\"}");
+      "{\"status\":\"error\",\"message\":\"Settings file too large (max 12 KB)\"}");
     return;
   }
 
@@ -1353,6 +1396,30 @@ static void handleSettingsImportFinish() {
       if (gauges["heatbreak"].is<JsonObject>()){ JsonObject g = gauges["heatbreak"]; gaugeColorsFromJson(g, dispSettings.heatbreak); }
       if (gauges["power"].is<JsonObject>())    { JsonObject g = gauges["power"];     gaugeColorsFromJson(g, dispSettings.power); }
       if (gauges["layer"].is<JsonObject>())    { JsonObject g = gauges["layer"];     gaugeColorsFromJson(g, dispSettings.layer); }
+    }
+
+    JsonObject glbl = disp["gaugeLabels"];
+    if (glbl) {
+      struct { const char* k; char* dst; size_t len; } LB[] = {
+        {"progress",    gaugeLabels.progress,    sizeof(gaugeLabels.progress)},
+        {"nozzle",      gaugeLabels.nozzle,      sizeof(gaugeLabels.nozzle)},
+        {"nozzleRight", gaugeLabels.nozzleRight, sizeof(gaugeLabels.nozzleRight)},
+        {"nozzleLeft",  gaugeLabels.nozzleLeft,  sizeof(gaugeLabels.nozzleLeft)},
+        {"bed",         gaugeLabels.bed,         sizeof(gaugeLabels.bed)},
+        {"partFan",     gaugeLabels.partFan,     sizeof(gaugeLabels.partFan)},
+        {"auxFan",      gaugeLabels.auxFan,      sizeof(gaugeLabels.auxFan)},
+        {"auxFanRight", gaugeLabels.auxFanRight, sizeof(gaugeLabels.auxFanRight)},
+        {"chamberFan",  gaugeLabels.chamberFan,  sizeof(gaugeLabels.chamberFan)},
+        {"exhaustFan",  gaugeLabels.exhaustFan,  sizeof(gaugeLabels.exhaustFan)},
+        {"chamberTemp", gaugeLabels.chamberTemp, sizeof(gaugeLabels.chamberTemp)},
+        {"heatbreak",   gaugeLabels.heatbreak,   sizeof(gaugeLabels.heatbreak)},
+        {"power",       gaugeLabels.power,       sizeof(gaugeLabels.power)},
+        {"layer",       gaugeLabels.layer,       sizeof(gaugeLabels.layer)},
+        {"clock",       gaugeLabels.clock,       sizeof(gaugeLabels.clock)},
+        {"amsBase",     gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase)},
+      };
+      for (auto& e : LB)
+        if (glbl[e.k].is<const char*>()) sanitizeGaugeLabel(glbl[e.k].as<const char*>(), e.dst, e.len);
     }
   }
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -123,6 +123,7 @@ static void readDisplayFromForm() {
   readGaugeLabelFromForm("lyr_lbl", gaugeLabels.layer,       sizeof(gaugeLabels.layer));
   readGaugeLabelFromForm("clk_lbl", gaugeLabels.clock,       sizeof(gaugeLabels.clock));
   readGaugeLabelFromForm("ams_lbl", gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase));
+  readGaugeLabelFromForm("dor_lbl", gaugeLabels.door,        sizeof(gaugeLabels.door));
 
   if (server.hasArg("fmins")) {
     dpSettings.finishDisplayMins = server.arg("fmins").toInt();
@@ -1111,6 +1112,7 @@ static void handleSettingsExport() {
   glbl["layer"]       = gaugeLabels.layer;
   glbl["clock"]       = gaugeLabels.clock;
   glbl["amsBase"]     = gaugeLabels.amsBase;
+  glbl["door"]        = gaugeLabels.door;
 
   // Display power
   JsonObject dp = doc["displayPower"].to<JsonObject>();
@@ -1417,6 +1419,7 @@ static void handleSettingsImportFinish() {
         {"layer",       gaugeLabels.layer,       sizeof(gaugeLabels.layer)},
         {"clock",       gaugeLabels.clock,       sizeof(gaugeLabels.clock)},
         {"amsBase",     gaugeLabels.amsBase,     sizeof(gaugeLabels.amsBase)},
+        {"door",        gaugeLabels.door,        sizeof(gaugeLabels.door)},
       };
       for (auto& e : LB)
         if (glbl[e.k].is<const char*>()) sanitizeGaugeLabel(glbl[e.k].as<const char*>(), e.dst, e.len);

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -364,6 +364,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
       {"PWR_LBL", gaugeLabels.power},      {"LYR_LBL", gaugeLabels.layer},
       {"CLK_LBL", gaugeLabels.clock},      {"AMS_LBL", gaugeLabels.amsBase},
       {"NZR_LBL", gaugeLabels.nozzleRight},{"NZL_LBL", gaugeLabels.nozzleLeft},
+      {"DOR_LBL", gaugeLabels.door},
     };
     for (auto& l : labels) {
       if (strcmp(name, l.tok) == 0) { out = l.val; return true; }

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -353,6 +353,23 @@ static bool resolvePlaceholder(const char* name, String& out) {
     }
   }
 
+  // --- Custom gauge labels (*_LBL). Stored already sanitized, so emit raw. ---
+  {
+    static const struct { const char* tok; const char* val; } labels[] = {
+      {"PRG_LBL", gaugeLabels.progress},   {"NOZ_LBL", gaugeLabels.nozzle},
+      {"BED_LBL", gaugeLabels.bed},        {"PFN_LBL", gaugeLabels.partFan},
+      {"AFN_LBL", gaugeLabels.auxFan},     {"AFR_LBL", gaugeLabels.auxFanRight},
+      {"CFN_LBL", gaugeLabels.chamberFan}, {"EXH_LBL", gaugeLabels.exhaustFan},
+      {"CHT_LBL", gaugeLabels.chamberTemp},{"HBK_LBL", gaugeLabels.heatbreak},
+      {"PWR_LBL", gaugeLabels.power},      {"LYR_LBL", gaugeLabels.layer},
+      {"CLK_LBL", gaugeLabels.clock},      {"AMS_LBL", gaugeLabels.amsBase},
+      {"NZR_LBL", gaugeLabels.nozzleRight},{"NZL_LBL", gaugeLabels.nozzleLeft},
+    };
+    for (auto& l : labels) {
+      if (strcmp(name, l.tok) == 0) { out = l.val; return true; }
+    }
+  }
+
   // --- Status / version / board ---
   if (strcmp(name, "DBGLOG") == 0)       { out = mqttDebugLog ? "checked" : ""; return true; }
   if (strcmp(name, "FW_VER") == 0)       { out = FW_VERSION; return true; }


### PR DESCRIPTION
## What

Lets users rename any gauge label from the web config portal, instead of shipping a full multi-language translation. Each gauge gets an optional custom label; an empty field keeps the built-in default (including dynamic ones like `L.Aux`/`Exhaust` on airduct printers).

## How

- New `GaugeLabels` struct + global, mirroring the existing `GaugeColors` flow (NVS `gl_*` keys, `gaugeLabelOr()` override-or-default helper). Applied at every draw site: main grid, idle, finished, split bands, and the internally drawn Progress/Layer/Clock labels.
- **Nozzle L/R:** `nozzleSideLabel()` uses the per-side override when set, else the combined Nozzle name + an `R`/`L` suffix - so `Hotend` becomes `Hotend R`/`Hotend L` automatically, while `Prawa`/`Lewa` can be set explicitly.
- **AMS:** a single base name rendered as `<base> 1`..`<base> 4` / `<base> A` / `<base> HT` via shared formatters.
- **Door:** the status-bar door indicator is renamable too; an empty value hides the text and shows only the padlock icon (default `Door` applies only on first run, so existing devices are unchanged).
- **ASCII only for now** (the bundled VLW fonts carry 0x20-0x7F only). The design keeps a future UTF-8 switch localized: one length constant, one sanitizer, a font regen. All label text is sanitized at a single point (form, JSON import, and after NVS load) so it is safe to emit raw into the page.
- **Bounded rendering:** `drawGaugeLabel()` centralizes label drawing - shrinks to the small font, then ellipsizes to the slot width, and clears the full label band before drawing so a label that changes at runtime (e.g. nozzle side flip) leaves no ghost. AMS strip/sidebar/drying captions reuse the same ellipsize helper.

## Web UI

The Display "Gauge Colors" card becomes "Gauge Appearance": a fixed-width label field per gauge, plus Clock / AMS / Nozzle L/R / Door rows. Labels save via the existing Apply path, render through `%*_LBL%` placeholders, and are carried in settings export/import (import cap raised to 12 KB).

## Testing

- Builds clean on all 7 maintained envs: esp32s3, cyd, esp32s3_zero, ws_lcd_200, ws_lcd_154, jc3248w535, esp32c3.
- Hardware-verified on ws_lcd_200, esp32s3, and jc3248w535: labels set/persist across reboot, round-trip through export/import, sanitizer strips unsafe/leading chars, long labels shrink+ellipsize without overrunning neighbors, nozzle side-flip leaves no ghost, Nozzle L/R auto-suffix + explicit names render, empty Door shows just the padlock.
- RAM impact ~230 bytes (one global); PAGE_HTML grows ~2 KB, streamed in 2 KB chunks.