### PR TITLE
Control printer plug from the device button (#136)

### DIFF
--- a/include/tasmota.h
+++ b/include/tasmota.h
@@ -13,6 +13,12 @@ void  tasmotaInit();
 uint8_t tasmotaPlugForPrinterSlot(uint8_t slot);
 uint8_t tasmotaPrinterSlotForPlug(uint8_t plug);
 
+// LOOSE control mapping: the plug a printer `slot` should power-control from the
+// device button. Matches the visibility mapping used by the watts gauge, so
+// "gauge visible" and "can power-control" stay coherent on single-plug ("Any")
+// builds where the strict mapping returns 0xFF on slots 1-3. 0xFF if none.
+uint8_t tasmotaControlPlugForSlot(uint8_t slot);
+
 // Display-side accessors. These keep all plug-mapping policy inside tasmota.cpp.
 //   tasmotaIsActiveForSlot - LOOSE visibility + strict freshness gate
 //   tasmotaGetWattsForSlot - LOOSE mapping; 0 when not active

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -1551,6 +1551,15 @@ R"rawliteral(
   </div>
 
   <div class="card">
+    <div class="card-head"><div><h3>Button power control</h3></div></div>
+    <label class="check-row">
+      <input type="checkbox" id="btnpwr" value="1" %BTN_PWR% onchange="toggleSetting('btnpwr',this.checked)">
+      <label for="btnpwr">Double-click device button to turn the plug on/off</label>
+    </label>
+    <div class="help-text" style="padding-left:28px">Double- or triple-click the device button (or touchscreen) to open a full-screen confirmation for the printer on screen, then hold to toggle its plug (red warning if it is printing). Only active when a plug is configured for the shown printer; while armed it adds a short delay to single-tap printer switching.</div>
+  </div>
+
+  <div class="card">
     <div class="card-head"><div><h3>Live stats</h3></div><span class="mono small text-dim">updates 5 s</span></div>
     <dl class="kv">
       <dt>Status</dt><dd><span id="ptStatusDot" class="text-dim">(offline)</span></dd>

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -3538,6 +3538,98 @@ void checkNightMode() {
 }
 
 // ---------------------------------------------------------------------------
+//  Screen: plug power on/off confirmation (#136)
+// ---------------------------------------------------------------------------
+// Fullscreen modal reached by double/triple-clicking the device button when a
+// plug is mapped to the shown printer. Static text (question + name) is painted
+// once on entry / phase change; the hold-to-confirm ring redraws every frame.
+static void drawPowerConfirm() {
+  PowerConfirmView v;
+  if (!powerConfirmGetView(&v)) return;
+
+  const int16_t cx = uiW() / 2;
+  const int16_t cy = uiH() / 2;
+  const uint16_t bg = v.warn ? TFT_RED : CLR_BG;
+
+  static int8_t prevPhase = -1;
+  static int8_t prevWarn  = -1;
+  bool full = forceRedraw || prevPhase != (int8_t)v.phase || prevWarn != (int8_t)v.warn;
+  prevPhase = (int8_t)v.phase;
+  prevWarn  = (int8_t)v.warn;
+
+  tft.setTextDatum(MC_DATUM);
+
+  if (full) {
+    tft.fillScreen(bg);
+    markFrameDirty();
+  }
+
+  // Sending: relay command in flight (blocking). Draw once, then tell main it is
+  // safe to fire the command (the frame is now committed by flushFrame()).
+  if (v.phase == 2) {
+    if (full) {
+      setFont(tft, FONT_LARGE);
+      tft.setTextColor(CLR_TEXT, bg);
+      tft.drawString("Sending...", cx, cy);
+      markFrameDirty();
+    }
+    powerConfirmMarkSendingDrawn();
+    return;
+  }
+
+  // Result: success / failure flash before returning to the prior screen.
+  if (v.phase == 3) {
+    if (full) {
+      setFont(tft, FONT_LARGE);
+      tft.setTextColor(v.resultOk ? CLR_GREEN : CLR_ORANGE, bg);
+      const char* msg = v.resultOk ? (v.desiredOn ? "Turned ON" : "Turned OFF")
+                                   : "Plug offline";
+      tft.drawString(msg, cx, cy);
+      markFrameDirty();
+    }
+    return;
+  }
+
+  // Wait-release / armed: question + name + hold ring.
+  if (full) {
+    setFont(tft, FONT_BODY);
+    tft.setTextColor(CLR_TEXT, bg);
+    tft.drawString(v.desiredOn ? "Turn ON printer" : "Turn OFF printer", cx, cy - 70);
+
+    setFont(tft, FONT_LARGE);
+    char nameBuf[28];
+    snprintf(nameBuf, sizeof(nameBuf), "\"%s\"", (v.name && v.name[0]) ? v.name : "printer");
+    tft.drawString(nameBuf, cx, cy - 44);
+
+    if (v.warn) {
+      setFont(tft, FONT_BODY);
+      tft.setTextColor(CLR_TEXT, bg);
+      tft.drawString("PRINTING", cx, cy - 16);
+    }
+
+    setFont(tft, FONT_SMALL);
+    tft.setTextColor(CLR_TEXT_DIM, bg);
+    tft.drawString("hold to confirm", cx, cy + 74);
+    tft.drawString("tap to cancel",   cx, cy + 92);
+    if (v.offline) {
+      tft.setTextColor(CLR_ORANGE, bg);
+      tft.drawString("plug offline", cx, cy + 110);
+    }
+  }
+
+  // Hold-to-confirm ring (redraw the full track every frame, then the fill, so a
+  // cancelled/restarted hold leaves no stale progress pixels).
+  const int16_t ry = cy + 24;
+  const int16_t rr = 34, rt = 8;
+  tft.drawArc(cx, ry, rr, rr - rt, 0, 360, CLR_TRACK);
+  float p = v.progress;
+  if (p < 0.0f) p = 0.0f;
+  if (p > 1.0f) p = 1.0f;
+  if (p > 0.003f) tft.drawArc(cx, ry, rr, rr - rt, 0, 360.0f * p, CLR_GREEN);
+  markFrameDirty();
+}
+
+// ---------------------------------------------------------------------------
 //  Main update (called from loop)
 // ---------------------------------------------------------------------------
 void updateDisplay() {
@@ -3653,6 +3745,10 @@ void updateDisplay() {
 #if defined(BOARD_HAS_CAMERA)
       drawCameraFullscreen();
 #endif
+      break;
+
+    case SCREEN_POWER_CONFIRM:
+      drawPowerConfirm();
       break;
 
     case SCREEN_FINISHED:

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -20,8 +20,27 @@ enum ScreenState {
   SCREEN_OFF,
   SCREEN_OTA_UPDATE,
   SCREEN_SPLIT,         // two printers side-by-side (top/bottom bands)
-  SCREEN_CAMERA         // fullscreen P1/A1 chamber image (#120); tap to exit
+  SCREEN_CAMERA,        // fullscreen P1/A1 chamber image (#120); tap to exit
+  SCREEN_POWER_CONFIRM  // fullscreen plug on/off confirmation (#136); hold to confirm
 };
+
+// Read-only snapshot of the plug power-confirm modal, filled by main.cpp so the
+// renderer (display_ui.cpp) never reaches into main's statics. phase mirrors the
+// PowerConfirmPhase enum in main.cpp: 0=wait-release, 1=armed, 2=sending, 3=result.
+struct PowerConfirmView {
+  const char* name;    // target printer name
+  bool  desiredOn;     // true = turning plug ON, false = OFF
+  bool  warn;          // printer is currently printing -> red screen
+  bool  offline;       // plug reading is stale/offline (live)
+  float progress;      // 0..1 hold-to-confirm ring fill
+  int   phase;         // see above
+  bool  resultOk;      // valid in phase 3: command succeeded
+};
+// Returns false when the modal is not active. Defined in main.cpp.
+bool powerConfirmGetView(PowerConfirmView* out);
+// Called by the renderer once it has drawn the "Sending..." frame, so main.cpp
+// only fires the (blocking) relay command after that frame is on screen.
+void powerConfirmMarkSendingDrawn();
 
 // Forward declaration so split-related declarations below can take an AmsState
 // by reference without pulling in bambu_state.h here.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,34 @@ static unsigned long boardBtnChangeMs = 0;
 static unsigned long boardBtnPressStartMs = 0;
 #endif
 
+// --- Button-driven plug power control (#136) --------------------------------
+static const uint32_t POWER_MULTICLICK_MS         = 450;   // double/triple-click window
+static const uint32_t POWER_CONFIRM_HOLD_MS       = 1500;  // hold-to-confirm duration
+static const uint32_t POWER_CONFIRM_INACTIVITY_MS = 10000; // auto-cancel on no input
+static const uint32_t POWER_RESULT_MS             = 1200;  // success/fail flash duration
+
+enum PowerConfirmPhase { PC_WAIT_RELEASE = 0, PC_ARMED = 1, PC_SENDING = 2, PC_RESULT = 3 };
+
+// Multi-click buffer (only armed when a plug is mapped to the shown printer).
+static uint8_t  pcPendingClicks = 0;
+static uint8_t  pcPendingSlot   = 0;
+static uint32_t pcLastTapMs     = 0;
+
+// Confirm-modal snapshot (frozen at open, never recomputed per frame).
+static PowerConfirmPhase pcPhase = PC_WAIT_RELEASE;
+static uint8_t     pcSlot            = 0;
+static uint8_t     pcPlug            = 0xFF;
+static bool        pcDesiredOn       = false;
+static bool        pcWasPrinting     = false;
+static bool        pcResultOk        = false;
+static ScreenState pcPriorScreen     = SCREEN_IDLE;
+static uint32_t    pcPressStartMs    = 0;
+static uint32_t    pcLastActivityMs  = 0;
+static uint32_t    pcResultUntilMs   = 0;
+static float       pcProgress        = 0.0f;
+static bool        pcPrevHeld        = false;
+static volatile bool pcSendingDrawn  = false;
+
 static bool isPrinterActivityStateFresh(uint8_t slot) {
   if (slot >= MAX_ACTIVE_PRINTERS || !isPrinterConfigured(slot)) return false;
   BambuState& s = printers[slot].state;
@@ -227,6 +255,108 @@ static void doTapActions() {
   }
 }
 
+// --- Button-driven plug power control (#136) --------------------------------
+// The multi-click watcher is armed only when the setting is on, a plug is mapped
+// to the shown printer, and the screen is a single-printer browseable one. When
+// disarmed the tap path stays bit-for-bit unchanged (zero latency).
+static bool powerControlAvailableForSlot(uint8_t slot) {
+  if (!dispSettings.buttonPowerControl) return false;
+  if (tasmotaControlPlugForSlot(slot) == 0xFF) return false;
+  ScreenState s = getScreenState();
+  // SCREEN_CONNECTING_MQTT is the screen shown for a powered-OFF local printer -
+  // the primary "turn the plug on" case (#136), so it must be armed there too.
+  return (s == SCREEN_IDLE || s == SCREEN_PRINTING || s == SCREEN_FINISHED ||
+          s == SCREEN_CONNECTING_MQTT);
+}
+
+static void openPowerConfirm(uint8_t slot) {
+  pcSlot = slot;
+  pcPlug = tasmotaControlPlugForSlot(slot);
+  TasmotaPlugStatsView v;
+  tasmotaGetStats(pcPlug, &v);
+  // Mirror the web-UI inference: Shelly reports relay state, Tasmota infers from watts.
+  bool currentOn = v.powerStateKnown ? v.powerOn : (v.online && v.watts > 0.5f);
+  pcDesiredOn      = !currentOn;
+  pcWasPrinting    = isPrintingGcodeState(printers[slot].state.gcodeStateId);
+  pcPriorScreen    = getScreenState();
+  pcPhase          = PC_WAIT_RELEASE;   // require a finger release before arming
+  pcPrevHeld       = true;
+  pcProgress       = 0.0f;
+  pcLastActivityMs = millis();
+  pcSendingDrawn   = false;
+  setScreenState(SCREEN_POWER_CONFIRM);
+}
+
+// Replaces the direct doTapActions() call at both tap dispatch sites. Buffers
+// clicks only when power control is armed for the shown printer; otherwise the
+// tap is dispatched immediately with no pending state and no rotation-hold.
+static void registerTap() {
+  uint8_t slot = rotState.displayIndex;
+  if (!powerControlAvailableForSlot(slot)) {
+    doTapActions();
+    return;
+  }
+  uint32_t now = millis();
+  if (pcPendingClicks == 0) {
+    pcPendingSlot = slot;   // frozen at click 1
+    // Hold the shown printer for the window so rotation/snap can't drift the target.
+    rotState.displayHoldUntilMs = now + POWER_MULTICLICK_MS + 200;
+  }
+  if (pcPendingClicks < 255) pcPendingClicks++;
+  pcLastTapMs = now;
+}
+
+// Modal input state machine. Called every loop while SCREEN_POWER_CONFIRM is up.
+static void handlePowerConfirmInput(bool held) {
+  uint32_t now = millis();
+  switch (pcPhase) {
+    case PC_WAIT_RELEASE:
+      pcProgress = 0.0f;
+      if (!held) {                  // consume the opening release, then arm
+        pcPhase          = PC_ARMED;
+        pcPrevHeld       = false;
+        pcLastActivityMs = now;
+      }
+      return;
+
+    case PC_ARMED: {
+      bool pressEdge   = (held && !pcPrevHeld);
+      bool releaseEdge = (!held && pcPrevHeld);
+      pcPrevHeld = held;
+      if (pressEdge) {
+        pcPressStartMs   = now;
+        pcLastActivityMs = now;
+      }
+      if (held) {
+        uint32_t hm = now - pcPressStartMs;
+        pcProgress = (float)hm / (float)POWER_CONFIRM_HOLD_MS;
+        if (pcProgress > 1.0f) pcProgress = 1.0f;
+        if (hm >= POWER_CONFIRM_HOLD_MS) {     // hold-to-confirm: fire while held
+          pcProgress     = 1.0f;
+          pcSendingDrawn = false;
+          pcPhase        = PC_SENDING;
+        }
+      } else {
+        pcProgress = 0.0f;
+        if (releaseEdge) {                      // short tap -> cancel
+          setScreenState(pcPriorScreen);
+          pcPhase = PC_WAIT_RELEASE;
+          return;
+        }
+        if (now - pcLastActivityMs > POWER_CONFIRM_INACTIVITY_MS) {
+          setScreenState(pcPriorScreen);        // inactivity timeout -> cancel
+          pcPhase = PC_WAIT_RELEASE;
+        }
+      }
+      return;
+    }
+
+    case PC_SENDING:
+    case PC_RESULT:
+      return;   // driven by handlePowerConfirmService() after the frame flush
+  }
+}
+
 static void handleWakeButton() {
   // Both edge pollers MUST be called every loop unconditionally - each owns its
   // own debounce + held-state machine, and skipping a call would freeze it.
@@ -248,25 +378,48 @@ static void handleWakeButton() {
   if (isSleepStickyScreen(getScreenState())) suppressDim = true;
 #endif
 
+  // Tap/hold disambiguation state (LED-enabled path). Hoisted so the power-confirm
+  // intercept can keep them in sync and avoid a stray release-edge tap on close.
+  static bool wasHeldPrev = false;
+  static bool holdConsumedThisPress = false;
+
+  // Plug power-confirm modal (#136) owns all input while up. Still tick the dimmer
+  // (suppressed) so its 2 s save-debounce keeps draining and no dim session starts,
+  // then hand off and return before the normal tap/hold logic.
+  if (getScreenState() == SCREEN_POWER_CONFIRM) {
+    ledHoldDimUpdate(held, holdMs, /*suppressDim=*/true);
+    if (touchPress || boardPress) { buzzerPlayClick(); ledOnUserInteraction(); }
+    handlePowerConfirmInput(held);
+    wasHeldPrev = held;
+    holdConsumedThisPress = false;
+    return;
+  }
+
+  // Flush a buffered multi-click once the window closes: 1 click = the normal tap
+  // action, 2+ = open the power-confirm modal for the frozen target slot.
+  if (pcPendingClicks > 0 && (millis() - pcLastTapMs) > POWER_MULTICLICK_MS) {
+    uint8_t n = pcPendingClicks;
+    pcPendingClicks = 0;
+    if (n >= 2) { openPowerConfirm(pcPendingSlot); return; }
+    doTapActions();
+  }
+
   // Tick the dimmer every loop regardless of state - it owns the 2 s save debounce.
   bool holdConsumed = ledHoldDimUpdate(held, holdMs, suppressDim);
 
-  // LED disabled or unconfigured: take the ORIGINAL press-edge path, bit-for-bit
-  // identical to pre-feature behavior. The dimmer's entry guard prevents any
-  // new dim session from starting, so holdConsumed is always false here.
+  // LED disabled or unconfigured: take the ORIGINAL press-edge path (with the new
+  // multi-click shim). The dimmer's entry guard prevents any dim session, so
+  // holdConsumed is always false here.
   if (!ledSettings.enabled) {
     if (touchPress || boardPress) {
       buzzerPlayClick();
       ledOnUserInteraction();
-      doTapActions();
+      registerTap();
     }
     return;
   }
 
   // LED enabled: tap/hold disambiguation.
-  static bool wasHeldPrev = false;
-  static bool holdConsumedThisPress = false;
-
   if (touchPress || boardPress) {
     // Press edge - immediate feedback (preserves today's snappy feel).
     buzzerPlayClick();
@@ -281,7 +434,44 @@ static void handleWakeButton() {
 
   if (releaseEdge && !holdConsumedThisPress) {
     // Was a tap - fire deferred actions (sub-100 ms perceived delay).
-    doTapActions();
+    registerTap();
+  }
+}
+
+// Accessor for the renderer (display_ui.cpp). Read-only snapshot; never mutates
+// the confirm state. offline is read live for the badge only.
+bool powerConfirmGetView(PowerConfirmView* out) {
+  if (!out || getScreenState() != SCREEN_POWER_CONFIRM) return false;
+  out->name      = printers[pcSlot].config.name;
+  out->desiredOn = pcDesiredOn;
+  out->warn      = pcWasPrinting;
+  out->progress  = pcProgress;
+  out->phase     = (int)pcPhase;
+  out->resultOk  = pcResultOk;
+  TasmotaPlugStatsView v;
+  tasmotaGetStats(pcPlug, &v);
+  out->offline = !v.online;
+  return true;
+}
+
+void powerConfirmMarkSendingDrawn() { pcSendingDrawn = true; }
+
+// Runs after updateDisplay()+flushFrame() so the "Sending..." frame is committed
+// before the blocking relay command, and the result flash shows before close.
+static void handlePowerConfirmService() {
+  if (getScreenState() != SCREEN_POWER_CONFIRM) return;
+  uint32_t now = millis();
+  if (pcPhase == PC_SENDING) {
+    if (!pcSendingDrawn) return;   // wait until the frame is on screen
+    pcResultOk = tasmotaSetPower(pcPlug, pcDesiredOn);
+    buzzerPlay(pcResultOk ? BUZZ_CONNECTED : BUZZ_ERROR);
+    pcPhase         = PC_RESULT;
+    pcResultUntilMs = now + POWER_RESULT_MS;
+  } else if (pcPhase == PC_RESULT) {
+    if ((long)(now - pcResultUntilMs) >= 0) {
+      setScreenState(pcPriorScreen);
+      pcPhase = PC_WAIT_RELEASE;
+    }
   }
 }
 
@@ -426,6 +616,11 @@ static void updateDisplayedPrinterScreenState() {
     }
     return;
   }
+
+  // Plug power-confirm modal (#136) is sticky: hold it against the auto state
+  // machine (dismissed only by the modal's own input / timeout). Placed after OTA
+  // so an auto-OTA still preempts it.
+  if (current == SCREEN_POWER_CONFIRM) return;
 
 #if defined(BOARD_HAS_CAMERA)
   // Camera fullscreen (#120) is sticky: entered/exited only by tap. Hold it
@@ -644,12 +839,17 @@ static void handleGcodeStateTransitions() {
           ledStartFinishEffect();
           ps.finishBuzzerPlayed = true;
         }
-        if (rotState.displayIndex != i) {
-          rotState.displayIndex = i;
-          triggerDisplayTransition();
+        // Suppress the display-snap side effects while the power-confirm modal is
+        // up (they would steal the frozen target / drop the modal). The one-shot
+        // alert + light + Tasmota bookkeeping below still run unconditionally.
+        if (getScreenState() != SCREEN_POWER_CONFIRM) {
+          if (rotState.displayIndex != i) {
+            rotState.displayIndex = i;
+            triggerDisplayTransition();
+          }
+          setBacklight(getEffectiveBrightness());
+          rotState.displayHoldUntilMs = millis() + rotState.intervalMs;
         }
-        setBacklight(getEffectiveBrightness());
-        rotState.displayHoldUntilMs = millis() + rotState.intervalMs;
         scheduleLightOff(i, LIGHT_OFF_ON_FINISH);
       }
       if (isPrintingGcodeState(ps.gcodeStateId) &&
@@ -888,15 +1088,21 @@ void loop() {
   // and a concurrent second TLS session to Bambu Cloud is unsupported.
   if (isWiFiConnected() && !isAPMode() && isAnyPrinterConfigured() && !isOtaAutoInProgress()) {
     handleBambuMqtt();
-    // Freeze auto-rotation while the camera fullscreen is up so the displayed
-    // printer (and its stream) does not drift out from under the view.
-    if (getScreenState() != SCREEN_CAMERA) handleRotation();
+    // Freeze auto-rotation while the camera fullscreen or the power-confirm modal
+    // is up so the displayed printer (and its stream / target) does not drift.
+    if (getScreenState() != SCREEN_CAMERA &&
+        getScreenState() != SCREEN_POWER_CONFIRM) handleRotation();
   }
 
   // Commit the framebuffer sprite to the panel. On JC3248W535 this is a
   // ~20ms QSPI push (300 KB @ 32MHz QIO); on all other boards it's a no-op
   // since draws go directly to the panel.
   flushFrame();
+
+  // Plug power-confirm (#136): fire the blocking relay command only after the
+  // "Sending..." frame is committed, and time out the result flash. Runs after
+  // flushFrame() for the same reason cameraService() does.
+  handlePowerConfirmService();
 
 #if defined(BOARD_HAS_CAMERA)
   // Blocking camera socket work (connect can stall up to the TLS timeout) runs

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -175,6 +175,7 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.hideClockDate = false;
   ds.showClockInfo = false;
   ds.amsTrayTypes = true;       // default ON: preserves existing per-tray labels
+  ds.buttonPowerControl = false;  // #136: default OFF (opt-in per device)
   ds.showBatteryIndicator = false;  // default OFF on all boards; enable per device
   ds.hideStatusReadout = false; // default ON-screen readout stays visible
   ds.nozzleScaleMax  = GAUGE_NOZZLE_SCALE_DEFAULT;
@@ -409,6 +410,7 @@ void loadSettings() {
   dispSettings.hideClockDate = prefs.getBool("dsp_clkhd", def.hideClockDate);
   dispSettings.showClockInfo = prefs.getBool("dsp_clkif", def.showClockInfo);
   dispSettings.amsTrayTypes = prefs.getBool("dsp_amst", def.amsTrayTypes);
+  dispSettings.buttonPowerControl = prefs.getBool("dsp_btpw", def.buttonPowerControl);
   dispSettings.showBatteryIndicator = prefs.getBool("dsp_bat", def.showBatteryIndicator);
   dispSettings.hideStatusReadout = prefs.getBool("dsp_hidlp", def.hideStatusReadout);
   dispSettings.nozzleScaleMax  = constrain((int)prefs.getUShort("dsp_nozmx", def.nozzleScaleMax),
@@ -703,6 +705,7 @@ void saveSettings() {
   prefs.putBool("dsp_clkhd", dispSettings.hideClockDate);
   prefs.putBool("dsp_clkif", dispSettings.showClockInfo);
   prefs.putBool("dsp_amst", dispSettings.amsTrayTypes);
+  prefs.putBool("dsp_btpw", dispSettings.buttonPowerControl);
   prefs.putBool("dsp_bat", dispSettings.showBatteryIndicator);
   prefs.putBool("dsp_hidlp", dispSettings.hideStatusReadout);
   prefs.putUShort("dsp_nozmx", dispSettings.nozzleScaleMax);

--- a/src/settings.h
+++ b/src/settings.h
@@ -86,6 +86,7 @@ struct DisplaySettings {
   bool     hideClockDate;  // minimalist mode: time only, no date line
   bool     showClockInfo;  // footer on the idle/clock screen: each configured printer's name + LAN IP
   bool     amsTrayTypes;   // show per-tray filament-type label under AMS bars (portrait strip); off = taller bars, no text
+  bool     buttonPowerControl; // #136: double/triple-click device button opens plug on/off confirm
   bool     showBatteryIndicator; // Waveshare boards: show battery icon in status bar
   // Gauge full-scale ranges (arc maxima). Lowering a scale makes the arc sweep
   // fuller for a printer's normal range. Defaults suit any Bambu printer.

--- a/src/tasmota.cpp
+++ b/src/tasmota.cpp
@@ -110,6 +110,12 @@ static uint8_t visiblePlugForSlot(uint8_t slot) {
 #endif
 }
 
+// Public wrapper around the (static) loose mapping, for the button power-control
+// feature in main.cpp. Kept here so all plug-mapping policy stays in tasmota.cpp.
+uint8_t tasmotaControlPlugForSlot(uint8_t slot) {
+  return visiblePlugForSlot(slot);
+}
+
 // ---------------------------------------------------------------------------
 //  Polling + Status 10 parser
 // ---------------------------------------------------------------------------

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -571,6 +571,7 @@ static void handleToggleSetting() {
   else if (key == "p9s")     dispSettings.portrait9Slots = on;
   else if (key == "clkinfo") dispSettings.showClockInfo = on;
   else if (key == "amst")    dispSettings.amsTrayTypes = on;
+  else if (key == "btnpwr")  dispSettings.buttonPowerControl = on;
   else if (key == "nighten") dpSettings.nightModeEnabled = on;
   else if (key == "use24h")  netSettings.use24h = on;
   else if (key == "rotsplit")  rotState.splitEnabled = on;
@@ -1124,6 +1125,7 @@ static void handleSettingsExport() {
   disp["hideClockDate"] = dispSettings.hideClockDate;
   disp["showClockInfo"] = dispSettings.showClockInfo;
   disp["amsTrayTypes"] = dispSettings.amsTrayTypes;
+  disp["buttonPowerControl"] = dispSettings.buttonPowerControl;
   disp["animatedBar"] = dispSettings.animatedBar;
   disp["pongClock"] = dispSettings.pongClock;
   disp["smallLabels"] = dispSettings.smallLabels;
@@ -1428,6 +1430,7 @@ static void handleSettingsImportFinish() {
     if (disp["hideClockDate"].is<bool>()) dispSettings.hideClockDate = disp["hideClockDate"].as<bool>();
     if (disp["showClockInfo"].is<bool>()) dispSettings.showClockInfo = disp["showClockInfo"].as<bool>();
     if (disp["amsTrayTypes"].is<bool>())  dispSettings.amsTrayTypes = disp["amsTrayTypes"].as<bool>();
+    if (disp["buttonPowerControl"].is<bool>()) dispSettings.buttonPowerControl = disp["buttonPowerControl"].as<bool>();
     if (disp["animatedBar"].is<bool>())       dispSettings.animatedBar = disp["animatedBar"].as<bool>();
     if (disp["pongClock"].is<bool>())           dispSettings.pongClock = disp["pongClock"].as<bool>();
     if (disp["smallLabels"].is<bool>())         dispSettings.smallLabels = disp["smallLabels"].as<bool>();

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -214,6 +214,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
   if (strcmp(name, "FMP") == 0)    { out = dispSettings.fanMatchPrinter ? "checked" : ""; return true; }
   if (strcmp(name, "HIDELP") == 0) { out = dispSettings.hideStatusReadout ? "checked" : ""; return true; }
   if (strcmp(name, "CLK_INFO") == 0) { out = dispSettings.showClockInfo ? "checked" : ""; return true; }
+  if (strcmp(name, "BTN_PWR") == 0) { out = dispSettings.buttonPowerControl ? "checked" : ""; return true; }
   if (strcmp(name, "AMST_ROW") == 0) {
     // Per-tray filament-type labels only render in the enhanced portrait AMS
     // strip, and only 320x480 (Guition / ws_lcd_350) drives the 3-AMS case


### PR DESCRIPTION
Addresses #136.

Adds an on-device way to switch a printer's Tasmota/Shelly plug on or off, so you don't have to open the Tasmota web UI in a browser.

## How it works
- **Double- or triple-click** the button / TTP223 / touchscreen to open a fullscreen confirmation for the printer currently on screen.
- **Hold ~1.5s** to toggle its plug (a filling ring shows progress). Short tap or 10s of inactivity cancels.
- The screen turns **red** while that printer is printing, since turning off a live print is destructive.
- It also works from the "Connecting to printer" screen, so a powered-off local printer can be switched on - which is the main use case.

Because touch input is position-independent (a tap lands the same anywhere), the confirmation uses hold-to-confirm rather than on-screen Yes/No buttons.

## Behaviour / safety
- Off by default. Enable **Button power control** in the web **Power Monitoring** section.
- Only armed when a plug is mapped to the shown printer; otherwise single-tap behaviour is completely unchanged (no added latency).
- Multi-click is buffered (wait mode) so a fast double/triple never lets a printer-cycle fire first - the confirmation always targets the printer you were looking at, which matters on dual-printer / dual-plug setups.
- Reuses the existing `tasmotaSetPower()` path; the relay command is sent only after the "Sending..." frame is on screen.

## Testing
- Builds for `esp32s3`, `ws_lcd_200`, `cyd` (low-RAM single plug) and `jc3248w535` (camera board).
- Verified on a Waveshare 2.0" touch unit: cloud printer (H2C) and a powered-off local printer (P1S) both open the confirm and toggle the plug.