### PR TITLE
AMS drying: tap-to-peek during a print + time-display mode (#150, #152)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -4,7 +4,7 @@
 // =============================================================================
 //  Firmware version
 // =============================================================================
-#define FW_VERSION          "v3.7.6"
+#define FW_VERSION          "v3.7.7"
 
 // Board variant — injected into the web UI for OTA asset filtering.
 // Normally set via build_flags in platformio.ini; this is a fallback.

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -76,7 +76,7 @@ function saveWifi(){
 //    Printer:  pname, ip, serial, code, connmode, region, cl_token, cl_serial,
 //              cl_pname, dualp, gs0..gs5, amsv
 //    Display:  bright, nighten, nstart, nend, nbright, ssbright, afterprint,
-//              fmins, dack, kps, pong, abar, slbl, shtire, fanmp, hidelp, invcol,
+//              fmins, dack, kps, pong, abar, slbl, timem, fanmp, hidelp, invcol,
 //              cydcls, cyd32e, rskin, rotation, tz, use24h, datefmt, clk_time, clk_date,
 //              clk_size, clk_dsize, clk_hidedate, noz_max, bed_max, cht_max, pwr_max,
 //              gsmooth, warn_thr, warn_clr,
@@ -887,10 +887,15 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <input type="checkbox" id="abar" value="1" %ABAR% onchange="toggleSetting('abar',this.checked)">
       <label for="abar">Animated progress bar (shimmer effect)</label>
     </label>
-    <label class="check-row">
-      <input type="checkbox" id="shtire" value="1" %SHTIRE% onchange="toggleSetting('shtire',this.checked)">
-      <label for="shtire">Show remaining time instead of ETA</label>
-    </label>
+    <div class="field">
+      <label for="timem">Time display</label>
+      <select id="timem" onchange="toggleSetting('timem',this.value)">
+        <option value="0" %TIMEM0%>Finish time / ETA (default)</option>
+        <option value="1" %TIMEM1%>Remaining time</option>
+        <option value="2" %TIMEM2%>Both (finish time + remaining)</option>
+      </select>
+      <span class="text-dim small">applies immediately</span>
+    </div>
     <label class="check-row">
       <input type="checkbox" id="fanmp" value="1" %FMP% onchange="toggleSetting('fanmp',this.checked)">
       <label for="fanmp">Match printer fan % (10% steps - applies on next printer update)</label>
@@ -2510,7 +2515,7 @@ function applyDisplay(){
   if (document.getElementById('abar').checked) p.append('abar', '1');
   if (document.getElementById('pong').checked) p.append('pong', '1');
   if (document.getElementById('slbl').checked) p.append('slbl', '1');
-  if (document.getElementById('shtire').checked) p.append('shtire', '1');
+  p.append('timem', document.getElementById('timem').value);
   if (document.getElementById('fanmp').checked) p.append('fanmp', '1');
   p.append('tz', document.getElementById('tz').value);
   if (document.getElementById('use24h').checked) p.append('use24h', '1');

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -890,9 +890,9 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="field">
       <label for="timem">Time display</label>
       <select id="timem" onchange="toggleSetting('timem',this.value)">
-        <option value="0" %TIMEM0%>Finish time / ETA (default)</option>
-        <option value="1" %TIMEM1%>Remaining time</option>
-        <option value="2" %TIMEM2%>Both (finish time + remaining)</option>
+        <option value="0" %TIMEM0%>Finish time / ETA (default) - "ETA: 17:45"</option>
+        <option value="1" %TIMEM1%>Remaining time - "Remaining: 2h 05m"</option>
+        <option value="2" %TIMEM2%>Both - "17:45 &middot; 2h05m"</option>
       </select>
       <span class="text-dim small">applies immediately</span>
     </div>

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -55,7 +55,7 @@ uint32_t   sPrevAirduct[2]  = { 0xFFFFFFFFu, 0xFFFFFFFFu };
 uint8_t    sPrevHdrState[2] = { 0xFF, 0xFF };
 uint8_t    sPrevBarProg[2]  = { 0xFF, 0xFF };
 char       sPrevFootCenter[2][20] = { { 0 }, { 0 } };
-char       sPrevEta[2][24] = { { 0 }, { 0 } };
+char       sPrevEta[2][40] = { { 0 }, { 0 } };
 BambuState sPrevState[2];
 
 // Drying-band state (index 0 = top/left band, 1 = bottom/right band). A band
@@ -78,13 +78,15 @@ const unsigned long DRY_ROT_MS = 60000;            // rotate drying units every 
 // (display_ui.cpp): wall-clock finish time when the user prefers it and NTP is
 // up, otherwise the remaining duration. Returns false when there is nothing to
 // show (not printing / no estimate) so the caller can render a dim placeholder.
-bool buildSplitEta(const BambuState& s, char* buf, size_t n) {
+bool buildSplitEta(const BambuState& s, char* buf, size_t n, int16_t maxW) {
   if (s.remainingMinutes == 0) return false;
   // labelRemaining=false: no "Remaining:" prefix - the progress gauge already
-  // labels this context and the narrow landscape bands are tight. Width fitting
-  // is the caller's job (it owns the band geometry), so no budget is passed.
+  // labels this context and the narrow landscape bands are tight. maxW is the
+  // band width, so formatEtaLine can step a long combined/cross-day value down
+  // to a form that fits instead of overrunning into the neighbouring band. The
+  // caller sets the ETA font before calling, so the width measurement is right.
   formatEtaLine(s.remainingMinutes, dispSettings.timeDisplayMode,
-                /*labelRemaining=*/false, /*maxW=*/0, buf, n);
+                /*labelRemaining=*/false, maxW, buf, n);
   return true;
 }
 
@@ -444,8 +446,9 @@ void drawBand(const BambuState& s, const PrinterConfig& cfg, uint8_t slotIndex,
       swType  = s.ams.vtType;
     }
 
-    char etaStr[24];
-    const bool hasEta = buildSplitEta(s, etaStr, sizeof(etaStr));
+    char etaStr[40];
+    setFont(tft, g.etaFont);   // set before building: formatEtaLine measures to fit
+    const bool hasEta = buildSplitEta(s, etaStr, sizeof(etaStr), g.w - 4);
     if (!hasEta) strlcpy(etaStr, "ETA: --", sizeof(etaStr));
     const uint16_t etaClr = hasEta ? CLR_GREEN : CLR_TEXT_DIM;
 

--- a/src/display_split.cpp
+++ b/src/display_split.cpp
@@ -80,35 +80,11 @@ const unsigned long DRY_ROT_MS = 60000;            // rotate drying units every 
 // show (not printing / no estimate) so the caller can render a dim placeholder.
 bool buildSplitEta(const BambuState& s, char* buf, size_t n) {
   if (s.remainingMinutes == 0) return false;
-  time_t nowEpoch = time(nullptr);
-  struct tm now;
-  localtime_r(&nowEpoch, &now);
-  const bool ntpSynced = now.tm_year > (2020 - 1900);
-
-  if (!dispSettings.showTimeRemaining && ntpSynced) {
-    time_t etaEpoch = nowEpoch + (time_t)s.remainingMinutes * 60;
-    struct tm e;
-    localtime_r(&etaEpoch, &e);
-    int eh = e.tm_hour;
-    const char* ampm = "";
-    if (!netSettings.use24h) { ampm = eh < 12 ? "AM" : "PM"; eh %= 12; if (eh == 0) eh = 12; }
-    if (e.tm_yday != now.tm_yday || e.tm_year != now.tm_year) {
-      if (netSettings.use24h)
-        snprintf(buf, n, "ETA: %02d.%02d. %02d:%02d", e.tm_mday, e.tm_mon + 1, eh, e.tm_min);
-      else
-        snprintf(buf, n, "ETA: %02d/%02d %d:%02d%s", e.tm_mon + 1, e.tm_mday, eh, e.tm_min, ampm);
-    } else {
-      if (netSettings.use24h)
-        snprintf(buf, n, "ETA: %02d:%02d", eh, e.tm_min);
-      else
-        snprintf(buf, n, "ETA: %d:%02d %s", eh, e.tm_min, ampm);
-    }
-  } else {
-    // showTimeRemaining set, or NTP not synced yet: show the duration. No
-    // "Remaining:" prefix - the progress gauge already labels this context and
-    // the narrow landscape bands are tight.
-    snprintf(buf, n, "%dh %02dm", s.remainingMinutes / 60, s.remainingMinutes % 60);
-  }
+  // labelRemaining=false: no "Remaining:" prefix - the progress gauge already
+  // labels this context and the narrow landscape bands are tight. Width fitting
+  // is the caller's job (it owns the band geometry), so no budget is passed.
+  formatEtaLine(s.remainingMinutes, dispSettings.timeDisplayMode,
+                /*labelRemaining=*/false, /*maxW=*/0, buf, n);
   return true;
 }
 

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -938,6 +938,12 @@ static void drawStringClipped(const char* s, int16_t x, int16_t y, int16_t maxW)
   if (n > 0) tft.drawString(buf, x, y);
 }
 
+// Pixel length of a +/-halfDeg clear sector measured at the glyph-center radius.
+// Curved text longer than this paints outside the band drawCurvedString() clears.
+static inline int16_t arcBudgetPx(int16_t r, int16_t halfDeg) {
+  return (int16_t)(2.0f * (float)halfDeg * 3.14159265f / 180.0f * (float)r);
+}
+
 static void drawCelsiusUnit(int16_t x, int16_t y, uint16_t color) {
   setFont(tft, FONT_LARGE);
   tft.setTextDatum(ML_DATUM);
@@ -1068,6 +1074,24 @@ static void drawIdleDryingRound(PrinterSlot& p) {
     setFont(tft, FONT_BODY);
     tft.setTextColor(amsHumidityColor(u.humidityRaw, u.humidity, true), CLR_BG);
     tft.drawString(buf, cx, LY_RND_G_Y + 16);
+  }
+
+  // Finish time curved along the bottom rim. The square drying screens have
+  // carried this line all along; the round one never did, so the "show
+  // remaining instead of ETA" setting looked ignored here (#152). Pinned to the
+  // clock form for the same reason as the square layouts - the big line above
+  // is already the remaining duration.
+  if (unitChanged || u.dryRemainMin != prevMin) {
+    markFrameDirty();
+    char etaBuf[40];
+    setFont(tft, FONT_BODY);
+    uint16_t etaClr = formatEtaLine(u.dryRemainMin, /*mode=*/0,
+                                    /*labelRemaining=*/true,
+                                    arcBudgetPx(LY_RND_ARC_R, LY_RND_ARC_ETA_HDEG),
+                                    etaBuf, sizeof(etaBuf));
+    drawCurvedString(tft, etaBuf, cx, cx, LY_RND_ARC_R, true, etaClr,
+                     FONT_BODY, LY_RND_ARC_ETA_HDEG);
+    tft.setTextDatum(MC_DATUM);
   }
 
   prevUnit  = ui;
@@ -1354,45 +1378,21 @@ static void drawIdleDrying(PrinterSlot& p) {
     tft.fillRect(0, etaY, scrW, etaH, CLR_BG);
     tft.setTextDatum(MC_DATUM);
 
-    time_t nowEpoch = time(nullptr);
-    struct tm now;
-    localtime_r(&nowEpoch, &now);
-    bool ntpOk = (now.tm_year > (2020 - 1900));
-
-    char etaBuf[32];
-    if (ntpOk && u.dryRemainMin > 0) {
-      time_t etaEpoch = nowEpoch + (time_t)u.dryRemainMin * 60;
-      struct tm etaTm;
-      localtime_r(&etaEpoch, &etaTm);
-      int etaH = etaTm.tm_hour;
-      const char* ampm = "";
-      if (!netSettings.use24h) {
-        ampm = etaH < 12 ? "AM" : "PM";
-        etaH = etaH % 12;
-        if (etaH == 0) etaH = 12;
-      }
-      if (etaTm.tm_yday != now.tm_yday || etaTm.tm_year != now.tm_year) {
-        if (netSettings.use24h)
-          snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d.%02d. %02d:%02d",
-                   etaTm.tm_mday, etaTm.tm_mon + 1, etaH, etaTm.tm_min);
-        else
-          snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d/%02d %d:%02d%s",
-                   etaTm.tm_mon + 1, etaTm.tm_mday, etaH, etaTm.tm_min, ampm);
-      } else {
-        if (netSettings.use24h)
-          snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d:%02d", etaH, etaTm.tm_min);
-        else
-          snprintf(etaBuf, sizeof(etaBuf), "ETA: %d:%02d %s", etaH, etaTm.tm_min, ampm);
-      }
-    } else if (u.dryRemainMin > 0) {
-      uint16_t h = u.dryRemainMin / 60;
-      uint16_t m = u.dryRemainMin % 60;
-      snprintf(etaBuf, sizeof(etaBuf), "ETA: %dh %02dm", h, m);
+    char etaBuf[40];
+    uint16_t etaClr = CLR_GREEN;
+    setFont(tft, FONT_LARGE);
+    if (u.dryRemainMin > 0) {
+      // Pinned to the clock form (mode 0) rather than following
+      // dispSettings.timeDisplayMode: this screen already shows the remaining
+      // duration on the line above, so honouring "remaining" here would just
+      // print the same value twice. Falls back to the duration when NTP is
+      // down, which is also what stops the old "ETA: 2h 05m" mislabel.
+      etaClr = formatEtaLine(u.dryRemainMin, /*mode=*/0, /*labelRemaining=*/true,
+                             scrW - 4, etaBuf, sizeof(etaBuf));
     } else {
       snprintf(etaBuf, sizeof(etaBuf), "---");
     }
-    setFont(tft, FONT_LARGE);
-    tft.setTextColor(CLR_GREEN, CLR_BG);
+    tft.setTextColor(etaClr, CLR_BG);
     tft.drawString(etaBuf, cx, etaTextY);
   }
 
@@ -2772,6 +2772,107 @@ void drawGaugeTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
   }
 }
 
+// ---------------------------------------------------------------------------
+//  Shared finish-time line
+// ---------------------------------------------------------------------------
+//  Used by the printing screen, the split bands, the round print skins and the
+//  drying screen, so it MUST live outside the DISPLAY_ROUND_240 block below -
+//  square builds and display_split.cpp link against it too.
+// ---------------------------------------------------------------------------
+uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
+                       int16_t maxW, char* buf, size_t n) {
+  // Use time() directly - avoids the getLocalTime() race with timeout 0. Once
+  // NTP syncs the RTC keeps running, so latch it: a momentary dip must not flip
+  // the whole UI back to durations.
+  static bool ntpSynced = false;
+  time_t nowEpoch = time(nullptr);
+  struct tm now;
+  localtime_r(&nowEpoch, &now);
+  if (now.tm_year > (2020 - 1900)) ntpSynced = true;
+
+  const uint16_t h = remainingMin / 60;
+  const uint16_t m = remainingMin % 60;
+
+  // Duration form, also the fallback whenever the clock is not trustworthy.
+  auto duration = [&]() -> uint16_t {
+    if (labelRemaining) snprintf(buf, n, "Remaining: %dh %02dm", h, m);
+    else                snprintf(buf, n, "%dh %02dm", h, m);
+    return CLR_TEXT;
+  };
+
+  if (!ntpSynced) return duration();
+
+  if (mode == 1) {
+    uint16_t clr = duration();
+    // Tight sectors (round Speedo) can't take the labelled form - dropping the
+    // word is better than painting outside the clear band.
+    if (maxW > 0 && labelRemaining && tft.textWidth(buf) > maxW)
+      snprintf(buf, n, "%dh %02dm", h, m);
+    return clr;
+  }
+
+  time_t etaEpoch = nowEpoch + (time_t)remainingMin * 60;
+  struct tm e;
+  localtime_r(&etaEpoch, &e);
+  const bool crossDay = (e.tm_yday != now.tm_yday) || (e.tm_year != now.tm_year);
+
+  int eh = e.tm_hour;
+  const char* ampm = "";
+  if (!netSettings.use24h) {
+    ampm = eh < 12 ? "AM" : "PM";
+    eh %= 12;
+    if (eh == 0) eh = 12;
+  }
+
+  auto clockOnly = [&]() -> uint16_t {
+    if (crossDay) {
+      if (netSettings.use24h)
+        snprintf(buf, n, "ETA: %02d.%02d. %02d:%02d",
+                 e.tm_mday, e.tm_mon + 1, eh, e.tm_min);
+      else
+        snprintf(buf, n, "ETA: %02d/%02d %d:%02d%s",
+                 e.tm_mon + 1, e.tm_mday, eh, e.tm_min, ampm);
+    } else {
+      if (netSettings.use24h) snprintf(buf, n, "ETA: %02d:%02d", eh, e.tm_min);
+      else                    snprintf(buf, n, "ETA: %d:%02d %s", eh, e.tm_min, ampm);
+    }
+    return CLR_GREEN;
+  };
+
+  // Both values on one line. The "ETA:" prefix is dropped - a clock time sitting
+  // next to a duration needs no label, and the width buys the second value.
+  // Separator is U+00B7 MIDDLE DOT, which the bundled VLW pack carries.
+  auto both = [&]() -> uint16_t {
+    char t[24];
+    if (crossDay) {
+      if (netSettings.use24h)
+        snprintf(t, sizeof(t), "%02d.%02d. %02d:%02d",
+                 e.tm_mday, e.tm_mon + 1, eh, e.tm_min);
+      else
+        snprintf(t, sizeof(t), "%02d/%02d %d:%02d%s",
+                 e.tm_mon + 1, e.tm_mday, eh, e.tm_min, ampm);
+    } else {
+      if (netSettings.use24h) snprintf(t, sizeof(t), "%02d:%02d", eh, e.tm_min);
+      else                    snprintf(t, sizeof(t), "%d:%02d%s", eh, e.tm_min, ampm);
+    }
+    snprintf(buf, n, "%s \xC2\xB7 %dh%02dm", t, h, m);
+    return CLR_GREEN;
+  };
+
+  uint16_t clr = (mode == 2) ? both() : clockOnly();
+  if (maxW > 0 && tft.textWidth(buf) > maxW) {
+    // Step down to the most compact form that fits: both -> clock -> duration.
+    if (mode == 2) {
+      clr = clockOnly();
+      if (tft.textWidth(buf) <= maxW) return clr;
+    }
+    clr = duration();
+    if (labelRemaining && tft.textWidth(buf) > maxW)
+      snprintf(buf, n, "%dh %02dm", h, m);
+  }
+  return clr;
+}
+
 #if defined(DISPLAY_ROUND_240)
 // ===========================================================================
 //  Round display (GC9A01): printing screen. Three skins selectable from the
@@ -2782,48 +2883,23 @@ void drawGaugeTile(uint8_t gt, const BambuState& s, uint8_t slotIndex,
 
 // Compose the ETA / Remaining / alert line shared by the round skins.
 // Returns the text color. Logic matches the square printing screen's ETA zone.
-static uint16_t buildRoundEtaLine(BambuState& s, char* buf, size_t bufLen) {
+//
+// maxW is the caller's clear-band width and measureFont the widest font it may
+// end up drawing with. The curved skins need this because drawCurvedString()
+// clears a fixed sector but lays glyphs out over the string's full width with no
+// clamp, so anything longer paints outside the cleared band and leaves ghosts -
+// Speedo's sector is only ~131px, which the labelled "Remaining: 2h 05m" form
+// (146px at FONT_BODY) already overflows today. Rings draws straight but into a
+// fixed 116px rect, so it passes its own budget at its FONT_SMALL fallback.
+static uint16_t buildRoundEtaLine(BambuState& s, char* buf, size_t bufLen,
+                                  int16_t maxW, FontID measureFont) {
   if (s.gcodeStateId == GCODE_PAUSE)  { strlcpy(buf, "PAUSED", bufLen); return CLR_YELLOW; }
   if (s.gcodeStateId == GCODE_FAILED) { strlcpy(buf, "ERROR!", bufLen); return CLR_RED; }
   if (s.remainingMinutes == 0) { strlcpy(buf, "ETA: ---", bufLen); return CLR_TEXT_DIM; }
 
-  static bool ntpSynced = false;
-  time_t nowEpoch = time(nullptr);
-  struct tm now;
-  localtime_r(&nowEpoch, &now);
-  if (now.tm_year > (2020 - 1900)) ntpSynced = true;
-
-  if (!dispSettings.showTimeRemaining && ntpSynced) {
-    time_t etaEpoch = nowEpoch + (time_t)s.remainingMinutes * 60;
-    struct tm etaTm;
-    localtime_r(&etaEpoch, &etaTm);
-
-    int etaH = etaTm.tm_hour;
-    const char* ampm = "";
-    if (!netSettings.use24h) {
-      ampm = etaH < 12 ? "AM" : "PM";
-      etaH = etaH % 12;
-      if (etaH == 0) etaH = 12;
-    }
-    if (etaTm.tm_yday != now.tm_yday || etaTm.tm_year != now.tm_year) {
-      if (netSettings.use24h)
-        snprintf(buf, bufLen, "ETA: %02d.%02d. %02d:%02d",
-                 etaTm.tm_mday, etaTm.tm_mon + 1, etaH, etaTm.tm_min);
-      else
-        snprintf(buf, bufLen, "ETA: %02d/%02d %d:%02d%s",
-                 etaTm.tm_mon + 1, etaTm.tm_mday, etaH, etaTm.tm_min, ampm);
-    } else {
-      if (netSettings.use24h)
-        snprintf(buf, bufLen, "ETA: %02d:%02d", etaH, etaTm.tm_min);
-      else
-        snprintf(buf, bufLen, "ETA: %d:%02d %s", etaH, etaTm.tm_min, ampm);
-    }
-    return CLR_GREEN;
-  }
-
-  snprintf(buf, bufLen, "Remaining: %dh %02dm",
-           s.remainingMinutes / 60, s.remainingMinutes % 60);
-  return CLR_TEXT;
+  setFont(tft, measureFont);   // the fit check lies if the font doesn't match
+  return formatEtaLine(s.remainingMinutes, dispSettings.timeDisplayMode,
+                       /*labelRemaining=*/true, maxW, buf, bufLen);
 }
 
 // Compact temperature readout for the Speedo / Rings skins: colored marker
@@ -3202,7 +3278,9 @@ static void drawPrintingSpeedo() {
   if (etaChanged || stateChanged) {
     markFrameDirty();
     char buf[32];
-    uint16_t clr = buildRoundEtaLine(s, buf, sizeof(buf));
+    uint16_t clr = buildRoundEtaLine(
+        s, buf, sizeof(buf),
+        arcBudgetPx(LY_RND_SPD_ETA_R, LY_RND_SPD_ETA_HDEG), FONT_BODY);
     drawCurvedString(tft, buf, cx, cx, LY_RND_SPD_ETA_R, true, clr,
                      FONT_BODY, LY_RND_SPD_ETA_HDEG);
   }
@@ -3292,7 +3370,11 @@ static void drawPrintingRings() {
   if (etaChanged || stateChanged) {
     markFrameDirty();
     char buf[32];
-    uint16_t clr = buildRoundEtaLine(s, buf, sizeof(buf));
+    // Straight text into a fixed 116px rect. Budget is measured at FONT_SMALL -
+    // the widest form this skin can still render - so the font fallback below
+    // stays the first line of defence and the string only shortens when even
+    // FONT_SMALL would spill (mode 2 with a cross-day date).
+    uint16_t clr = buildRoundEtaLine(s, buf, sizeof(buf), 116, FONT_SMALL);
     tft.fillRect(cx - 58, LY_RND_RGS_ETA_Y - 11, 116, 22, CLR_BG);
     // FONT_BODY when it fits the chord; the long date+time ETA form drops
     // to FONT_SMALL instead of clipping.
@@ -3421,7 +3503,9 @@ static void drawPrintingRound() {
   if (etaChanged || stateChanged) {
     markFrameDirty();
     char buf[32];
-    uint16_t clr = buildRoundEtaLine(s, buf, sizeof(buf));
+    uint16_t clr = buildRoundEtaLine(
+        s, buf, sizeof(buf),
+        arcBudgetPx(LY_RND_ARC_R, LY_RND_ARC_ETA_HDEG), FONT_BODY);
     drawCurvedString(tft, buf, cx, cx, LY_RND_ARC_R, true, clr,
                      FONT_BODY, LY_RND_ARC_ETA_HDEG);
   }
@@ -3984,54 +4068,13 @@ static void drawPrinting() {
       tft.setTextColor(CLR_RED, CLR_BG);
       tft.drawString("ERROR!", etaCx, eff_etaTextY);
     } else if (s.remainingMinutes > 0) {
-      // Use time() directly - avoids getLocalTime() race condition with timeout 0.
-      // Once NTP syncs the RTC keeps running; ntpSynced latches true forever.
-      static bool ntpSynced = false;
-      time_t nowEpoch = time(nullptr);
-      struct tm now;
-      localtime_r(&nowEpoch, &now);
-      if (now.tm_year > (2020 - 1900)) ntpSynced = true;
-
-      if (!dispSettings.showTimeRemaining && ntpSynced) {
-        // Calculate ETA: current time + remaining minutes
-        time_t etaEpoch = nowEpoch + (time_t)s.remainingMinutes * 60;
-        struct tm etaTm;
-        localtime_r(&etaEpoch, &etaTm);
-
-        char etaBuf[32];
-        int etaH = etaTm.tm_hour;
-        const char* ampm = "";
-        if (!netSettings.use24h) {
-          ampm = etaH < 12 ? "AM" : "PM";
-          etaH = etaH % 12;
-          if (etaH == 0) etaH = 12;
-        }
-        if (etaTm.tm_yday != now.tm_yday || etaTm.tm_year != now.tm_year) {
-          if (netSettings.use24h)
-            snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d.%02d. %02d:%02d",
-                     etaTm.tm_mday, etaTm.tm_mon + 1, etaH, etaTm.tm_min);
-          else
-            snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d/%02d %d:%02d%s",
-                     etaTm.tm_mon + 1, etaTm.tm_mday, etaH, etaTm.tm_min, ampm);
-        } else {
-          if (netSettings.use24h)
-            snprintf(etaBuf, sizeof(etaBuf), "ETA: %02d:%02d", etaH, etaTm.tm_min);
-          else
-            snprintf(etaBuf, sizeof(etaBuf), "ETA: %d:%02d %s", etaH, etaTm.tm_min, ampm);
-        }
-        setFont(tft, FONT_LARGE);
-        tft.setTextColor(CLR_GREEN, CLR_BG);
-        tft.drawString(etaBuf, etaCx, eff_etaTextY);
-      } else {
-        // NTP not synced yet OR user requested remaining time - show remaining time only
-        char remBuf[24];
-        uint16_t h = s.remainingMinutes / 60;
-        uint16_t m = s.remainingMinutes % 60;
-        snprintf(remBuf, sizeof(remBuf), "Remaining: %dh %02dm", h, m);
-        setFont(tft, FONT_LARGE);
-        tft.setTextColor(CLR_TEXT, CLR_BG);
-        tft.drawString(remBuf, etaCx, eff_etaTextY);
-      }
+      char etaBuf[40];
+      setFont(tft, FONT_LARGE);   // set before formatting: it measures to fit
+      uint16_t clr = formatEtaLine(s.remainingMinutes, dispSettings.timeDisplayMode,
+                                   /*labelRemaining=*/true, etaW - 4,
+                                   etaBuf, sizeof(etaBuf));
+      tft.setTextColor(clr, CLR_BG);
+      tft.drawString(etaBuf, etaCx, eff_etaTextY);
     } else {
       setFont(tft, FONT_LARGE);
       tft.setTextColor(CLR_TEXT_DIM, CLR_BG);

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -4802,7 +4802,8 @@ void updateDisplay() {
     tickProgressShimmer(tft, 0, sh.progress, sh.printing);
     markFrameDirty();
   }
-  if (currentScreen == SCREEN_IDLE && isPrinterConfigured(rotState.displayIndex)) {
+  if ((currentScreen == SCREEN_IDLE || currentScreen == SCREEN_DRY_PEEK) &&
+      isPrinterConfigured(rotState.displayIndex)) {
     BambuState& sh = displayedPrinter().state;
     if (sh.ams.anyDrying) {
       uint8_t dp = 0;
@@ -4924,6 +4925,14 @@ void updateDisplay() {
 
     case SCREEN_IDLE:
       drawIdle();
+      break;
+
+    case SCREEN_DRY_PEEK:
+      // Same renderer as the idle drying screen (#150). updateDisplay() already
+      // cleared the panel and set forceRedraw on the state change, so the
+      // renderer's prev* caches repaint from scratch on entry and the print
+      // screen repaints in full on the way out.
+      drawIdleDrying(displayedPrinter());
       break;
 
     case SCREEN_PRINTING:

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -904,13 +904,28 @@ static void drawIdleNoPrinter() {
 
 // ---------------------------------------------------------------------------
 //  Screen: Idle Drying (AMS drying active while printer idle)
-//  Shows ONE drying AMS at a time. Rotates between drying units every 60s.
+//  Shows ONE drying AMS at a time, rotating between drying units - every 60s on
+//  the idle screen, faster inside a drying peek (see dryRotateIntervalMs()).
 //  Layout: progress bar, header, large temp, time remaining, humidity, ETA.
 // ---------------------------------------------------------------------------
 static bool wasDrying = false;
 static uint8_t dryDisplayIdx = 0;           // which drying unit we're showing
 static unsigned long dryRotateMs = 0;       // last rotation timestamp
 static const unsigned long DRY_ROTATE_MS = 60000;  // 60s rotation interval
+
+// A drying peek (#150) is far shorter than the idle screen's 60s dwell, so it
+// steps units at DRY_PEEK_DWELL_MS instead - otherwise a tap on a 3-AMS setup
+// would only ever show one unit and the user would have to wait out a full
+// idle-screen rotation between taps to see the others. main.cpp sizes the peek
+// window from the same constant so every unit gets its turn before it closes.
+static inline unsigned long dryRotateIntervalMs() {
+  return (currentScreen == SCREEN_DRY_PEEK) ? DRY_PEEK_DWELL_MS : DRY_ROTATE_MS;
+}
+
+void resetDryingRotation() {
+  dryDisplayIdx = 0;
+  dryRotateMs = millis();
+}
 
 // Draw a string left-aligned, hard-truncating at character boundary if it
 // doesn't fit maxW. No ellipsis.
@@ -969,12 +984,16 @@ static int8_t findDryingUnit(AmsState& ams, uint8_t idx) {
   return -1;
 }
 
-static uint8_t countDryingUnits(AmsState& ams) {
+static uint8_t countDryingUnits(const AmsState& ams) {
   uint8_t n = 0;
   for (uint8_t i = 0; i < ams.unitCount && i < AMS_MAX_UNITS; i++)
     if (ams.units[i].dryRemainMin > 0) n++;
   return n;
 }
+
+// Public wrapper: main.cpp sizes the drying peek (#150) from this so a peek on
+// a multi-AMS printer lasts long enough for every unit to come around.
+uint8_t dryingUnitCount(const AmsState& ams) { return countDryingUnits(ams); }
 
 #if defined(DISPLAY_ROUND_240)
 // Round (GC9A01) drying screen: rim ring = drying progress, centered text
@@ -985,7 +1004,7 @@ static void drawIdleDryingRound(PrinterSlot& p) {
   const int16_t cx = SCREEN_W / 2;
 
   uint8_t dryCount = countDryingUnits(s.ams);
-  if (dryCount > 1 && millis() - dryRotateMs >= DRY_ROTATE_MS) {
+  if (dryCount > 1 && millis() - dryRotateMs >= dryRotateIntervalMs()) {
     dryDisplayIdx = (dryDisplayIdx + 1) % dryCount;
     dryRotateMs = millis();
     forceRedraw = true;
@@ -1116,7 +1135,7 @@ static void drawIdleDrying(PrinterSlot& p) {
 
   // Count drying units and handle rotation
   uint8_t dryCount = countDryingUnits(s.ams);
-  if (dryCount > 1 && millis() - dryRotateMs >= DRY_ROTATE_MS) {
+  if (dryCount > 1 && millis() - dryRotateMs >= dryRotateIntervalMs()) {
     dryDisplayIdx = (dryDisplayIdx + 1) % dryCount;
     dryRotateMs = millis();
     forceRedraw = true;

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2793,23 +2793,22 @@ uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
   const uint16_t h = remainingMin / 60;
   const uint16_t m = remainingMin % 60;
 
-  // Duration form, also the fallback whenever the clock is not trustworthy.
+  // Duration form, and the terminal fallback of every step-down path below.
+  // The width fit-down lives INSIDE it on purpose: tight sectors (round Speedo,
+  // ~130 px at FONT_BODY) cannot take the labelled form ("Remaining: 2h 05m" is
+  // 146 px), and dropping the word is better than painting outside the band
+  // drawCurvedString() clears. Every route to a duration must get that check -
+  // the pre-NTP path most of all, since that is the state right after boot.
   auto duration = [&]() -> uint16_t {
     if (labelRemaining) snprintf(buf, n, "Remaining: %dh %02dm", h, m);
     else                snprintf(buf, n, "%dh %02dm", h, m);
+    if (maxW > 0 && labelRemaining && tft.textWidth(buf) > maxW)
+      snprintf(buf, n, "%dh %02dm", h, m);
     return CLR_TEXT;
   };
 
   if (!ntpSynced) return duration();
-
-  if (mode == 1) {
-    uint16_t clr = duration();
-    // Tight sectors (round Speedo) can't take the labelled form - dropping the
-    // word is better than painting outside the clear band.
-    if (maxW > 0 && labelRemaining && tft.textWidth(buf) > maxW)
-      snprintf(buf, n, "%dh %02dm", h, m);
-    return clr;
-  }
+  if (mode == 1)  return duration();
 
   time_t etaEpoch = nowEpoch + (time_t)remainingMin * 60;
   struct tm e;
@@ -2866,9 +2865,7 @@ uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
       clr = clockOnly();
       if (tft.textWidth(buf) <= maxW) return clr;
     }
-    clr = duration();
-    if (labelRemaining && tft.textWidth(buf) > maxW)
-      snprintf(buf, n, "%dh %02dm", h, m);
+    clr = duration();   // strips its own label when even that overflows
   }
   return clr;
 }

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -21,7 +21,8 @@ enum ScreenState {
   SCREEN_OTA_UPDATE,
   SCREEN_SPLIT,         // two printers side-by-side (top/bottom bands)
   SCREEN_CAMERA,        // fullscreen P1/A1 chamber image (#120); tap to exit
-  SCREEN_POWER_CONFIRM  // fullscreen plug on/off confirmation (#136); hold to confirm
+  SCREEN_POWER_CONFIRM, // fullscreen plug on/off confirmation (#136); hold to confirm
+  SCREEN_DRY_PEEK       // AMS drying view tapped up during a print (#150); auto-closes
 };
 
 // Read-only snapshot of the plug power-confirm modal, filled by main.cpp so the

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -126,4 +126,19 @@ void formatAmsLetterLabel(char* out, size_t len, uint8_t unitIndex);   // "<base
 void formatAmsDryName(char* out, size_t len, bool isHT, uint8_t displayNum,
                       uint8_t dryDisplayIdx, uint8_t dryCount);        // "<base>[ HT] N  (x/y)"
 
+// Build the finish-time line shared by the printing, split, round and drying
+// screens, and return the color it should be drawn in.
+//   mode           - a dispSettings.timeDisplayMode value: 0 = wall-clock ETA,
+//                    1 = remaining duration, 2 = both on one line. Callers that
+//                    must pin one form (the drying screen, whose layout already
+//                    carries the duration) pass it literally instead of reading
+//                    the setting.
+//   labelRemaining - false emits a bare "2h 05m" for the tight split bands.
+//   maxW           - when > 0, step down to the most compact form that fits this
+//                    pixel budget at the currently loaded font. Only the curved
+//                    round skins need it; everyone else passes 0.
+// Falls back to the duration whenever NTP has not synced, whatever mode asks for.
+uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
+                       int16_t maxW, char* buf, size_t n);
+
 #endif // DISPLAY_UI_H

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -47,6 +47,22 @@ void powerConfirmMarkSendingDrawn();
 // by reference without pulling in bambu_state.h here.
 struct AmsState;
 
+// --- AMS drying screen: unit rotation ---------------------------------------
+// The drying screen shows one unit at a time. On the idle screen it dwells 60 s
+// per unit, which is far longer than a drying peek (#150) lasts - so a peek
+// would only ever show whichever unit that free-running timer happened to be
+// on. main.cpp therefore restarts the rotation when it opens a peek and sizes
+// the peek window from the unit count, while the renderer steps at the shorter
+// cadence below whenever SCREEN_DRY_PEEK is up. Keep the two in agreement:
+// this constant is the per-unit dwell inside a peek.
+static const uint32_t DRY_PEEK_DWELL_MS = 5000;
+
+// Number of AMS units actively drying (dryRemainMin > 0).
+uint8_t dryingUnitCount(const AmsState& ams);
+// Restart the rotation at the first drying unit. Called when a peek opens so
+// the unit shown is deterministic rather than a function of wall-clock timing.
+void resetDryingRotation();
+
 extern lgfx::LovyanGFX* tft_ptr;
 // Macro (NOT a reference) so callers' `tft.method()` always dereferences the
 // current value of `tft_ptr`. On JC3248W535 we retarget this pointer to a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -689,7 +689,14 @@ static void updateDisplayedPrinterScreenState() {
     if (!expired &&
         isPrinterActivityStateFresh(rotState.displayIndex) &&
         displayedPrinter().state.printing &&
-        displayedPrinter().state.ams.anyDrying) return;
+        displayedPrinter().state.ams.anyDrying) {
+      // Override the LED_ACT_IDLE default set at the top of this function: a
+      // print is still running behind the peek, so the status LED must not drop
+      // out of its printing animation for the ten seconds the screen is up.
+      ledSetActivity(displayedPrinter().state.gcodeStateId == GCODE_PAUSE
+                     ? LED_ACT_PAUSED : LED_ACT_PRINTING);
+      return;
+    }
     closeDryPeek();
     return;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,11 @@ static float       pcProgress        = 0.0f;
 static bool        pcPrevHeld        = false;
 static volatile bool pcSendingDrawn  = false;
 
+// AMS drying peek (#150): tapping during a print brings the drying screen up for
+// a few seconds, then it closes itself.
+static const uint32_t DRY_PEEK_MS = 10000;
+static uint32_t dryPeekUntilMs = 0;
+
 static bool isPrinterActivityStateFresh(uint8_t slot) {
   if (slot >= MAX_ACTIVE_PRINTERS || !isPrinterConfigured(slot)) return false;
   BambuState& s = printers[slot].state;
@@ -199,6 +204,33 @@ static bool isBoardButton3Held() {
 #endif
 }
 
+// Open the AMS drying peek (#150) for the shown printer, if it has anything to
+// show. Single entry point on purpose: there are two call sites (tap from the
+// print screen, and tapping out of the camera) and both MUST arm the deadline -
+// setting the screen state without it leaves a stale value and the expiry check
+// closes the peek on the very next loop.
+//
+// state.printing is required rather than just "the print screen is up": with
+// keepPrintScreen the dashboard is also shown while idle, and the sticky branch
+// in updateDisplayedPrinterScreenState() demands real printing, so mismatched
+// predicates would open a peek that immediately closes.
+static bool openDryPeek() {
+  PrinterSlot& p = displayedPrinter();
+  if (!p.state.printing || !p.state.ams.anyDrying) return false;
+  dryPeekUntilMs = millis() + DRY_PEEK_MS;
+  setScreenState(SCREEN_DRY_PEEK);
+  return true;
+}
+
+// Leave the peek. Auto-rotation is frozen while it is up but lastRotateMs keeps
+// aging, and the minimum rotate interval is also 10s - without this reset the
+// user taps to check drying and lands on a different printer the moment it
+// closes.
+static void closeDryPeek() {
+  rotState.lastRotateMs = millis();
+  setScreenState(SCREEN_PRINTING);
+}
+
 // Existing on-press behavior, factored out so it can be invoked either on
 // press-edge (LED disabled path: unchanged behavior) or on release-edge
 // (LED enabled path: deferred until tap/hold disambiguation completes).
@@ -233,6 +265,9 @@ static void doTapActions() {
   // fullscreen, and tapping out advances to the next printer (so the cycle keeps
   // moving instead of stranding the user here until the next auto-rotate).
   if (cur == SCREEN_CAMERA) {
+    // Keep the drying peek reachable on camera boards by making it the next
+    // stop in the cycle: printing -> camera -> drying -> printing (+ next).
+    if (openDryPeek()) return;
     setScreenState(SCREEN_PRINTING);
     if (getActiveConnCount() >= 2) cycleDisplayedPrinterFromButton();
     return;
@@ -243,6 +278,17 @@ static void doTapActions() {
     return;
   }
 #endif
+
+  // AMS drying peek (#150). During a print the tap has no job on a
+  // single-printer setup, so it brings up the drying view for a few seconds.
+  // Tapping out advances the printer when more than one is connected, matching
+  // how the camera tile behaves.
+  if (cur == SCREEN_DRY_PEEK) {
+    closeDryPeek();
+    if (getActiveConnCount() >= 2) cycleDisplayedPrinterFromButton();
+    return;
+  }
+  if (cur == SCREEN_PRINTING && openDryPeek()) return;
 
   if (getActiveConnCount() >= 2) {
     cycleDisplayedPrinterFromButton();
@@ -633,6 +679,21 @@ static void updateDisplayedPrinterScreenState() {
   }
 #endif
 
+  // AMS drying peek (#150) is sticky for its timeout: hold it against the auto
+  // state machine, then drop back and let the normal flow re-derive next loop.
+  // Placed above the drying-wake and split branches so neither steals it.
+  // Note this is not the only expiry check - handleDisplaySleepTimeouts() runs
+  // even when WiFi is down, where this function is never called at all.
+  if (current == SCREEN_DRY_PEEK) {
+    bool expired = (long)(millis() - dryPeekUntilMs) >= 0;
+    if (!expired &&
+        isPrinterActivityStateFresh(rotState.displayIndex) &&
+        displayedPrinter().state.printing &&
+        displayedPrinter().state.ams.anyDrying) return;
+    closeDryPeek();
+    return;
+  }
+
   // Global drying-wake: if any fresh printer state is drying, leave sleep-sticky
   // screens regardless of which slot is currently displayed. Point displayIndex
   // at the dryer so the rendered drying screen reflects real state.
@@ -733,6 +794,16 @@ static void handleDisplaySleepTimeouts() {
   // Covers both SCREEN_IDLE (printer connected but not printing) and
   // SCREEN_CONNECTING_MQTT (printer offline/unreachable at startup).
   ScreenState cur = getScreenState();
+
+  // AMS drying peek (#150) auto-close. This runs unconditionally, unlike
+  // updateDisplayedPrinterScreenState() which is gated on WiFi being up - a
+  // normal STA drop does not change the screen and AP fallback can be 15 min
+  // away, so without this the peek would sit there for the whole outage.
+  if (cur == SCREEN_DRY_PEEK && (long)(millis() - dryPeekUntilMs) >= 0) {
+    closeDryPeek();
+    cur = getScreenState();
+  }
+
   if ((cur == SCREEN_FINISHED || (cur == SCREEN_PRINTING && dpSettings.keepPrintScreen)) &&
       !dpSettings.keepDisplayOn && finishActive) {
     BambuState& fs = displayedPrinter().state;
@@ -849,6 +920,11 @@ static void handleGcodeStateTransitions() {
         // The one-shot alert + light + Tasmota bookkeeping below still run.
         if (getScreenState() != SCREEN_POWER_CONFIRM &&
             !isSleepStickyScreen(getScreenState())) {
+          // A finish outranks the drying peek (#150): this branch moves
+          // displayIndex, and leaving the peek up would render another
+          // printer's drying data under it. Close it and let the state machine
+          // land on the finish screen.
+          if (getScreenState() == SCREEN_DRY_PEEK) closeDryPeek();
           if (rotState.displayIndex != i) {
             rotState.displayIndex = i;
             triggerDisplayTransition();
@@ -1108,7 +1184,8 @@ void loop() {
     // Freeze auto-rotation while the camera fullscreen or the power-confirm modal
     // is up so the displayed printer (and its stream / target) does not drift.
     if (getScreenState() != SCREEN_CAMERA &&
-        getScreenState() != SCREEN_POWER_CONFIRM) handleRotation();
+        getScreenState() != SCREEN_POWER_CONFIRM &&
+        getScreenState() != SCREEN_DRY_PEEK) handleRotation();
   }
 
   // Commit the framebuffer sprite to the panel. On JC3248W535 this is a

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,8 @@ static bool        pcPrevHeld        = false;
 static volatile bool pcSendingDrawn  = false;
 
 // AMS drying peek (#150): tapping during a print brings the drying screen up for
-// a few seconds, then it closes itself.
+// a few seconds, then it closes itself. 10 s is what the issue asked for and is
+// what a single drying unit still gets; see openDryPeek() for the multi-unit case.
 static const uint32_t DRY_PEEK_MS = 10000;
 static uint32_t dryPeekUntilMs = 0;
 
@@ -217,7 +218,22 @@ static bool isBoardButton3Held() {
 static bool openDryPeek() {
   PrinterSlot& p = displayedPrinter();
   if (!p.state.printing || !p.state.ams.anyDrying) return false;
-  dryPeekUntilMs = millis() + DRY_PEEK_MS;
+
+  // Restart the drying screen's unit rotation. Its timer free-runs on the idle
+  // screen at a 60 s dwell and keeps aging while no peek is up, so without this
+  // the unit you land on is down to wall-clock luck and two peeks a few seconds
+  // apart show the same one.
+  resetDryingRotation();
+
+  // Size the window so every drying unit gets a turn. One unit keeps the 10 s
+  // promised in #150; beyond that each unit gets DRY_PEEK_DWELL_MS, which is
+  // also the cadence the renderer steps at while SCREEN_DRY_PEEK is up. Without
+  // this a 3-AMS printer showed exactly one unit per tap and the user had to
+  // wait out a full idle-screen rotation between taps to see the other two -
+  // which is the "check the drying during a long print" the issue asked for.
+  const uint32_t units = dryingUnitCount(p.state.ams);
+  const uint32_t span  = units * DRY_PEEK_DWELL_MS;
+  dryPeekUntilMs = millis() + (span > DRY_PEEK_MS ? span : DRY_PEEK_MS);
   setScreenState(SCREEN_DRY_PEEK);
   return true;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -170,7 +170,7 @@ void defaultDisplaySettings(DisplaySettings& ds) {
   ds.animatedBar = true;
   ds.pongClock = false;
   ds.smallLabels = false;
-  ds.showTimeRemaining = false;
+  ds.timeDisplayMode = 0;      // ETA (wall-clock finish time)
   ds.fanMatchPrinter = true;
   ds.invertColors = false;
   ds.cydPanelClassic = false;
@@ -493,7 +493,14 @@ void loadSettings() {
   dispSettings.animatedBar = prefs.getBool("dsp_abar", def.animatedBar);
   dispSettings.pongClock = prefs.getBool("dsp_pong", def.pongClock);
   dispSettings.smallLabels = prefs.getBool("dsp_slbl", def.smallLabels);
-  dispSettings.showTimeRemaining = prefs.getBool("dsp_shtire", def.showTimeRemaining);
+  {
+    // Pre-3.7.7 devices only have the boolean "show remaining instead of ETA".
+    // 0xFF means the new key was never written, so fall back to it once; from
+    // the next save on, both keys are kept in sync.
+    uint8_t tdm = prefs.getUChar("dsp_timem", 0xFF);
+    if (tdm > 2) tdm = prefs.getBool("dsp_shtire", false) ? 1 : 0;
+    dispSettings.timeDisplayMode = tdm;
+  }
   dispSettings.fanMatchPrinter = prefs.getBool("dsp_fanmp", def.fanMatchPrinter);
   dispSettings.invertColors = prefs.getBool("dsp_inv", def.invertColors);
   dispSettings.cydPanelClassic = prefs.getBool("dsp_cydcls", def.cydPanelClassic);
@@ -802,7 +809,10 @@ void saveSettings() {
   prefs.putBool("dsp_abar", dispSettings.animatedBar);
   prefs.putBool("dsp_pong", dispSettings.pongClock);
   prefs.putBool("dsp_slbl", dispSettings.smallLabels);
-  prefs.putBool("dsp_shtire", dispSettings.showTimeRemaining);
+  prefs.putUChar("dsp_timem", dispSettings.timeDisplayMode);
+  // Keep the legacy boolean in sync so a firmware downgrade lands on the
+  // closest behaviour ("Both" degrades to the ETA form).
+  prefs.putBool("dsp_shtire", dispSettings.timeDisplayMode == 1);
   prefs.putBool("dsp_fanmp", dispSettings.fanMatchPrinter);
   prefs.putBool("dsp_inv", dispSettings.invertColors);
   prefs.putBool("dsp_cydcls", dispSettings.cydPanelClassic);

--- a/src/settings.h
+++ b/src/settings.h
@@ -69,7 +69,8 @@ struct DisplaySettings {
   bool     animatedBar;       // shimmer effect on progress bar
   bool     pongClock;         // Pong/Breakout animated clock
   bool     smallLabels;       // use smaller gauge labels (Font 1 instead of Font 2)
-  bool     showTimeRemaining; // always show time remaining instead of ETA
+  uint8_t  timeDisplayMode;   // finish-time line: 0=ETA clock, 1=remaining duration,
+                              // 2=both on one static line ("17:45 · 2h05m")
   bool     fanMatchPrinter;   // round fan % to 10% steps to match printer LCD (else 1% precision from fan_gear)
   bool     hideStatusReadout; // hide the printing status-bar center layer/power readout (redundant when shown as gauges); frees width for the filament name
   bool     invertColors;   // invert display colors (fixes white-bg on some panels)

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -162,7 +162,10 @@ static void readDisplayFromForm() {
   dispSettings.animatedBar = server.hasArg("abar");
   dispSettings.pongClock = server.hasArg("pong");
   dispSettings.smallLabels = server.hasArg("slbl");
-  dispSettings.showTimeRemaining = server.hasArg("shtire");
+  if (server.hasArg("timem")) {
+    int tm = server.arg("timem").toInt();
+    if (tm >= 0 && tm <= 2) dispSettings.timeDisplayMode = (uint8_t)tm;
+  }
   dispSettings.fanMatchPrinter = server.hasArg("fanmp");
 
   // Clock settings (timezone, 24h)
@@ -570,7 +573,7 @@ static void handleToggleSetting() {
   else if (key == "abar")    dispSettings.animatedBar = on;
   else if (key == "pong")    dispSettings.pongClock = on;
   else if (key == "slbl")    dispSettings.smallLabels = on;
-  else if (key == "shtire")  dispSettings.showTimeRemaining = on;
+  else if (key == "timem")   dispSettings.timeDisplayMode = (uint8_t)constrain(server.arg("val").toInt(), 0, 2);
   else if (key == "fanmp")   dispSettings.fanMatchPrinter = on;
   else if (key == "hidelp")  dispSettings.hideStatusReadout = on;
   else if (key == "invcol")  dispSettings.invertColors = on;
@@ -600,7 +603,7 @@ static void handleToggleSetting() {
   }
 
   saveSettings();
-  if (key == "invcol" || key == "slbl" || key == "abar" || key == "shtire") applyDisplaySettings();
+  if (key == "invcol" || key == "slbl" || key == "abar" || key == "timem") applyDisplaySettings();
   if (key == "cydcls") scheduleRestart(800);  // panel swap needs a fresh init
   if (key == "cyd32e") scheduleRestart(800);  // re-init amp enable + RGB pins cleanly
   if (key == "rskin") triggerDisplayTransition();  // repaint print dashboard with the new skin
@@ -1143,7 +1146,10 @@ static void handleSettingsExport() {
   disp["animatedBar"] = dispSettings.animatedBar;
   disp["pongClock"] = dispSettings.pongClock;
   disp["smallLabels"] = dispSettings.smallLabels;
-  disp["showTimeRemaining"] = dispSettings.showTimeRemaining;
+  disp["timeDisplayMode"] = dispSettings.timeDisplayMode;
+  // Legacy key, still emitted so an export imported by pre-3.7.7 firmware keeps
+  // the closest behaviour ("Both" degrades to the ETA form).
+  disp["showTimeRemaining"] = (dispSettings.timeDisplayMode == 1);
   disp["fanMatchPrinter"] = dispSettings.fanMatchPrinter;
   disp["hideStatusReadout"] = dispSettings.hideStatusReadout;
   disp["showBatteryIndicator"] = dispSettings.showBatteryIndicator;
@@ -1466,7 +1472,13 @@ static void handleSettingsImportFinish() {
     if (disp["animatedBar"].is<bool>())       dispSettings.animatedBar = disp["animatedBar"].as<bool>();
     if (disp["pongClock"].is<bool>())           dispSettings.pongClock = disp["pongClock"].as<bool>();
     if (disp["smallLabels"].is<bool>())         dispSettings.smallLabels = disp["smallLabels"].as<bool>();
-    if (disp["showTimeRemaining"].is<bool>())   dispSettings.showTimeRemaining = disp["showTimeRemaining"].as<bool>();
+    // New tri-state key wins; fall back to the legacy boolean for old exports.
+    if (disp["timeDisplayMode"].is<int>()) {
+      int tm = disp["timeDisplayMode"].as<int>();
+      dispSettings.timeDisplayMode = (tm >= 0 && tm <= 2) ? (uint8_t)tm : 0;
+    } else if (disp["showTimeRemaining"].is<bool>()) {
+      dispSettings.timeDisplayMode = disp["showTimeRemaining"].as<bool>() ? 1 : 0;
+    }
     if (disp["fanMatchPrinter"].is<bool>())     dispSettings.fanMatchPrinter = disp["fanMatchPrinter"].as<bool>();
     if (disp["hideStatusReadout"].is<bool>())   dispSettings.hideStatusReadout = disp["hideStatusReadout"].as<bool>();
     if (disp["showBatteryIndicator"].is<bool>()) dispSettings.showBatteryIndicator = disp["showBatteryIndicator"].as<bool>();

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -230,7 +230,10 @@ static bool resolvePlaceholder(const char* name, String& out) {
   if (strcmp(name, "ABAR") == 0)   { out = dispSettings.animatedBar ? "checked" : ""; return true; }
   if (strcmp(name, "PONG") == 0)   { out = dispSettings.pongClock ? "checked" : ""; return true; }
   if (strcmp(name, "SLBL") == 0)   { out = dispSettings.smallLabels ? "checked" : ""; return true; }
-  if (strcmp(name, "SHTIRE") == 0) { out = dispSettings.showTimeRemaining ? "checked" : ""; return true; }
+  if (strncmp(name, "TIMEM", 5) == 0 && name[5] >= '0' && name[5] <= '2' && name[6] == '\0') {
+    out = dispSettings.timeDisplayMode == (uint8_t)(name[5] - '0') ? "selected" : "";
+    return true;
+  }
   if (strcmp(name, "FMP") == 0)    { out = dispSettings.fanMatchPrinter ? "checked" : ""; return true; }
   if (strcmp(name, "HIDELP") == 0) { out = dispSettings.hideStatusReadout ? "checked" : ""; return true; }
   if (strcmp(name, "CLK_INFO") == 0) { out = dispSettings.showClockInfo ? "checked" : ""; return true; }


### PR DESCRIPTION
Addresses two AMS drying requests from @NilsRo in one branch. Targets v3.7.7.

Closes #150
Closes #152

## #150 - check AMS drying during a print

Tapping the button while a print is running now brings up the AMS drying
screen for 10 seconds, then returns to the print dashboard on its own. A
second tap closes it early.

- Only offered when the printer on screen actually has an AMS drying. With
  nothing drying, the tap behaves exactly as before, so nothing changes for
  anyone who does not dry mid-print. No new setting.
- With two or more printers connected, tapping out of the drying view moves
  on to the next printer, so the button keeps cycling instead of stranding
  you on one screen.
- On boards with a camera tile it becomes another stop in the same cycle:
  print -> camera -> drying -> print.
- A print finishing on any printer takes priority and closes the peek, so a
  finish notification is never missed because the drying screen was up.
- The peek does not knock the status LED out of its printing animation.
- With several AMS units drying it shows each of them in turn. The drying
  screen's unit rotation normally dwells 60 s, which no 10 s peek could ever
  outlast, so opening a peek restarts that rotation at the first unit and
  sizes its own window to the unit count - 10 s for a single unit as the
  issue asked for, then 5 s per unit beyond that. Without it a 3-AMS printer
  showed one unit per tap, and which unit depended on where the free-running
  timer happened to be.

Implemented as a new `SCREEN_DRY_PEEK` state reusing the existing
`drawIdleDrying()` renderer, with the auto-close deadline handled in the
unconditional sleep-timeout path so it still expires during a WiFi outage.

## #152 - "remaining time" vs ETA on the drying screen

Two parts, addressed a little differently than proposed:

The square layouts were already showing both values: the remaining time on
its own line ("2h 05m remaining") and the finish time below it
("ETA: 17:45"). The "Show remaining time instead of ETA" checkbox never fed
into that screen, which is where the report came from.

The web UI setting is now a three-way picker instead of a checkbox, wired
through a shared `formatEtaLine()` helper so print, split and round views all
agree:

- Finish time / ETA (default) - "ETA: 17:45"
- Remaining time - "Remaining: 2h 05m"
- Both - "17:45 · 2h05m"

The combined line drops the "ETA:" / "Remaining:" labels to buy the width for
the second value, so each option in the web UI now spells out the form it
produces rather than just naming it.

The old `showTimeRemaining` boolean is migrated to the new `timeDisplayMode`
on load, and the settings export still carries the legacy field, so upgrading
from an older build keeps whatever was previously selected.

Rotating "both" was considered and dropped in favour of a static combined
line: it is motion on a glance display (the same reporter opened #55 about clock
flicker) and it was the only part that needed per-renderer phase caches and
5 s repaint churn.

While wiring the round layout in, the finish-time line is now also drawn on
the round drying screen (it was square-only before), and the shared formatter
steps the string down to a shorter form when it would overflow a curved
sector on the Speedo skin.

## Build

All 16 buildable envs compile green. RAM flat; flash cost is small (esp32c3,
the tightest env, moves +1012 B to 94.1% and still has headroom).
`ws_amoled_216` lives on its own branch and was not built here.

## Not merging yet

Everything above is build-verified only. It was written on a temporary PC
with no printers or devices attached, so none of it has run on hardware.
Holding this open until I can flash and validate the drying peek, the round
finish-time line, the split ETA line and the settings migration on real
boards next week.


