### PR TITLE
fix: replace UTF-8 em dashes with ASCII dashes in partition CSV files

### DIFF
--- a/partitions_16mb.csv
+++ b/partitions_16mb.csv
@@ -1,5 +1,5 @@
-# Partition table for 16 MB flash (Guition JC3248W535 — ESP32-S3-N16R8)
-# Dual OTA app slots of 6.25 MB each — large headroom for future features.
+# Partition table for 16 MB flash (Guition JC3248W535 -- ESP32-S3-N16R8)
+# Dual OTA app slots of 6.25 MB each -- large headroom for future features.
 # SPIFFS reserved at end but unused (settings stored in NVS).
 # NOTE: changing the partition table requires a full USB flash; OTA cannot update it.
 #

--- a/partitions_4mb.csv
+++ b/partitions_4mb.csv
@@ -1,5 +1,5 @@
 # Partition table for 4 MB flash (ESP32-S3 Super Mini, CYD, ESP32-C3)
-# app partitions are 1.75 MB each — 568 KB headroom over current firmware size.
+# app partitions are 1.75 MB each -- 568 KB headroom over current firmware size.
 # SPIFFS is not used by BambuHelper (settings stored in NVS).
 # NOTE: changing the partition table requires a full USB flash; OTA cannot update it.
 #


### PR DESCRIPTION
PlatformIO's espressif32 platform reads partition CSV files using Python's default encoding, which is GBK on Chinese Windows systems (and CP932/CP949 on Japanese/Korean Windows). The UTF-8 em dash character (U+2014, encoded as 0xE2 0x80 0x94) in comment lines cannot be decoded by these codecs, causing a UnicodeDecodeError during the build process:

  UnicodeDecodeError: 'gbk' codec can't decode byte 0x94

This error occurs at the checkprogsize step after successful linking, making it particularly frustrating as the build appears to succeed until the final verification stage.

Fix: Replace all UTF-8 em dashes (—) with ASCII double dashes (--) in partition CSV comments, making these files pure ASCII. This ensures they can be read under any locale encoding without errors, and the comment meaning remains intact.

Files changed:
- partitions_4mb.csv: 1 occurrence
- partitions_16mb.csv: 2 occurrences
- partitions_8mb.csv: no change needed (already pure ASCII)