### PR TITLE
Chamber light control (#126)

### DIFF
--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -54,6 +54,11 @@ struct AmsState {
   char     vtType[16];
 };
 
+// Chamber-light automation flags (PrinterConfig.lightFlags bitmask)
+#define LIGHT_OFF_ON_FINISH 0x01  // turn light off after a successful print
+#define LIGHT_OFF_ON_FAILED 0x02  // turn light off after a failed/cancelled print
+#define LIGHT_ON_AT_START   0x04  // turn light on when a print starts
+
 struct BambuState {
   bool connected;
   bool printing;
@@ -94,6 +99,8 @@ struct BambuState {
   bool finishBuzzerPlayed;    // true after FINISH buzzer played (reset on next print)
   bool doorAcknowledged;      // true after door opened on FINISH screen (print removed)
   bool bedCooldownAlertArmed; // armed on FINISH transition, fired when bedTemp <= threshold
+  int8_t lightState;          // chamber_light from lights_report: -1 unknown, 0 off, 1 on
+  unsigned long lightOffDueMs; // millis() deadline for a scheduled light-off, 0 = none pending
   AmsState ams;               // AMS tray data
 };
 
@@ -167,6 +174,8 @@ struct PrinterConfig {
   uint8_t landscapeExtras[2];  // Col 4 (top, bot) - landscape 8-slot mode only.
   uint8_t portraitExtras[3];   // Row 3 (left, mid, right) - portrait 9-slot mode only.
   bool    amsView;             // 240x240: replace gauge row 2 with AMS strip (per-printer)
+  uint8_t lightFlags;          // chamber-light automation bitmask (LIGHT_* flags), 0 = all off
+  uint8_t lightOffDelayMin;    // minutes to wait before turning light off (0-60), default 5
 };
 
 struct PrinterSlot {

--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -100,6 +100,7 @@ struct BambuState {
   bool doorAcknowledged;      // true after door opened on FINISH screen (print removed)
   bool bedCooldownAlertArmed; // armed on FINISH transition, fired when bedTemp <= threshold
   int8_t lightState;          // chamber_light from lights_report: -1 unknown, 0 off, 1 on
+  bool hasSecondLight;        // true if printer reports chamber_light2 (H2C/H2D dual bar)
   unsigned long lightOffDueMs; // millis() deadline for a scheduled light-off, 0 = none pending
   AmsState ams;               // AMS tray data
 };

--- a/include/config.h
+++ b/include/config.h
@@ -211,6 +211,7 @@
 #define LED_HEARTBEAT_PERIOD_MS   1500   // pyk-pyk-pause cycle
 #define LED_PAUSE_PERIOD_MS       3500   // slow breath while printer paused
 #define LED_ERROR_STROBE_MS        180   // strobe half-period (180 on / 180 off)
+#define LED_ERROR_STROBE_DEFAULT_S  60   // error strobe auto-off after N s (0 = never)
 #define LED_TICK_MIN_INTERVAL_MS    16   // throttle ledTick() to ~60Hz
 #define LED_TEST_DURATION_S          8   // /led/test runs the chosen effect for 8s
 

--- a/include/config.h
+++ b/include/config.h
@@ -4,7 +4,7 @@
 // =============================================================================
 //  Firmware version
 // =============================================================================
-#define FW_VERSION          "v3.7.1"
+#define FW_VERSION          "v3.7.2"
 
 // Board variant — injected into the web UI for OTA asset filtering.
 // Normally set via build_flags in platformio.ini; this is a fallback.

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -834,7 +834,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="card-head">
       <div>
         <h3>Chamber light</h3>
-        <p>Control this printer's chamber light. Automation runs per-printer; manual buttons toggle it now. Works in both LAN and Cloud mode (X1, P-series, H2 with a <em>chamber_light</em>).</p>
+        <p>Control this printer's chamber light. Automation runs per-printer; manual buttons toggle it now. Works in both LAN and Cloud mode (X1, P-series, H2). Dual-bar printers (H2C/H2D) switch both bars together.</p>
       </div>
       <span id="lightStateLbl" class="status-pill status-na">Light: -</span>
     </div>

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -86,7 +86,7 @@ function saveWifi(){
 //    Hardware: rotmode, rotinterval, btntype, btnpin, buzzen (DOUBLE Z!),
 //              buzpin, buzqs, buzqe, buzclick, buzbeden, buzbedtemp, leden,
 //              ledpin, ledbr, ledfxmd, ledfxsec, ledfxbr, ledauto, ledpause,
-//              lederr, batshow
+//              lederr, lederrsec, batshow
 //    WiFi:     ssid, pass, showpass2, netmode, net_ip, net_gw, net_sn,
 //              net_dns, showip, importFile, otaFile
 //    Power:    tsm_cur, tsm_tar, tsm_en, tsm_pt, tsm_ip, tsm_dm (radio), tsm_pi,
@@ -1197,9 +1197,13 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
         <label for="ledpause">Slow pulse during pause</label>
       </label>
       <label class="check-row">
-        <input type="checkbox" id="lederr" %LED_ERR%>
+        <input type="checkbox" id="lederr" %LED_ERR% onchange="toggleLedErr()">
         <label for="lederr">Fast strobe on error</label>
       </label>
+      <div class="field" id="ledErrParams" style="margin-top:var(--sp-2)">
+        <label for="lederrsec">Strobe auto-off (0 = never, else 5-600 seconds)</label>
+        <div class="hstack" style="gap:var(--sp-2)"><input type="number" id="lederrsec" min="0" max="600" value="%LED_ERR_SEC%" style="max-width:120px"><span class="text-dim small">seconds</span></div>
+      </div>
     </div>
   </div>
 
@@ -2071,11 +2075,17 @@ function toggleBuzPin(){
 function toggleLed(){
   document.getElementById('ledFields').style.display = document.getElementById('leden').value !== '0' ? 'block' : 'none';
   toggleLedFx();
+  toggleLedErr();
 }
 function toggleLedFx(){
   var fx = document.getElementById('ledfxmd');
   if (!fx) return;
   document.getElementById('ledFxParams').style.display = fx.value !== '0' ? 'block' : 'none';
+}
+function toggleLedErr(){
+  var c = document.getElementById('lederr');
+  if (!c) return;
+  document.getElementById('ledErrParams').style.display = c.checked ? 'block' : 'none';
 }
 function ledPreviewSend(){
   var p = new URLSearchParams();
@@ -2129,6 +2139,7 @@ function saveRotation(){
   p.append('ledauto', document.getElementById('ledauto').checked ? '1' : '0');
   p.append('ledpause', document.getElementById('ledpause').checked ? '1' : '0');
   p.append('lederr', document.getElementById('lederr').checked ? '1' : '0');
+  p.append('lederrsec', document.getElementById('lederrsec').value);
   var bs = document.getElementById('batshow');
   if (bs) p.append('batshow', bs.checked ? '1' : '0');
   fetch('/save/rotation',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -508,6 +508,7 @@ button, input, select, textarea { font-family: inherit; font-size: inherit; colo
   border-left: 3px solid var(--line);
   background: var(--bg-sub);
   color: var(--text-mid);
+  white-space: nowrap;
 }
 .status-pill.status-ok { border-left-color: var(--success); color: var(--success); }
 .status-pill.status-off { border-left-color: var(--danger); color: var(--danger); }

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -829,6 +829,37 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <button type="button" class="btn btn-primary" onclick="saveGaugeLayout()">Save Gauge Layout</button>
     </div>
   </div>
+
+  <div class="card">
+    <div class="card-head">
+      <div>
+        <h3>Chamber light</h3>
+        <p>Control this printer's chamber light. Automation runs per-printer; manual buttons toggle it now. Works in both LAN and Cloud mode (X1, P-series, H2 with a <em>chamber_light</em>).</p>
+      </div>
+      <span id="lightStateLbl" class="status-pill status-na">Light: -</span>
+    </div>
+    <label class="check-row">
+      <input type="checkbox" id="loff_fin" value="1">
+      <label for="loff_fin">Turn off after a successful print</label>
+    </label>
+    <label class="check-row">
+      <input type="checkbox" id="loff_fail" value="1">
+      <label for="loff_fail">Turn off after a failed or cancelled print</label>
+    </label>
+    <label class="check-row">
+      <input type="checkbox" id="lon_start" value="1">
+      <label for="lon_start">Turn on when a print starts</label>
+    </label>
+    <div class="field"><label for="ldelay">Off delay (applies to both off rules)</label>
+      <div class="hstack"><input type="number" id="ldelay" min="0" max="60" value="5">
+      <span class="text-dim small">min &middot; 0 = immediate</span></div>
+    </div>
+    <div class="action-bar">
+      <button type="button" class="btn btn-ghost btn-sm" onclick="setLight('on')">Light On</button>
+      <button type="button" class="btn btn-ghost btn-sm" onclick="setLight('off')">Light Off</button>
+      <button type="button" class="btn btn-primary" onclick="saveLightConfig()">Save Light Settings</button>
+    </div>
+  </div>
 </div>
 
 <!-- ===== Section 2: Display ===== -->
@@ -1798,6 +1829,45 @@ function saveGaugeLayout(){
     .catch(function(){showToast('Save failed');});
 }
 
+/* ============ Chamber light ============ */
+function renderLightState(v){
+  var el = document.getElementById('lightStateLbl');
+  if (!el) return;
+  if (v === 1) { el.className = 'status-pill status-ok'; el.textContent = 'Light: On'; }
+  else if (v === 0) { el.className = 'status-pill status-off'; el.textContent = 'Light: Off'; }
+  else { el.className = 'status-pill status-na'; el.textContent = 'Light: -'; }
+}
+function refreshLightState(){
+  fetch('/printer/config?slot=' + currentSlot).then(function(r){return r.json();})
+    .then(function(d){ renderLightState(d.lightState); }).catch(function(){});
+}
+function saveLightConfig(){
+  var p = new URLSearchParams();
+  p.append('slot', currentSlot);
+  if (document.getElementById('loff_fin').checked)  p.append('loff_fin', '1');
+  if (document.getElementById('loff_fail').checked) p.append('loff_fail', '1');
+  if (document.getElementById('lon_start').checked) p.append('lon_start', '1');
+  p.append('ldelay', document.getElementById('ldelay').value);
+  fetch('/light/config',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
+    .then(function(r){return r.json();})
+    .then(function(d){if(d.status==='ok')showToast('Light settings saved!');else showToast('Error');})
+    .catch(function(){showToast('Save failed');});
+}
+function setLight(mode){
+  var p = new URLSearchParams();
+  p.append('slot', currentSlot);
+  p.append('mode', mode);
+  fetch('/light/set',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
+    .then(function(r){return r.json();})
+    .then(function(d){
+      if (d.status === 'ok'){
+        showToast(mode === 'on' ? 'Light on sent' : 'Light off sent');
+        setTimeout(refreshLightState, 1500);  // confirm from next lights_report
+      } else showToast('Error');
+    })
+    .catch(function(){showToast('Command failed');});
+}
+
 /* ============ Printer tabs ============ */
 var currentSlot = 0;
 function selectPrinterTab(slot){
@@ -1832,6 +1902,12 @@ function selectPrinterTab(slot){
     if (d.portraitExtras)  { for (var g = 0; g < 3; g++) { var sel = document.getElementById('px' + g); if (sel) sel.value = d.portraitExtras[g] || 0; } }
     var av = document.getElementById('amsv');
     if (av) { av.checked = !!d.amsView; syncAmsView(); }
+    var lf = d.lightFlags || 0;
+    document.getElementById('loff_fin').checked  = !!(lf & 1);
+    document.getElementById('loff_fail').checked = !!(lf & 2);
+    document.getElementById('lon_start').checked = !!(lf & 4);
+    if (typeof d.lightDelay === 'number') document.getElementById('ldelay').value = d.lightDelay;
+    renderLightState(d.lightState);
     toggleConnMode();
     var ps = document.getElementById('printerStatus');
     if (d.connected) { ps.className = 'status-pill status-ok'; ps.textContent = 'Connected'; }

--- a/src/bambu_mqtt.cpp
+++ b/src/bambu_mqtt.cpp
@@ -225,6 +225,21 @@ static bool requestPushall(MqttConn& c, PushallReason reason) {
 // ---------------------------------------------------------------------------
 //  Chamber light control: publish a ledctrl command (LAN + Cloud, same topic)
 // ---------------------------------------------------------------------------
+static bool sendLightCtrlNode(MqttConn& c, const char* topic, const char* node, bool on) {
+  char payload[192];
+  snprintf(payload, sizeof(payload),
+           "{\"system\":{\"sequence_id\":\"%u\",\"command\":\"ledctrl\","
+           "\"led_node\":\"%s\",\"led_mode\":\"%s\","
+           "\"led_on_time\":500,\"led_off_time\":500,"
+           "\"loop_times\":0,\"interval_time\":0}}",
+           c.pushallSeqId++, node, on ? "on" : "off");
+  if (!c.mqtt->publish(topic, payload)) {
+    MQTT_LOG("[%d] ledctrl %s publish FAILED", c.slotIndex, node);
+    return false;
+  }
+  return true;
+}
+
 static bool sendLightCtrl(MqttConn& c, bool on) {
   if (!c.mqtt) return false;
 
@@ -232,20 +247,12 @@ static bool sendLightCtrl(MqttConn& c, bool on) {
   char topic[64];
   snprintf(topic, sizeof(topic), "device/%s/request", cfg.serial);
 
-  char payload[192];
-  snprintf(payload, sizeof(payload),
-           "{\"system\":{\"sequence_id\":\"%u\",\"command\":\"ledctrl\","
-           "\"led_node\":\"chamber_light\",\"led_mode\":\"%s\","
-           "\"led_on_time\":500,\"led_off_time\":500,"
-           "\"loop_times\":0,\"interval_time\":0}}",
-           c.pushallSeqId++, on ? "on" : "off");
-
   MQTT_LOG("[%d] light %s -> %s", c.slotIndex, on ? "on" : "off", topic);
-  if (!c.mqtt->publish(topic, payload)) {
-    MQTT_LOG("[%d] ledctrl publish FAILED", c.slotIndex);
-    return false;
-  }
-  return true;
+  bool ok = sendLightCtrlNode(c, topic, "chamber_light", on);
+  // H2C/H2D have a second bar (chamber_light2) the app keeps in sync; control both.
+  if (printers[c.slotIndex].state.hasSecondLight)
+    ok &= sendLightCtrlNode(c, topic, "chamber_light2", on);
+  return ok;
 }
 
 static void clearLiveMetrics(BambuState& s) {
@@ -723,10 +730,12 @@ static void parseMqttPayload(byte* payload, unsigned int length, BambuState& s, 
   if (print["lights_report"].is<JsonArray>()) {
     for (JsonObject lr : print["lights_report"].as<JsonArray>()) {
       const char* node = lr["node"];
-      if (node && strcmp(node, "chamber_light") == 0) {
+      if (!node) continue;
+      if (strcmp(node, "chamber_light") == 0) {
         const char* mode = lr["mode"];
         s.lightState = (mode && strcmp(mode, "off") == 0) ? 0 : 1;
-        break;
+      } else if (strcmp(node, "chamber_light2") == 0) {
+        s.hasSecondLight = true;  // H2C/H2D second bar - control it alongside chamber_light
       }
     }
   }
@@ -1606,6 +1615,7 @@ static void initConnSlot(uint8_t i) {
 
   BambuState& s = printers[i].state;
   memset(&s, 0, sizeof(BambuState));
+  s.lightState = -1;  // unknown until lights_report arrives (memset would read as "off")
   setPrinterGcodeStateCanonical(s, GCODE_UNKNOWN);
 
   if (isPrinterConfigured(i)) {

--- a/src/bambu_mqtt.cpp
+++ b/src/bambu_mqtt.cpp
@@ -222,6 +222,32 @@ static bool requestPushall(MqttConn& c, PushallReason reason) {
   return true;
 }
 
+// ---------------------------------------------------------------------------
+//  Chamber light control: publish a ledctrl command (LAN + Cloud, same topic)
+// ---------------------------------------------------------------------------
+static bool sendLightCtrl(MqttConn& c, bool on) {
+  if (!c.mqtt) return false;
+
+  PrinterConfig& cfg = printers[c.slotIndex].config;
+  char topic[64];
+  snprintf(topic, sizeof(topic), "device/%s/request", cfg.serial);
+
+  char payload[192];
+  snprintf(payload, sizeof(payload),
+           "{\"system\":{\"sequence_id\":\"%u\",\"command\":\"ledctrl\","
+           "\"led_node\":\"chamber_light\",\"led_mode\":\"%s\","
+           "\"led_on_time\":500,\"led_off_time\":500,"
+           "\"loop_times\":0,\"interval_time\":0}}",
+           c.pushallSeqId++, on ? "on" : "off");
+
+  MQTT_LOG("[%d] light %s -> %s", c.slotIndex, on ? "on" : "off", topic);
+  if (!c.mqtt->publish(topic, payload)) {
+    MQTT_LOG("[%d] ledctrl publish FAILED", c.slotIndex);
+    return false;
+  }
+  return true;
+}
+
 static void clearLiveMetrics(BambuState& s) {
   s.nozzleTemp = 0;    s.nozzleTarget = 0;
   s.nozzleTempN[0] = 0; s.nozzleTargetN[0] = 0;
@@ -306,6 +332,8 @@ static void parseMqttPayload(byte* payload, unsigned int length, BambuState& s, 
   pf["spd_lvl"] = true;
   pf["stat"] = true;       // H2/P2S door sensor (hex string, bit 0x00800000 = door open)
   pf["home_flag"] = true;  // X1 series door sensor (int, bit 23 = door open)
+  pf["lights_report"][0]["node"] = true;  // chamber_light on/off/flashing state
+  pf["lights_report"][0]["mode"] = true;
   // Note: H2D/H2C extruder data is parsed separately from raw payload (see below)
 
   JsonDocument doc;
@@ -689,6 +717,18 @@ static void parseMqttPayload(byte* payload, unsigned int length, BambuState& s, 
     const char* state = print["gcode_state"];
     setPrinterGcodeStateRaw(s, state);
     s.printing = isPrintingGcodeState(s.gcodeStateId);
+  }
+
+  // Chamber light: track real on/off state for the web UI (treat flashing as on)
+  if (print["lights_report"].is<JsonArray>()) {
+    for (JsonObject lr : print["lights_report"].as<JsonArray>()) {
+      const char* node = lr["node"];
+      if (node && strcmp(node, "chamber_light") == 0) {
+        const char* mode = lr["mode"];
+        s.lightState = (mode && strcmp(mode, "off") == 0) ? 0 : 1;
+        break;
+      }
+    }
   }
 
   if (print["mc_percent"].is<int>()) {
@@ -1581,6 +1621,12 @@ static void initConnSlot(uint8_t i) {
   }
 }
 
+// Pending chamber-light command per slot: -1 none, 0 off, 1 on. Set by the web
+// handler / automation hooks (main loop context) and drained in handleBambuMqtt()
+// so the actual PubSubClient publish always runs on the MQTT context.
+// Initialized to all -1 in initBambuMqtt() (static zero-init would mean "off").
+static volatile int8_t g_lightCmdReq[MAX_ACTIVE_PRINTERS];
+
 void initBambuMqtt() {
   Serial.println("MQTT: initBambuMqtt() — multi-printer");
 
@@ -1591,6 +1637,7 @@ void initBambuMqtt() {
     }
     releaseClients(conns[i]);
     conns[i].active = false;
+    g_lightCmdReq[i] = -1;  // no pending light command
   }
 
   // First: do all cloud API work (userId extraction) before any MQTT connects.
@@ -1639,6 +1686,13 @@ void handleBambuMqtt() {
       g_extRefreshReq[i] = false;
       requestCloudRefresh(i);
     }
+    // Drain a pending chamber-light command. Only publish on a live connection;
+    // otherwise keep the request so it fires once the slot reconnects.
+    if (g_lightCmdReq[i] >= 0 && conns[i].mqtt && conns[i].mqtt->connected()) {
+      bool on = (g_lightCmdReq[i] == 1);
+      g_lightCmdReq[i] = -1;
+      sendLightCtrl(conns[i], on);
+    }
   }
 }
 
@@ -1678,6 +1732,13 @@ void requestCloudRefreshFromTask(uint8_t slot) {
   // handleBambuMqtt(). A single-byte volatile write is atomic on ESP32; a race
   // with the drain just costs at most one extra refresh next loop.
   if (slot < MAX_ACTIVE_PRINTERS) g_extRefreshReq[slot] = true;
+}
+
+void requestLightCommand(uint8_t slot, bool on) {
+  if (slot >= MAX_ACTIVE_PRINTERS) return;
+  g_lightCmdReq[slot] = on ? 1 : 0;
+  // Turning the light on (manual or print-start) cancels any pending auto-off.
+  if (on) printers[slot].state.lightOffDueMs = 0;
 }
 
 void disconnectBambuMqtt() {

--- a/src/bambu_mqtt.h
+++ b/src/bambu_mqtt.h
@@ -60,6 +60,7 @@ void resetMqttBackoff();                 // reset backoff + force immediate reco
 void deferMqttReconnect();               // skip reconnect attempts for one iteration
 void requestCloudRefresh(uint8_t slot);  // manual pushall for cloud non-printing states (debounced)
 void requestCloudRefreshFromTask(uint8_t slot);  // thread-safe: defers the pushall to the MQTT task (safe to call from the Tasmota poll task)
+void requestLightCommand(uint8_t slot, bool on);  // chamber light on/off; deferred + published on the MQTT context
 
 // Human-readable error string for PubSubClient rc
 const char* mqttRcToString(int rc);

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -21,6 +21,14 @@ static uint8_t       finishEffectMode     = LED_FINISH_OFF;
 static uint8_t       finishEffectPeak     = 255;
 static unsigned long lastTickMs           = 0;
 
+// Error-strobe episode state. Armed on the first tick of a GCODE_FAILED episode
+// (not in ledSetActivity - main.cpp re-asserts IDLE then FAILED every loop, which
+// would reset the timer). Auto-stops after errorStrobeSeconds (0 = never), or when
+// dismissed by a user interaction. Re-arms once the activity leaves FAILED.
+static bool          errorStrobeArmed     = false;
+static unsigned long errorStrobeEndMs     = 0;
+static bool          errorStrobeDismissed = false;
+
 // Live-preview override. While set, ledTick() uses previewBrightness as the
 // resting/peak duty instead of ledSettings.brightness, so the 60Hz tick stops
 // fighting rapid slider previews with the stale saved value. Cleared on
@@ -159,6 +167,10 @@ void sanitizeLedPin() {
   if (ledSettings.finishMode > LED_FINISH_HEARTBEAT) ledSettings.finishMode = LED_FINISH_OFF;
   if (ledSettings.finishSeconds < 5)   ledSettings.finishSeconds = 5;
   if (ledSettings.finishSeconds > 600) ledSettings.finishSeconds = 600;
+  // errorStrobeSeconds: 0 = never time out; otherwise clamp to 5..600.
+  if (ledSettings.errorStrobeSeconds != 0 && ledSettings.errorStrobeSeconds < 5)
+    ledSettings.errorStrobeSeconds = 5;
+  if (ledSettings.errorStrobeSeconds > 600) ledSettings.errorStrobeSeconds = 600;
 
   // Default unset state (disabled + pin=0) is valid - skip pin validation.
   if (!ledSettings.enabled && ledSettings.pin == 0) return;
@@ -198,6 +210,8 @@ void initLed() {
   finishEffectActive = false;
   currentActivity = LED_ACT_IDLE;
   previewActive = false;
+  errorStrobeArmed = false;
+  errorStrobeDismissed = false;
 
   detachAndForceLow();
   // Disabled with a saved pin: drive it LOW instead of leaving it high-Z, so the
@@ -311,6 +325,13 @@ bool ledTriggerTestEffect(uint8_t mode, uint16_t seconds, uint8_t peakBrightness
 
 void ledOnUserInteraction() {
   if (finishEffectActive) ledStopFinishEffect();
+  // Button / touch / wake also silences an active error strobe - user has seen
+  // the fault. Stays dismissed until the activity leaves FAILED and a new fault
+  // re-arms it.
+  if (errorStrobeArmed && !errorStrobeDismissed) {
+    errorStrobeDismissed = true;
+    lastWrittenDuty = -1;  // force resting duty recompute on next tick
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -379,8 +400,26 @@ void ledTick() {
   // 4) Pause breathing (continuous while paused)
   // 5) Auto on/off based on activity
   // 6) Idle: configured brightness
+  // Error-strobe arming / auto-off. Arm on the first FAILED tick of an episode;
+  // re-arm only after the activity has left FAILED. errorStrobeSeconds == 0 means
+  // strobe until dismissed (button) or the fault clears.
+  if (currentActivity == LED_ACT_FAILED) {
+    if (!errorStrobeArmed) {
+      errorStrobeArmed = true;
+      errorStrobeDismissed = false;
+      errorStrobeEndMs = now + (unsigned long)ledSettings.errorStrobeSeconds * 1000UL;
+    }
+    if (!errorStrobeDismissed && ledSettings.errorStrobeSeconds > 0 &&
+        (long)(now - errorStrobeEndMs) >= 0) {
+      errorStrobeDismissed = true;
+      lastWrittenDuty = -1;  // force resting duty on this tick
+    }
+  } else {
+    errorStrobeArmed = false;
+  }
+
   uint8_t baseBrightness = restingBrightness();
-  if (ledSettings.errorStrobe && currentActivity == LED_ACT_FAILED) {
+  if (ledSettings.errorStrobe && currentActivity == LED_ACT_FAILED && !errorStrobeDismissed) {
     duty = patternStrobe(now, LED_ERROR_STROBE_MS, baseBrightness);
   } else if (finishEffectActive) {
     unsigned long phase = now - finishEffectStartMs;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -594,6 +594,30 @@ static void handleConnectingScreenRecovery() {
   }
 }
 
+// Schedule a chamber-light-off for a slot if the given automation flag is set.
+// The off is published later by processLightTimers() once the delay elapses.
+// A delay of 0 fires on the next loop (due = now, but never the 0 sentinel).
+static void scheduleLightOff(uint8_t slot, uint8_t flag) {
+  PrinterConfig& cfg = printers[slot].config;
+  if (!(cfg.lightFlags & flag)) return;
+  unsigned long due = millis() + (unsigned long)cfg.lightOffDelayMin * 60000UL;
+  if (due == 0) due = 1;  // 0 means "none pending"
+  printers[slot].state.lightOffDueMs = due;
+}
+
+// Fire any chamber-light-off whose delay has elapsed. Called once per loop.
+static void processLightTimers() {
+  unsigned long now = millis();
+  for (uint8_t i = 0; i < MAX_ACTIVE_PRINTERS; i++) {
+    if (!isPrinterConfigured(i)) continue;
+    BambuState& ps = printers[i].state;
+    if (ps.lightOffDueMs != 0 && (long)(now - ps.lightOffDueMs) >= 0) {
+      ps.lightOffDueMs = 0;
+      requestLightCommand(i, false);
+    }
+  }
+}
+
 static void handleGcodeStateTransitions() {
   // Per-slot transition tracking. All transition checks must happen BEFORE
   // updating prevGcodeStateId[i] at the end - so a single combined helper
@@ -605,6 +629,7 @@ static void handleGcodeStateTransitions() {
     if (prevGcodeStateSeen[i]) {
       if (ps.gcodeStateId == GCODE_FAILED && prevGcodeStateId[i] != GCODE_FAILED) {
         buzzerPlay(BUZZ_ERROR);
+        scheduleLightOff(i, LIGHT_OFF_ON_FAILED);
       }
       if (ps.gcodeStateId == GCODE_FINISH && prevGcodeStateId[i] != GCODE_FINISH) {
         if (buzzerSettings.bedCooldownAlert) {
@@ -625,11 +650,14 @@ static void handleGcodeStateTransitions() {
         }
         setBacklight(getEffectiveBrightness());
         rotState.displayHoldUntilMs = millis() + rotState.intervalMs;
+        scheduleLightOff(i, LIGHT_OFF_ON_FINISH);
       }
       if (isPrintingGcodeState(ps.gcodeStateId) &&
           !isPrintingGcodeState(prevGcodeStateId[i])) {
         ps.bedCooldownAlertArmed = false;
         ps.finishBuzzerPlayed = false;  // per-slot reset so a hidden printer's next finish still beeps
+        if (printers[i].config.lightFlags & LIGHT_ON_AT_START)
+          requestLightCommand(i, true);  // also cancels any pending auto-off
       }
 
       // Per-slot Tasmota print start/end edges — independent of which printer
@@ -829,6 +857,7 @@ void loop() {
   handleDisplaySleepTimeouts();
   handleConnectingScreenRecovery();
   handleGcodeStateTransitions();
+  processLightTimers();
   handleBedCooldownBuzzers();
 
   buzzerTick();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -357,8 +357,15 @@ void loadSettings() {
     snprintf(key, sizeof(key), "p%d_amsv", i);
     cfg.amsView = prefs.getBool(key, false);
 
+    // Chamber-light automation (per-printer): flag bitmask + off delay (minutes)
+    snprintf(key, sizeof(key), "p%d_lflag", i);
+    cfg.lightFlags = prefs.getUChar(key, 0);
+    snprintf(key, sizeof(key), "p%d_ldly", i);
+    cfg.lightOffDelayMin = prefs.getUChar(key, 5);
+
     // Zero out state
     memset(&printers[i].state, 0, sizeof(BambuState));
+    printers[i].state.lightState = -1;  // unknown until lights_report arrives
     setPrinterGcodeStateCanonical(printers[i].state, GCODE_UNKNOWN);
   }
 
@@ -844,6 +851,11 @@ void savePrinterConfig(uint8_t index) {
   snprintf(key, sizeof(key), "p%d_amsv", index);
   prefs.putBool(key, cfg.amsView);
 
+  snprintf(key, sizeof(key), "p%d_lflag", index);
+  prefs.putUChar(key, cfg.lightFlags);
+  snprintf(key, sizeof(key), "p%d_ldly", index);
+  prefs.putUChar(key, cfg.lightOffDelayMin);
+
   if (needOpen) prefs.end();
 }
 
@@ -853,6 +865,7 @@ void clearPrinterConfig(uint8_t index) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.mode   = CONN_LOCAL;
   cfg.region = REGION_US;
+  cfg.lightOffDelayMin = 5;  // sensible default after a slot is cleared
   defaultGaugeSlots(cfg.gaugeSlots);
   memset(cfg.landscapeExtras, GAUGE_EMPTY, sizeof(cfg.landscapeExtras));
   memset(cfg.portraitExtras, GAUGE_EMPTY, sizeof(cfg.portraitExtras));

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -31,6 +31,7 @@ LedSettings ledSettings = {
   /*autoOnWhilePrinting*/ false,
   /*pauseBreathing*/      false,
   /*errorStrobe*/         false,
+  /*errorStrobeSeconds*/  LED_ERROR_STROBE_DEFAULT_S,
 };
 TasmotaSettings tasmotaSettings[TASMOTA_PLUG_COUNT] = {};
 float tasmotaTariffPerKwh = 0.0f;
@@ -573,6 +574,7 @@ void loadSettings() {
   ledSettings.autoOnWhilePrinting = prefs.getBool("led_auto_pr", false);
   ledSettings.pauseBreathing      = prefs.getBool("led_pause",   false);
   ledSettings.errorStrobe         = prefs.getBool("led_err",     false);
+  ledSettings.errorStrobeSeconds  = prefs.getUShort("led_err_sec", LED_ERROR_STROBE_DEFAULT_S);
 
   // Cloud email (display only)
   strlcpy(cloudEmail, prefs.getString("cl_email", "").c_str(), sizeof(cloudEmail));
@@ -904,6 +906,7 @@ void saveLedSettings() {
   prefs.putBool("led_auto_pr", ledSettings.autoOnWhilePrinting);
   prefs.putBool("led_pause",   ledSettings.pauseBreathing);
   prefs.putBool("led_err",     ledSettings.errorStrobe);
+  prefs.putUShort("led_err_sec", ledSettings.errorStrobeSeconds);
   prefs.end();
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -216,6 +216,7 @@ struct LedSettings {
   bool autoOnWhilePrinting;    // LED on only while printer is printing
   bool pauseBreathing;         // slow breath during GCODE_PAUSE
   bool errorStrobe;            // fast strobe during GCODE_FAILED
+  uint16_t errorStrobeSeconds; // error strobe auto-off after N s (0 = never)
 };
 
 // Tasmota smart plug power monitoring

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -734,6 +734,11 @@ static void handleLightConfig() {
   if (server.hasArg("ldelay"))
     cfg.lightOffDelayMin = constrain(server.arg("ldelay").toInt(), 0, 60);
 
+  // If both off-rules are now disabled, cancel any pending off timer so a stale
+  // deadline scheduled under the old rules doesn't still turn the light off later.
+  if (!(flags & (LIGHT_OFF_ON_FINISH | LIGHT_OFF_ON_FAILED)))
+    printers[slot].state.lightOffDueMs = 0;
+
   savePrinterConfig(slot);
   server.send(200, "application/json", "{\"status\":\"ok\"}");
 }
@@ -743,8 +748,16 @@ static void handleLightSet() {
   uint8_t slot = 0;
   if (server.hasArg("slot")) slot = server.arg("slot").toInt();
   if (slot >= MAX_ACTIVE_PRINTERS) slot = 0;
-  bool on = server.hasArg("mode") && server.arg("mode") == "on";
-  requestLightCommand(slot, on);
+  if (!isPrinterConfigured(slot)) {
+    server.send(409, "application/json", "{\"status\":\"error\",\"message\":\"printer not configured\"}");
+    return;
+  }
+  String mode = server.hasArg("mode") ? server.arg("mode") : String();
+  if (mode != "on" && mode != "off") {
+    server.send(400, "application/json", "{\"status\":\"error\",\"message\":\"mode must be on or off\"}");
+    return;
+  }
+  requestLightCommand(slot, mode == "on");
   server.send(200, "application/json", "{\"status\":\"ok\"}");
 }
 
@@ -1093,6 +1106,8 @@ static void handleSettingsExport() {
     JsonArray pext = p["portraitExtras"].to<JsonArray>();
     for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
     p["amsView"] = cfg.amsView;
+    p["lightFlags"] = cfg.lightFlags;       // chamber-light automation bitmask
+    p["lightDelay"] = cfg.lightOffDelayMin; // off delay (minutes)
   }
 
   // Display
@@ -1391,6 +1406,8 @@ static void handleSettingsImportFinish() {
       } else if (legacyAmsViewPresent) {
         cfg.amsView = legacyAmsView;
       }
+      if (p["lightFlags"].is<uint8_t>()) cfg.lightFlags = p["lightFlags"].as<uint8_t>();
+      if (p["lightDelay"].is<uint8_t>()) cfg.lightOffDelayMin = constrain(p["lightDelay"].as<int>(), 0, 60);
     }
   }
 

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -432,6 +432,7 @@ static void handleStatus() {
   doc["layers"] = st.totalLayers;
   doc["display_off"] = (getScreenState() == SCREEN_OFF);
   doc["name"] = printers[slot].config.name;
+  doc["lightState"] = st.lightState;  // -1 unknown / 0 off / 1 on (chamber light)
 
   // Device-wide (new design's Detected Hardware + WiFi live KV)
   doc["heap_kb"] = ESP.getFreeHeap() / 1024;
@@ -709,10 +710,42 @@ static void handlePrinterConfig() {
   JsonArray pext = doc["portraitExtras"].to<JsonArray>();
   for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
   doc["amsView"] = cfg.amsView;
+  doc["lightFlags"] = cfg.lightFlags;       // chamber-light automation bitmask
+  doc["lightDelay"] = cfg.lightOffDelayMin; // off delay (minutes)
+  doc["lightState"] = st.lightState;        // -1 unknown / 0 off / 1 on
 
   String json;
   serializeJson(doc, json);
   server.send(200, "application/json", json);
+}
+
+// Save chamber-light automation settings (no MQTT reinit - mirrors gauge layout)
+static void handleLightConfig() {
+  uint8_t slot = 0;
+  if (server.hasArg("slot")) slot = server.arg("slot").toInt();
+  if (slot >= MAX_ACTIVE_PRINTERS) slot = 0;
+
+  PrinterConfig& cfg = printers[slot].config;
+  uint8_t flags = 0;
+  if (server.hasArg("loff_fin"))  flags |= LIGHT_OFF_ON_FINISH;
+  if (server.hasArg("loff_fail")) flags |= LIGHT_OFF_ON_FAILED;
+  if (server.hasArg("lon_start")) flags |= LIGHT_ON_AT_START;
+  cfg.lightFlags = flags;
+  if (server.hasArg("ldelay"))
+    cfg.lightOffDelayMin = constrain(server.arg("ldelay").toInt(), 0, 60);
+
+  savePrinterConfig(slot);
+  server.send(200, "application/json", "{\"status\":\"ok\"}");
+}
+
+// Turn chamber light on/off now from the web UI
+static void handleLightSet() {
+  uint8_t slot = 0;
+  if (server.hasArg("slot")) slot = server.arg("slot").toInt();
+  if (slot >= MAX_ACTIVE_PRINTERS) slot = 0;
+  bool on = server.hasArg("mode") && server.arg("mode") == "on";
+  requestLightCommand(slot, on);
+  server.send(200, "application/json", "{\"status\":\"ok\"}");
 }
 
 // Test buzzer from web UI
@@ -1865,6 +1898,8 @@ void initWebServer() {
   server.on("/led/test",    HTTP_POST, handleLedTest);
   server.on("/printer/config", HTTP_GET, handlePrinterConfig);
   server.on("/printer/clear", HTTP_POST, handleClearPrinter);
+  server.on("/light/config", HTTP_POST, handleLightConfig);
+  server.on("/light/set", HTTP_POST, handleLightSet);
   server.on("/apply", HTTP_POST, handleApply);
   server.on("/brightness", HTTP_GET, handleBrightnessPreview);
   server.on("/status", HTTP_GET, handleStatus);

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -893,6 +893,11 @@ static void handleSaveRotation() {
   if (server.hasArg("ledauto"))  ledSettings.autoOnWhilePrinting = (server.arg("ledauto")  == "1");
   if (server.hasArg("ledpause")) ledSettings.pauseBreathing      = (server.arg("ledpause") == "1");
   if (server.hasArg("lederr"))   ledSettings.errorStrobe         = (server.arg("lederr")   == "1");
+  if (server.hasArg("lederrsec")) {
+    int v = server.arg("lederrsec").toInt();
+    if (v != 0 && v < 5) v = 5; if (v > 600) v = 600;
+    ledSettings.errorStrobeSeconds = (uint16_t)v;
+  }
   saveLedSettings();
   initLed();
 
@@ -1180,6 +1185,7 @@ static void handleSettingsExport() {
   led["autoOnWhilePrinting"] = ledSettings.autoOnWhilePrinting;
   led["pauseBreathing"]      = ledSettings.pauseBreathing;
   led["errorStrobe"]         = ledSettings.errorStrobe;
+  led["errorStrobeSeconds"]  = ledSettings.errorStrobeSeconds;
 
   // Tasmota power monitoring
   JsonObject tsm = doc["tasmota"].to<JsonObject>();
@@ -1529,6 +1535,11 @@ static void handleSettingsImportFinish() {
     if (led["autoOnWhilePrinting"].is<bool>()) ledSettings.autoOnWhilePrinting = led["autoOnWhilePrinting"].as<bool>();
     if (led["pauseBreathing"].is<bool>())      ledSettings.pauseBreathing      = led["pauseBreathing"].as<bool>();
     if (led["errorStrobe"].is<bool>())         ledSettings.errorStrobe         = led["errorStrobe"].as<bool>();
+    if (led["errorStrobeSeconds"].is<uint16_t>()) {
+      uint16_t s = led["errorStrobeSeconds"].as<uint16_t>();
+      if (s != 0 && s < 5) s = 5; if (s > 600) s = 600;
+      ledSettings.errorStrobeSeconds = s;
+    }
   }
 
   // Tasmota power monitoring

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -450,6 +450,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
   if (strcmp(name, "LED_AUTO")      == 0) { out = ledSettings.autoOnWhilePrinting ? "checked" : ""; return true; }
   if (strcmp(name, "LED_PAUSE")     == 0) { out = ledSettings.pauseBreathing ? "checked" : ""; return true; }
   if (strcmp(name, "LED_ERR")       == 0) { out = ledSettings.errorStrobe ? "checked" : ""; return true; }
+  if (strcmp(name, "LED_ERR_SEC")   == 0) { out = String(ledSettings.errorStrobeSeconds); return true; }
 
   // --- Battery indicator (Waveshare boards only) ---
   if (strcmp(name, "BAT_TOGGLE_ROW") == 0) {


### PR DESCRIPTION
Adds per-printer chamber-light control - the first write/control feature (until now the firmware was a read-only monitor).

## Features
- **Manual control:** Light On / Light Off buttons per printer from the web UI, live state label (On / Off / unknown) read from `lights_report`.
- **Automation (per printer):** turn off after a successful print, turn off after a failed/cancelled print, turn on when a print starts, with a configurable off delay (0-60 min).
- Works in both LAN and Cloud mode (X1, P-series, H2). Publishes a `ledctrl` command to `device/<serial>/request`.

## Dual-bar printers (H2C/H2D)
These expose two light bars (`chamber_light` + `chamber_light2`). The initial implementation only switched the left bar, leaving the right one lit. Now `chamber_light2` is detected from `lights_report` and the command is mirrored to both bars so they track together. Single-bar printers are unaffected.

## Hardening
- Restore `lightState = -1` (unknown) after the connection-slot reset so the UI doesn't show a false "Off" before the printer reports.
- Settings export/import now carry `lightFlags` and `lightOffDelayMin` so automation survives backup/restore.
- Cancel a pending off timer when both off-rules are disabled.
- `/light/set` returns 409 for an unconfigured slot and 400 for a missing/invalid mode.
- Status pill no longer wraps onto two lines.

## Testing
- All 7 maintained envs build (esp32s3, ws_lcd_200, cyd, esp32s3_zero, ws_lcd_154, jc3248w535, esp32c3).
- Manual control verified live on P1S (LAN) and H2C (Cloud, both bars).

Version bumped to v3.7.2.

Addresses #126
