### PR TITLE
Warn when an update no longer fits the OTA slot

### DIFF
--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -2763,6 +2763,14 @@ function checkForUpdates(){
       if (!isNewer(latest, current)){ res.style.color = 'var(--success)'; res.textContent = latest === current ? 'You are up to date (' + current + ')' : 'Running newer version (' + current + ')'; return; }
       var board = '%BOARD%', expectedPrefix = 'BambuHelper-' + board + '-', otaBin = null;
       for (var i = 0; i < d.assets.length; i++){ var n = d.assets[i].name; if (n.startsWith(expectedPrefix) && n.endsWith('-ota.bin')){ otaBin = d.assets[i]; break; } }
+      var slotB = parseInt('%OTASLOT%', 10) || 0, flashMb = parseInt('%FLASHMB%', 10) || 0;
+      if (otaBin && slotB > 0 && otaBin.size > slotB){
+        res.style.color = 'var(--danger)';
+        res.textContent = 'Update ' + latest + ' (' + Math.round(otaBin.size/1024) + ' KB) does not fit the ' + Math.round(slotB/1024) + ' KB update slot on this device.' +
+          (flashMb >= 16 ? ' Back up settings (Export), then reflash once via the web flasher to repartition the ' + flashMb + ' MB chip - OTA works normally afterwards.'
+                         : ' This board cannot hold this update - stay on the current version.');
+        return;
+      }
       res.style.color = 'var(--warn)'; res.textContent = 'Update available!';
       document.getElementById('updateVer').textContent = latest;
       document.getElementById('updateDate').textContent = new Date(d.published_at).toLocaleDateString();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1273,6 +1273,19 @@ static bool   settingsImportOverflow = false;
 static bool   otaInProgress  = false;
 static bool   otaFirstChunk  = false;
 static String otaError       = "";
+
+// A >=16 MB flash chip still running the 4 MB partition table (1.75 MB OTA
+// slots). Such a board can be repartitioned with a one-time full web-flasher
+// flash, so "firmware too large" OTA failures get actionable guidance appended
+// instead of dead-ending the user on a generic error.
+static bool isUnderPartitioned() {
+  const esp_partition_t* p = esp_ota_get_next_update_partition(NULL);
+  return p && p->size <= 0x1C0000 && ESP.getFlashChipSize() >= 16 * 1024 * 1024;
+}
+static const char REPARTITION_HINT[] =
+  " This board has a 16 MB flash chip on the old 4 MB layout: back up settings"
+  " (Export), then reflash once via the web flasher to repartition. OTA works"
+  " normally afterwards.";
 // Every OTA entry point calls disconnectBambuMqtt() up front, and only a
 // reboot (success path) re-arms the connections. When an OTA attempt fails
 // or is aborted, this flag requests initBambuMqtt() from handleWebServer()
@@ -1720,10 +1733,14 @@ static void otaAutoTaskFn(void* param) {
       break;
     case HTTP_UPDATE_FAILED:
     default: {
+      int lastErr = httpUpdate.getLastError();
       String err = httpUpdate.getLastErrorString();
-      Serial.printf("OTA auto: failed (%d) %s\n", httpUpdate.getLastError(), err.c_str());
-      // Retry once with setInsecure() in case CA bundle fails
-      if (httpUpdate.getLastError() != -107) {  // -107 = firmware too large, don't retry
+      Serial.printf("OTA auto: failed (%d) %s\n", lastErr, err.c_str());
+      // Retry once with setInsecure() in case CA bundle fails. Deterministic
+      // failures are excluded: HTTP_UE_TOO_LESS_SPACE (firmware exceeds the
+      // OTA slot) and HTTP_UE_BIN_FOR_WRONG_FLASH (image header mismatch)
+      // fail identically on any transport.
+      if (lastErr != HTTP_UE_TOO_LESS_SPACE && lastErr != HTTP_UE_BIN_FOR_WRONG_FLASH) {
         client.setInsecure();
         ret = httpUpdate.update(client, url);
         if (ret == HTTP_UPDATE_OK) {
@@ -1734,6 +1751,8 @@ static void otaAutoTaskFn(void* param) {
         }
       }
       otaAutoStatus = "failed: " + err;
+      if (lastErr == HTTP_UE_TOO_LESS_SPACE && isUnderPartitioned())
+        otaAutoStatus += REPARTITION_HINT;
       otaMqttReinitPending = true;  // no reboot coming - restore MQTT
       break;
     }
@@ -1837,6 +1856,8 @@ static void handleOtaUpload() {
 
     if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
       otaError = Update.errorString();
+      if (Update.getError() == UPDATE_ERROR_SPACE && isUnderPartitioned())
+        otaError += REPARTITION_HINT;
       Update.abort();
       otaInProgress = false;
     }
@@ -1848,6 +1869,8 @@ static void handleOtaUpload() {
       Serial.printf("OTA: success, %u bytes\n", upload.totalSize);
     } else {
       otaError = Update.errorString();
+      if (Update.getError() == UPDATE_ERROR_SPACE && isUnderPartitioned())
+        otaError += REPARTITION_HINT;
       Serial.printf("OTA: end failed: %s\n", otaError.c_str());
     }
     otaInProgress = false;

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -25,6 +25,7 @@
 #include "buzzer.h"
 #include "led.h"
 #include "timezones.h"
+#include "esp_ota_ops.h"   // OTASLOT token: next update partition size
 #include "tasmota.h"
 #include <Arduino.h>
 
@@ -376,6 +377,15 @@ static bool resolvePlaceholder(const char* name, String& out) {
   // --- Status / version / board ---
   if (strcmp(name, "DBGLOG") == 0)       { out = mqttDebugLog ? "checked" : ""; return true; }
   if (strcmp(name, "FW_VER") == 0)       { out = FW_VERSION; return true; }
+  // Update-size gate for the release check JS: OTA slot size in bytes and
+  // physical flash chip size in MB (16 MB chip on a small slot => the fix is a
+  // one-time web-flasher repartition, and the warning says so).
+  if (strcmp(name, "OTASLOT") == 0) {
+    const esp_partition_t* p = esp_ota_get_next_update_partition(NULL);
+    out = String(p ? p->size : 0);
+    return true;
+  }
+  if (strcmp(name, "FLASHMB") == 0)      { out = String(ESP.getFlashChipSize() >> 20); return true; }
   if (strcmp(name, "BOARD") == 0)        { out = BOARD_VARIANT; return true; }
   if (strcmp(name, "BOARD_NAME") == 0)   { out = BOARD_NAME; return true; }
   if (strcmp(name, "BOARD_PANEL") == 0)  { out = BOARD_PANEL; return true; }


### PR DESCRIPTION
## Summary

Both Waveshare boards (2.0" and 1.54") have 16 MB flash chips but currently run the 4 MB partition table with 1.75 MB OTA slots. Firmware sits at ~1.70 MB after the diacritics pack, so the first release that crosses the line would leave those users with a generic "Not Enough Space" error and no explanation. This ships the detector ahead of that day.

## What it does

**Before download - update check.** The release check in the web UI now compares the GitHub asset size against the device's actual OTA slot (exposed via new `OTASLOT`/`FLASHMB` template tokens). If it does not fit, the Install button is withheld and the user is told exactly what to do: on a 16 MB chip, back up settings and reflash once via the web flasher to repartition (OTA works normally afterwards); on a genuinely 4 MB board, stay on the current version.

**At flash time - both OTA paths.** If an oversized image still reaches the device (stale page, manual upload of a too-big .bin), the space failure now appends the same repartition guidance to the error shown in the web UI - but only on under-partitioned boards (16 MB chip, small slot), detected at runtime from the flash chip ID.

**Small fix along the way.** The auto-install "retry once with setInsecure()" no longer retries `HTTP_UE_TOO_LESS_SPACE` - a size failure is deterministic and retrying on a different transport cannot succeed. Also corrected the mislabeled `-107` comment (that code is `HTTP_UE_BIN_FOR_WRONG_FLASH`, not "firmware too large").

No user-visible change today: nothing fires until an update actually exceeds the slot.

## Testing

- Builds clean on esp32s3, ws_lcd_200, cyd.
- Flashed to a live ws_lcd_200: page renders `slotB = 1835008` (exactly the 1.75 MB slot) and `flashMb = 16` from the real chip, so the gate arms with true hardware values.