### PR TITLE
Generic DIY display target: build-flag pins + driver for hand-wired panels (#153, #151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,46 @@ When using Bambu Cloud, BambuHelper connects through Bambu Lab's cloud MQTT serv
 | ![Panlee WT32-SC01 Plus](img/SC01Plus3.5.png) | **Panlee WT32-SC01 Plus 3.5"** | `320x480` **ST7796** IPS panel driven over an **8-bit 8080 parallel** bus (the project's first `Bus_Parallel8` board, not SPI or QSPI), ESP32-S3-N16R8 (`16MB` flash / `8MB` PSRAM), and **FT6336** capacitive touch on I2C. Use the `wt32_sc01_plus` firmware build. Reuses the same `320x480` layout as the JC3248W535 and supports **up to 2 printers** (up to 4 with the experimental opt-in). The board has an I2S audio amp, but the buzzer is disabled by default because its default pin is the touch I2C clock line. Sold as the *WT32-SC01 Plus*. | [@cliomjh](https://github.com/cliomjh) |
 | ![CYD TZT variant](img/CYD_tzt.png) | **CYD / TZT L1435-2.4** (ST7789) | Looks almost identical to the standard CYD, but uses a `240x320` **ST7789V** panel (instead of ILI9341) and the backlight is on GPIO27. Use the `tzt_2432` firmware build - the regular `cyd` build will give you a black screen on this hardware. Due to RAM limits, this board supports **1 printer only**. Often sold on Aliexpress as *"TZT ESP32 LVGL 2.4 inch LCD TFT 240*320 With Touch"*. | _community_ |
 
+### Custom-Wired Displays (generic DIY env)
+
+Wired your own SPI display to a bare ESP32 and it doesn't match any board above? Instead of editing C++, there is a **generic DIY build** whose display driver and pins come from build flags in a `boards/*.ini` file. Set your wiring once and build - no source changes.
+
+**Supported drivers:** `GC9A01` (round 240x240), `ST7789` (240x240 or 240x320), `ILI9341` (240x320), `ST7796` (320x480).
+
+**Two starter files** live in [`boards/`](boards/):
+
+- **`boards/diy_round240.ini`** - a ready-to-use example for a GC9A01 round module on an ESP32-C3 Super Mini. Edit the five `DIY_PIN_*` lines to match your wiring and build with `pio run -e diy_round240`.
+- **`boards/diy_spi_template.ini`** - a fully commented template (a working ST7789 240x320 example). Copy it to a new `boards/<yourname>.ini`, rename the `[env:...]`, and edit the flags.
+
+**Required flags** in the env's `build_flags`:
+
+```ini
+-D BOARD_IS_DIY=1
+-D DIY_PANEL_GC9A01=1        ; pick ONE panel driver
+-D DISPLAY_ROUND_240=1       ; the layout that MATCHES the driver (see table)
+-D DIY_PIN_SCLK=4            ; SPI clock
+-D DIY_PIN_MOSI=3            ; SPI data (SDA)
+-D DIY_PIN_DC=10             ; data/command
+-D DIY_PIN_CS=1              ; chip select
+-D BACKLIGHT_PIN=-1          ; a GPIO, or -1 if the backlight is hardwired on
+```
+
+**Driver &harr; layout pairing** (the build refuses to compile if they disagree, so you can't silently ship the wrong layout - which is what makes text fall off a round screen):
+
+| Panel driver | Layout flag to set |
+|---|---|
+| `DIY_PANEL_GC9A01` | `DISPLAY_ROUND_240` |
+| `DIY_PANEL_ST7789` (240x240) | *(none)* |
+| `DIY_PANEL_ST7789` (240x320) | `DISPLAY_240x320` **+** `DIY_PANEL_H=320` |
+| `DIY_PANEL_ILI9341` | `DISPLAY_240x320` |
+| `DIY_PANEL_ST7796` | `DISPLAY_320x480` |
+
+**Optional flags:** `DIY_PIN_MISO` / `DIY_PIN_RST` (default `-1`), `DIY_FREQ_WRITE` (default 40 MHz), `DIY_INVERT` (flip if colours are wrong), `DIY_RGB_ORDER=1` (if red/blue are swapped), `DIY_OFFSET_ROTATION` (0-7, if the image is mirrored/rotated).
+
+**Classic ESP32 (DevKitC / WROOM)** rather than S3/C3: add `board = esp32dev`, `board_build.partitions = min_spiffs.csv`, `-D BOARD_LOW_RAM=1` and `-D DIY_SPI_HOST=VSPI_HOST` (drop the `ARDUINO_USB_CDC_ON_BOOT` flag - classic ESP32 has no native USB). See the commented block in `diy_spi_template.ini`.
+
+The button, buzzer, and status-LED pins default to *disabled* on a DIY build (their normal defaults often collide with a custom display's SPI pins), and the firmware refuses to assign any of them to a pin that's already driving the display. Configure them in the web UI once the device boots. These envs are user-compiled and are **not** part of the web flasher / release set.
+
 ## Features
 
 - **One-click web flasher** - install firmware directly from [keralots.github.io/BambuHelper](https://keralots.github.io/BambuHelper/) in desktop Chrome/Edge - no PlatformIO, no esptool, no flash offsets

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Wired your own SPI display to a bare ESP32 and it doesn't match any board above?
 **Two starter files** live in [`boards/`](boards/):
 
 - **`boards/diy_round240.ini`** - a ready-to-use example for a GC9A01 round module on an ESP32-C3 Super Mini. Edit the five `DIY_PIN_*` lines to match your wiring and build with `pio run -e diy_round240`.
+- **`boards/diy_round240_esp32.ini`** - the same round module on a **classic ESP32** (DevKitC / WROOM). Build with `pio run -e diy_round240_esp32`.
 - **`boards/diy_spi_template.ini`** - a fully commented template (a working ST7789 240x320 example). Copy it to a new `boards/<yourname>.ini`, rename the `[env:...]`, and edit the flags.
 
 **Required flags** in the env's `build_flags`:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Wired your own SPI display to a bare ESP32 and it doesn't match any board above?
 | `DIY_PANEL_ILI9341` | `DISPLAY_240x320` |
 | `DIY_PANEL_ST7796` | `DISPLAY_320x480` |
 
-**Optional flags:** `DIY_PIN_MISO` / `DIY_PIN_RST` (default `-1`), `DIY_FREQ_WRITE` (default 40 MHz), `DIY_INVERT` (flip if colours are wrong), `DIY_RGB_ORDER=1` (if red/blue are swapped), `DIY_OFFSET_ROTATION` (0-7, if the image is mirrored/rotated).
+**Optional flags:** `DIY_PIN_MISO` / `DIY_PIN_RST` (default `-1`), `DIY_FREQ_WRITE` (default 40 MHz), `DIY_INVERT` (flip if colours are wrong), `DIY_RGB_ORDER=1` (if red/blue are swapped), `DIY_OFFSET_ROTATION` (0-7, if the image is mirrored/rotated), `DIY_OFFSET_X` / `DIY_OFFSET_Y` (default `0` - where the glass starts inside the controller's GRAM; set these if the image is *shifted* by a fixed number of pixels with a noisy or blank strip along one edge, e.g. `DIY_OFFSET_Y=80` on a 240x240 ST7789 bonded to the far end of its 240x320 die).
 
 **Classic ESP32 (DevKitC / WROOM)** rather than S3/C3: add `board = esp32dev`, `board_build.partitions = min_spiffs.csv`, `-D BOARD_LOW_RAM=1` and `-D DIY_SPI_HOST=VSPI_HOST` (drop the `ARDUINO_USB_CDC_ON_BOOT` flag - classic ESP32 has no native USB). See the commented block in `diy_spi_template.ini`.
 

--- a/boards/DIY-DISPLAY-HOWTO.md
+++ b/boards/DIY-DISPLAY-HOWTO.md
@@ -1,0 +1,136 @@
+# Custom-Wired (DIY) Displays
+
+Wired your own SPI display to a bare ESP32 and it does not match any of the
+maintained boards? Instead of editing C++, BambuHelper has a **generic DIY
+build target** (`BOARD_IS_DIY`) whose display driver, pins, and geometry all
+come from `-D DIY_*` build flags in a `boards/*.ini` file. Set your wiring
+once and build - no source changes.
+
+The flags are resolved and validated at compile time in
+[`include/diy_display_config.h`](../include/diy_display_config.h); the generic
+`LGFX_DIY` panel class is the first entry in
+[`src/lgfx_boards.h`](../src/lgfx_boards.h).
+
+## Quick start
+
+Two starter files ship in this folder:
+
+- **`boards/diy_round240.ini`** - a ready-to-use example for a GC9A01 round
+  240x240 module on an ESP32-C3 Super Mini. Edit the five `DIY_PIN_*` lines to
+  match your wiring, then build:
+
+  ```
+  pio run -e diy_round240
+  ```
+
+- **`boards/diy_spi_template.ini`** - a fully commented template (a working
+  ST7789 240x320 example). Copy it to a new `boards/<yourname>.ini`, rename the
+  `[env:...]` header, edit the flags, and build `pio run -e <yourname>`.
+
+Both are merged into the build through `extra_configs` in
+[`platformio.ini`](../platformio.ini). These envs are user-compiled and are
+**not** part of the web flasher or the official release set.
+
+## Pick one driver and its matching layout
+
+Set exactly one panel driver, and the **layout flag that matches it**. The
+build refuses to compile if they disagree, so you cannot silently ship the
+wrong layout - which is what makes text fall off the corners of a round
+screen.
+
+| Panel driver | Layout flag to set | Panel size |
+|---|---|---|
+| `DIY_PANEL_GC9A01` | `DISPLAY_ROUND_240` | 240x240 round |
+| `DIY_PANEL_ST7789` (240x240) | *(none)* | 240x240 |
+| `DIY_PANEL_ST7789` (240x320) | `DISPLAY_240x320` **+** `DIY_PANEL_H=320` | 240x320 |
+| `DIY_PANEL_ILI9341` | `DISPLAY_240x320` | 240x320 |
+| `DIY_PANEL_ST7796` | `DISPLAY_320x480` | 320x480 |
+
+`DISPLAY_CYD` is rejected on a DIY build, and setting more than one
+dimensional `DISPLAY_*` is a compile error.
+
+## Flags
+
+### Required
+
+| Flag | Meaning |
+|---|---|
+| `BOARD_IS_DIY=1` | Enable the generic DIY target |
+| `DIY_PANEL_<driver>=1` | Exactly one of `GC9A01` / `ST7789` / `ILI9341` / `ST7796` |
+| `DISPLAY_<layout>=1` | The layout that matches the driver (see table above) |
+| `DIY_PIN_SCLK` | SPI clock GPIO |
+| `DIY_PIN_MOSI` | SPI data (SDA/MOSI) GPIO |
+| `DIY_PIN_DC` | Data/command GPIO |
+| `DIY_PIN_CS` | Chip-select GPIO |
+| `BACKLIGHT_PIN` | Backlight GPIO, or `-1` if the backlight is hardwired on |
+
+Leaving out any of the four `DIY_PIN_*` required pins, or setting zero or more
+than one `DIY_PANEL_*`, is a compile error with a message telling you what is
+missing.
+
+### Optional pins
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `DIY_PIN_MISO` | `-1` | SPI MISO (most display-only modules do not use it) |
+| `DIY_PIN_RST` | `-1` | Panel reset (set it if your module has a RST pin) |
+| `DIY_SPI_HOST` | `SPI2_HOST` | SPI peripheral; use `VSPI_HOST` on a classic ESP32 |
+
+### Optional tuning
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `DIY_FREQ_WRITE` | `40000000` | SPI write clock in Hz (40 MHz). Lower it if a long cable glitches |
+| `DIY_INVERT` | per-driver* | Colour inversion. Flip (`0`/`1`) if colours look negative |
+| `DIY_RGB_ORDER` | `0` | Set `1` if red and blue are swapped |
+| `DIY_OFFSET_ROTATION` | `0` | Rotate/mirror the image, values `0`-`7`, if it comes up sideways |
+
+\* `DIY_INVERT` defaults to on for GC9A01 and ST7796, off for ST7789 and
+ILI9341. It is only a best-guess starting point - modules vary, so flip it if
+your panel looks wrong. You can also toggle inversion from the web UI's
+"invert colours" checkbox after the device boots.
+
+### Geometry overrides (rarely needed)
+
+Each driver sets a sensible panel/memory size by default. Override only if
+your glass differs from the driver's native GRAM:
+
+| Flag | Meaning |
+|---|---|
+| `DIY_PANEL_W` / `DIY_PANEL_H` | Visible panel width / height in pixels |
+| `DIY_MEM_W` / `DIY_MEM_H` | Controller GRAM width / height |
+
+(An ST7789 behind 240x240 glass still has a 240x320 GRAM, which the driver
+default already accounts for.)
+
+## Classic ESP32 (DevKitC / WROOM)
+
+The examples above target S3/C3 boards. On a classic ESP32, override these in
+your env instead of the S3 defaults:
+
+```ini
+board = esp32dev
+board_build.partitions = min_spiffs.csv   ; the app overflows the default 1.3MB slot
+build_flags =
+    ...
+    -D BOARD_LOW_RAM=1                     ; classic ESP32: single printer
+    -D DIY_SPI_HOST=VSPI_HOST              ; classic ESP32 SPI host
+    ; drop the ARDUINO_USB_CDC_ON_BOOT flag - classic ESP32 has no native USB CDC
+```
+
+The commented block at the top of `diy_spi_template.ini` has the same list.
+
+## Buttons, buzzer, and LED
+
+On a DIY build the button, buzzer, and status-LED pins default to **disabled**
+(their normal per-board defaults often collide with a custom panel's SPI
+pins), and the firmware refuses to assign any of them to a pin that is already
+driving the display. Configure them from the web UI once the device boots.
+
+## Combining with a chip-specific target
+
+`BOARD_IS_DIY` is checked first in every hardware selector, so it can be
+combined with a chip target such as `BOARD_IS_C3`: the DIY flags win the
+display and pin configuration while the chip target keeps its radio and USB
+fixes. See `diy_round240.ini`, which sets both `BOARD_IS_C3` and
+`BOARD_IS_DIY`.

--- a/boards/DIY-DISPLAY-HOWTO.md
+++ b/boards/DIY-DISPLAY-HOWTO.md
@@ -23,6 +23,16 @@ Two starter files ship in this folder:
   pio run -e diy_round240
   ```
 
+- **`boards/diy_round240_esp32.ini`** - the same round module on a **classic
+  ESP32** (DevKitC / WROOM) instead of a C3, pre-filled with the wiring from
+  issue #151. A classic ESP32 needs four things changed together (board,
+  partition table, SPI host, printer count), so it ships as its own file rather
+  than a note to apply by hand:
+
+  ```
+  pio run -e diy_round240_esp32
+  ```
+
 - **`boards/diy_spi_template.ini`** - a fully commented template (a working
   ST7789 240x320 example). Copy it to a new `boards/<yourname>.ini`, rename the
   `[env:...]` header, edit the flags, and build `pio run -e <yourname>`.

--- a/boards/DIY-DISPLAY-HOWTO.md
+++ b/boards/DIY-DISPLAY-HOWTO.md
@@ -92,16 +92,26 @@ your panel looks wrong. You can also toggle inversion from the web UI's
 
 ### Geometry overrides (rarely needed)
 
-Each driver sets a sensible panel/memory size by default. Override only if
-your glass differs from the driver's native GRAM:
+Each driver sets a sensible panel/memory size by default.
 
 | Flag | Meaning |
 |---|---|
 | `DIY_PANEL_W` / `DIY_PANEL_H` | Visible panel width / height in pixels |
 | `DIY_MEM_W` / `DIY_MEM_H` | Controller GRAM width / height |
 
-(An ST7789 behind 240x240 glass still has a 240x320 GRAM, which the driver
-default already accounts for.)
+`DIY_PANEL_W` / `DIY_PANEL_H` are **not** a free-form resize. The UI is laid
+out for the dimensions of the `DISPLAY_*` layout you picked, so the build
+requires these to equal that layout's size and errors out otherwise - a
+mismatch would hand LovyanGFX a panel a different size than the UI and
+silently clip the bottom or right edge. In practice the only time you set one
+is `DIY_PANEL_H=320` to select the 240x320 ST7789 variant (see the driver
+table above); if your glass is some other size, none of the layouts fit it and
+this target cannot drive it yet.
+
+`DIY_MEM_W` / `DIY_MEM_H` are the unconstrained pair - override them if your
+controller's GRAM differs from the driver default. (An ST7789 behind 240x240
+glass still has a 240x320 GRAM, which the driver default already accounts
+for.)
 
 ## Classic ESP32 (DevKitC / WROOM)
 

--- a/boards/DIY-DISPLAY-HOWTO.md
+++ b/boards/DIY-DISPLAY-HOWTO.md
@@ -94,10 +94,11 @@ your panel looks wrong. You can also toggle inversion from the web UI's
 
 Each driver sets a sensible panel/memory size by default.
 
-| Flag | Meaning |
-|---|---|
-| `DIY_PANEL_W` / `DIY_PANEL_H` | Visible panel width / height in pixels |
-| `DIY_MEM_W` / `DIY_MEM_H` | Controller GRAM width / height |
+| Flag | Default | Meaning |
+|---|---|---|
+| `DIY_PANEL_W` / `DIY_PANEL_H` | per-driver | Visible panel width / height in pixels |
+| `DIY_MEM_W` / `DIY_MEM_H` | per-driver | Controller GRAM width / height |
+| `DIY_OFFSET_X` / `DIY_OFFSET_Y` | `0` | Where the glass starts inside the GRAM |
 
 `DIY_PANEL_W` / `DIY_PANEL_H` are **not** a free-form resize. The UI is laid
 out for the dimensions of the `DISPLAY_*` layout you picked, so the build
@@ -112,6 +113,32 @@ this target cannot drive it yet.
 controller's GRAM differs from the driver default. (An ST7789 behind 240x240
 glass still has a 240x320 GRAM, which the driver default already accounts
 for.)
+
+#### Image shifted by a few pixels? (`DIY_OFFSET_X` / `DIY_OFFSET_Y`)
+
+When the panel is smaller than the controller's GRAM, the glass may be bonded
+somewhere other than the first row/column of that memory. The symptom is a
+picture shifted by a fixed number of pixels with a band of noise or a blank
+strip along one edge - not a wrong size, just displaced.
+
+`DIY_OFFSET_X` / `DIY_OFFSET_Y` are the GRAM column / row where the visible
+area begins. In practice only one case needs them:
+
+- **240x240 ST7789** (the glass is 240 rows of a 240x320 die): `0` for most
+  modules, `DIY_OFFSET_Y=80` if yours is bonded to the far end of the GRAM.
+- **GC9A01 / ILI9341 / ST7796, and 240x320 ST7789**: leave at `0`. Their GRAM
+  matches the glass, so there is nowhere for the window to move and the build
+  rejects a non-zero offset.
+
+Set them for **rotation 0 only**. LovyanGFX derives the flipped rotations
+itself, so a value that is right at rotation 0 stays right when you change the
+rotation in the web UI. The build checks that `offset + panel` still fits
+inside `DIY_MEM_*` and errors out if it does not.
+
+Note this knob cannot rescue glass of an *unsupported size*. A 240x280 ST7789,
+for example, would want `DIY_PANEL_H=280` - and there is no 280-row layout, so
+the driver/layout check rejects it before the offset ever matters. Offsets fix
+a panel that is the right size but in the wrong place, nothing else.
 
 ## Classic ESP32 (DevKitC / WROOM)
 

--- a/boards/diy_round240.ini
+++ b/boards/diy_round240.ini
@@ -1,0 +1,42 @@
+; =============================================================================
+;  DIY GC9A01 1.28" round 240x240 on ESP32-C3 SuperMini (issue #153)
+; =============================================================================
+;  A hand-wired GC9A01 round module. Unlike the stock esp32c3_round env, the
+;  display pins are NOT hardcoded in a C++ class - they come from the DIY_PIN_*
+;  build flags below, so a different wiring is just a different value here.
+;
+;  This file ships pre-filled with Trotter73's wiring from issue #153:
+;    SCLK=GPIO4  MOSI(SDA)=GPIO3  DC=GPIO10  CS=GPIO1  RST=GPIO0
+;  Change the five DIY_PIN_* lines to match your board.
+;
+;  See boards/DIY-DISPLAY-HOWTO.md for every flag and other panel types.
+; =============================================================================
+[env:diy_round240]
+platform = espressif32@6.12.0
+board = lolin_c3_mini
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = partitions_4mb.csv
+lib_deps = ${common.lib_deps}
+build_flags =
+    -D BOARD_VARIANT=\"diy_round240\"
+    -D BOARD_NAME=\"DIY_GC9A01_Round\"
+    -D BOARD_PANEL=\"GC9A01_240x240_round\"
+    ; Keep the C3 WiFi TX-power cap + Improv provisioning. BOARD_IS_DIY is
+    ; checked FIRST in every selector, so it still wins the display + pin
+    ; defaults while BOARD_IS_C3 supplies the radio fixes.
+    -D BOARD_IS_C3=1
+    -D BOARD_IS_DIY=1
+    -D DIY_PANEL_GC9A01=1
+    -D DISPLAY_ROUND_240=1
+    ; --- Custom display wiring (edit these to match your board) ---
+    -D DIY_PIN_SCLK=4
+    -D DIY_PIN_MOSI=3
+    -D DIY_PIN_DC=10
+    -D DIY_PIN_CS=1
+    -D DIY_PIN_RST=0
+    ; 7-pin GC9A01 modules have the backlight hardwired on: no BLK GPIO.
+    -D BACKLIGHT_PIN=-1
+    ; --- USB Serial (C3 native USB CDC) ---
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D BOARD_LOW_RAM=1

--- a/boards/diy_round240_esp32.ini
+++ b/boards/diy_round240_esp32.ini
@@ -1,0 +1,45 @@
+; =============================================================================
+;  DIY GC9A01 1.28" round 240x240 on a CLASSIC ESP32 (DevKitC / WROOM, #151)
+; =============================================================================
+;  Same display as diy_round240.ini, but on a plain ESP32 instead of a C3.
+;  Pre-filled with the wiring from issue #151:
+;    SCLK=GPIO14  MOSI(SDA)=GPIO15  DC=GPIO27  CS=GPIO5  RST=GPIO33
+;  Change the five DIY_PIN_* lines to match your board.
+;
+;  Why this is its own file rather than a note in the template: a classic ESP32
+;  needs four things changed at once (board, partition table, SPI host, printer
+;  count) and getting any one of them wrong fails in a way that is hard to read
+;  - VSPI_HOST in particular, since SPI2_HOST is the S3/C3 default.
+;
+;  See boards/DIY-DISPLAY-HOWTO.md for every flag and other panel types.
+; =============================================================================
+[env:diy_round240_esp32]
+platform = espressif32@6.12.0
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+; The firmware is ~1.7 MB - too big for Arduino's default 1.3 MB app slot.
+board_build.partitions = min_spiffs.csv
+lib_deps = ${common.lib_deps}
+build_flags =
+    -D BOARD_VARIANT=\"diy_round240_esp32\"
+    -D BOARD_NAME=\"DIY_GC9A01_Round_ESP32\"
+    -D BOARD_PANEL=\"GC9A01_240x240_round\"
+    -D BOARD_IS_DIY=1
+    -D DIY_PANEL_GC9A01=1
+    -D DISPLAY_ROUND_240=1
+    ; Classic ESP32 has no PSRAM on a bare DevKitC: one printer only.
+    -D BOARD_LOW_RAM=1
+    ; Classic ESP32 SPI host. The S3/C3 default (SPI2_HOST) is wrong here.
+    -D DIY_SPI_HOST=VSPI_HOST
+    ; --- Custom display wiring (edit these to match your board) ---
+    -D DIY_PIN_SCLK=14
+    -D DIY_PIN_MOSI=15
+    -D DIY_PIN_DC=27
+    -D DIY_PIN_CS=5
+    -D DIY_PIN_RST=33
+    ; 7-pin GC9A01 modules have the backlight hardwired on: no BLK GPIO. If your
+    ; module exposes BLK, put its GPIO here instead to get brightness control.
+    -D BACKLIGHT_PIN=-1
+; No ARDUINO_USB_CDC_ON_BOOT: classic ESP32 talks over the CP2102/CH340 UART
+; bridge, not native USB.

--- a/boards/diy_spi_template.ini
+++ b/boards/diy_spi_template.ini
@@ -1,0 +1,58 @@
+; =============================================================================
+;  DIY SPI display TEMPLATE - copy, rename, edit for your hand-wired display
+; =============================================================================
+;  The active [env:diy_spi_template] below is a working ST7789 240x320 example.
+;  Copy it to a new boards/<name>.ini, rename the env, and change the flags.
+;  Full documentation: boards/DIY-DISPLAY-HOWTO.md
+;
+;  Pick ONE panel driver and its MATCHING layout (the build errors out if they
+;  disagree, so you cannot silently ship the wrong layout):
+;
+;    DIY_PANEL_GC9A01   ->  DISPLAY_ROUND_240        (240x240 round)
+;    DIY_PANEL_ST7789   ->  (none) for 240x240, or DISPLAY_240x320 + DIY_PANEL_H=320
+;    DIY_PANEL_ILI9341  ->  DISPLAY_240x320
+;    DIY_PANEL_ST7796   ->  DISPLAY_320x480
+;
+;  Required pins: DIY_PIN_SCLK, DIY_PIN_MOSI, DIY_PIN_DC, DIY_PIN_CS.
+;  Optional: DIY_PIN_MISO (default -1), DIY_PIN_RST (default -1).
+;  Optional tuning: DIY_FREQ_WRITE (default 40 MHz), DIY_INVERT (per-driver
+;  default; flip if colours are wrong), DIY_RGB_ORDER (1 if red/blue swapped),
+;  DIY_OFFSET_ROTATION (0-7, if the image is mirrored/rotated).
+;  ALWAYS set BACKLIGHT_PIN (a GPIO, or -1 if the backlight is hardwired on).
+;
+;  --- Classic ESP32 (DevKitC / WROOM, e.g. issue #151) ------------------------
+;  Use these overrides instead of the S3 defaults below:
+;    board = esp32dev
+;    board_build.partitions = min_spiffs.csv   ; the app overflows the 1.3MB default slot
+;    -D BOARD_LOW_RAM=1                          ; classic ESP32: single printer
+;    -D DIY_SPI_HOST=VSPI_HOST                   ; classic ESP32 SPI host
+;  (drop the ARDUINO_USB_CDC_ON_BOOT flag - classic ESP32 has no native USB CDC)
+; =============================================================================
+[env:diy_spi_template]
+platform = espressif32@6.12.0
+board = lolin_s3_mini
+framework = arduino
+monitor_speed = 115200
+; The firmware is ~1.7 MB - too big for Arduino's default 1.3 MB app slot.
+; min_spiffs.csv gives ~1.97 MB app slots (same as the maintained envs).
+board_build.partitions = min_spiffs.csv
+lib_deps = ${common.lib_deps}
+build_flags =
+    -D BOARD_VARIANT=\"diy_spi_template\"
+    -D BOARD_NAME=\"DIY_ST7789_240x320\"
+    -D BOARD_PANEL=\"ST7789_240x320\"
+    -D BOARD_IS_DIY=1
+    -D DIY_PANEL_ST7789=1
+    -D DISPLAY_240x320=1
+    -D DIY_PANEL_H=320
+    ; --- Display wiring (edit to match your board) ---
+    -D DIY_PIN_SCLK=12
+    -D DIY_PIN_MOSI=11
+    -D DIY_PIN_DC=9
+    -D DIY_PIN_CS=10
+    -D DIY_PIN_RST=8
+    -D BACKLIGHT_PIN=-1
+    ; ST7789 modules commonly need inversion; flip if colours look wrong.
+    -D DIY_INVERT=1
+    ; --- USB Serial (S3 native USB CDC) ---
+    -D ARDUINO_USB_CDC_ON_BOOT=1

--- a/boards/diy_spi_template.ini
+++ b/boards/diy_spi_template.ini
@@ -17,7 +17,13 @@
 ;  Optional: DIY_PIN_MISO (default -1), DIY_PIN_RST (default -1).
 ;  Optional tuning: DIY_FREQ_WRITE (default 40 MHz), DIY_INVERT (per-driver
 ;  default; flip if colours are wrong), DIY_RGB_ORDER (1 if red/blue swapped),
-;  DIY_OFFSET_ROTATION (0-7, if the image is mirrored/rotated).
+;  DIY_OFFSET_ROTATION (0-7, if the image is mirrored/rotated),
+;  DIY_OFFSET_X / DIY_OFFSET_Y (default 0; where the glass starts inside the
+;  controller GRAM - set these if the image is SHIFTED by a fixed number of
+;  pixels with a noisy or blank strip along one edge. Only 240x240 ST7789
+;  needs it in practice: DIY_OFFSET_Y=80 if the glass is bonded to the far end
+;  of the 240x320 die. Rotation 0 only - LovyanGFX works out the flipped
+;  rotations itself).
 ;  ALWAYS set BACKLIGHT_PIN (a GPIO, or -1 if the backlight is hardwired on).
 ;
 ;  --- Classic ESP32 (DevKitC / WROOM, e.g. issue #151) ------------------------

--- a/include/config.h
+++ b/include/config.h
@@ -21,6 +21,9 @@
 #ifndef BACKLIGHT_PIN
 #define BACKLIGHT_PIN   TFT_BL  // TFT_eSPI: set via -D TFT_BL=N; LovyanGFX: set via -D BACKLIGHT_PIN=N
 #endif
+// Resolve/validate the generic DIY display flags (no-op unless BOARD_IS_DIY).
+// Included here, after BACKLIGHT_PIN, so isDiyReservedPin() can reference it.
+#include "diy_display_config.h"
 #define BACKLIGHT_CH    0
 #define BACKLIGHT_FREQ  5000
 #define BACKLIGHT_RES   8
@@ -151,7 +154,9 @@
 // =============================================================================
 //  Physical button
 // =============================================================================
-#ifdef DISPLAY_240x320
+#if defined(BOARD_IS_DIY)
+#define BUTTON_DEFAULT_PIN    0       // DIY: no button assumed; user configures in web UI
+#elif defined(DISPLAY_240x320)
 #define BUTTON_DEFAULT_PIN    0       // CYD: GPIO4 is RGB LED, not usable
 #elif defined(BOARD_IS_SENSECAP)
 #define BUTTON_DEFAULT_PIN    38      // SenseCAP Indicator: GPIO38 (inverted, normally HIGH)
@@ -172,7 +177,11 @@
 // =============================================================================
 //  Buzzer (optional passive buzzer)
 // =============================================================================
-#if defined(BOARD_IS_C3)
+#if defined(BOARD_IS_DIY)
+// DIY: no buzzer assumed - the generic C3 default (GPIO3) is often the display's
+// MOSI, and the S3 default (GPIO5) a common SCLK. Disable; user picks a free pin.
+#define BUZZER_DEFAULT_PIN    0
+#elif defined(BOARD_IS_C3)
 #define BUZZER_DEFAULT_PIN    3       // C3: GPIO 3 (GPIO 5 is backlight)
 #elif defined(BOARD_IS_SENSECAP)
 // SenseCAP Indicator: no buzzer hardware connected to ESP32-S3 GPIO.
@@ -231,7 +240,9 @@
 #define LED_PWM_FREQ    5000  // PWM frequency (Hz)
 #define LED_PWM_RES     8     // PWM resolution (bits) -> 0..255 duty
 
-#if defined(DISPLAY_CYD)
+#if defined(BOARD_IS_DIY)
+#define LED_DEFAULT_PIN 0     // DIY: no status LED assumed; user configures in web UI
+#elif defined(DISPLAY_CYD)
 #define LED_DEFAULT_PIN 22    // CYD: GPIO 22 on P3 connector
 #elif defined(BOARD_IS_SENSECAP)
 #define LED_DEFAULT_PIN 0     // SenseCAP Indicator: no dedicated LED pin (user must configure)

--- a/include/diy_display_config.h
+++ b/include/diy_display_config.h
@@ -1,0 +1,193 @@
+#pragma once
+// =============================================================================
+//  Generic DIY display configuration (issue #153 / #151)
+// =============================================================================
+//
+//  Resolves the DIY_* build flags into concrete pin / geometry / inversion
+//  macros and validates the combination at compile time, so a hand-wired SPI
+//  display is just a new boards/*.ini with no C++ edit. The matching LovyanGFX
+//  panel class lives in src/lgfx_boards.h (BOARD_IS_DIY branch).
+//
+//  IMPORTANT: this header is pulled in by config.h, which is included almost
+//  everywhere BEFORE LovyanGFX exists. It must therefore stay PURE PREPROCESSOR
+//  plus one plain-C helper - no `lgfx::` types. The `using DiyPanel = ...` type
+//  alias is in lgfx_boards.h, after <LovyanGFX.hpp>.
+//
+//  See boards/DIY-DISPLAY-HOWTO.md for the user-facing flag list.
+
+#if defined(BOARD_IS_DIY)
+
+// --- Exactly one panel driver -----------------------------------------------
+// Normalise to 0/1 first: `defined()` produced BY macro expansion is undefined
+// behaviour (GCC -Wexpansion-to-defined), so never `#define X (defined(A)+...)`.
+#if defined(DIY_PANEL_GC9A01)
+  #define DIY_HAS_GC9A01 1
+#else
+  #define DIY_HAS_GC9A01 0
+#endif
+#if defined(DIY_PANEL_ST7789)
+  #define DIY_HAS_ST7789 1
+#else
+  #define DIY_HAS_ST7789 0
+#endif
+#if defined(DIY_PANEL_ILI9341)
+  #define DIY_HAS_ILI9341 1
+#else
+  #define DIY_HAS_ILI9341 0
+#endif
+#if defined(DIY_PANEL_ST7796)
+  #define DIY_HAS_ST7796 1
+#else
+  #define DIY_HAS_ST7796 0
+#endif
+#if (DIY_HAS_GC9A01 + DIY_HAS_ST7789 + DIY_HAS_ILI9341 + DIY_HAS_ST7796) != 1
+  #error "BOARD_IS_DIY needs exactly one DIY_PANEL_* (GC9A01/ST7789/ILI9341/ST7796)"
+#endif
+
+// --- Per-driver defaults (geometry matches each panel's native GRAM) ---------
+// invert is a best-guess STARTING point; flip with DIY_INVERT or the web
+// "invert colours" checkbox if a module differs (it is module-specific: ES3N28P
+// runs ILI9341 invert=true, the maintained ST7789 envs force invert via
+// USE_ST7789_INVERT, WS350's ST7796 invert is HW-untested).
+#if   defined(DIY_PANEL_GC9A01)
+  #define DIY_DEF_INVERT 1
+  #define DIY_DEF_PW 240
+  #define DIY_DEF_PH 240
+  #define DIY_DEF_MW 240
+  #define DIY_DEF_MH 240
+#elif defined(DIY_PANEL_ST7789)
+  #define DIY_DEF_INVERT 0
+  #define DIY_DEF_PW 240
+  #define DIY_DEF_PH 240
+  #define DIY_DEF_MW 240
+  #define DIY_DEF_MH 320   // ST7789 GRAM is 240x320 even behind 240x240 glass
+#elif defined(DIY_PANEL_ILI9341)
+  #define DIY_DEF_INVERT 0
+  #define DIY_DEF_PW 240
+  #define DIY_DEF_PH 320
+  #define DIY_DEF_MW 240
+  #define DIY_DEF_MH 320
+#elif defined(DIY_PANEL_ST7796)
+  #define DIY_DEF_INVERT 1
+  #define DIY_DEF_PW 320
+  #define DIY_DEF_PH 480
+  #define DIY_DEF_MW 320
+  #define DIY_DEF_MH 480
+#endif
+
+// --- Pins: required (SCLK/MOSI/DC/CS) + optional (MISO/RST) -------------------
+#if !defined(DIY_PIN_SCLK) || !defined(DIY_PIN_MOSI) || \
+    !defined(DIY_PIN_DC)   || !defined(DIY_PIN_CS)
+  #error "BOARD_IS_DIY needs DIY_PIN_SCLK / DIY_PIN_MOSI / DIY_PIN_DC / DIY_PIN_CS"
+#endif
+#ifndef DIY_PIN_MISO
+  #define DIY_PIN_MISO -1
+#endif
+#ifndef DIY_PIN_RST
+  #define DIY_PIN_RST  -1
+#endif
+#ifndef DIY_SPI_HOST       // SPI2_HOST works on S3/C3; classic ESP32 wants VSPI_HOST
+  #define DIY_SPI_HOST SPI2_HOST
+#endif
+#ifndef DIY_FREQ_WRITE
+  #define DIY_FREQ_WRITE 40000000
+#endif
+
+// --- Geometry / inversion (override any of these in the env) ------------------
+#ifndef DIY_PANEL_W
+  #define DIY_PANEL_W DIY_DEF_PW
+#endif
+#ifndef DIY_PANEL_H
+  #define DIY_PANEL_H DIY_DEF_PH
+#endif
+#ifndef DIY_MEM_W
+  #define DIY_MEM_W DIY_DEF_MW
+#endif
+#ifndef DIY_MEM_H
+  #define DIY_MEM_H DIY_DEF_MH
+#endif
+#ifndef DIY_INVERT
+  #define DIY_INVERT DIY_DEF_INVERT
+#endif
+#ifndef DIY_RGB_ORDER
+  #define DIY_RGB_ORDER 0
+#endif
+#ifndef DIY_OFFSET_ROTATION
+  #define DIY_OFFSET_ROTATION 0
+#endif
+
+// --- Driver <-> layout compatibility, EXCLUSIVE ------------------------------
+// layout.h picks the FIRST matching DISPLAY_* (480x480 > round > 320x480 >
+// 240x320), so a "needs X" check alone would let GC9A01 + DISPLAY_ROUND_240 +
+// DISPLAY_480x480 build a 480x480 UI on a 240x240 panel. And DISPLAY_CYD must be
+// rejected outright: it makes initDisplay() compile CYD _tft_storage logic that
+// the DIY board selector never defines. So: forbid DISPLAY_CYD, count the
+// dimensional layouts, force exactly the matching one.
+#if defined(DISPLAY_CYD)
+  #error "BOARD_IS_DIY is incompatible with DISPLAY_CYD"
+#endif
+#if defined(DISPLAY_ROUND_240)
+  #define DIY_L_ROUND 1
+#else
+  #define DIY_L_ROUND 0
+#endif
+#if defined(DISPLAY_240x320)
+  #define DIY_L_240320 1
+#else
+  #define DIY_L_240320 0
+#endif
+#if defined(DISPLAY_320x480)
+  #define DIY_L_320480 1
+#else
+  #define DIY_L_320480 0
+#endif
+#if defined(DISPLAY_480x480)
+  #define DIY_L_480480 1
+#else
+  #define DIY_L_480480 0
+#endif
+#define DIY_L_COUNT (DIY_L_ROUND + DIY_L_240320 + DIY_L_320480 + DIY_L_480480)
+#if DIY_L_COUNT > 1
+  #error "BOARD_IS_DIY: set at most one dimensional DISPLAY_* layout"
+#endif
+#if defined(DIY_PANEL_GC9A01) && !DIY_L_ROUND
+  #error "DIY_PANEL_GC9A01 needs DISPLAY_ROUND_240 (and no other DISPLAY_*)"
+#endif
+#if defined(DIY_PANEL_ILI9341) && !DIY_L_240320
+  #error "DIY_PANEL_ILI9341 needs DISPLAY_240x320"
+#endif
+#if defined(DIY_PANEL_ST7796) && !DIY_L_320480
+  #error "DIY_PANEL_ST7796 needs DISPLAY_320x480"
+#endif
+#if defined(DIY_PANEL_ST7789)
+  #if   (DIY_PANEL_H == 320)
+    #if !DIY_L_240320
+      #error "DIY_PANEL_ST7789 with DIY_PANEL_H=320 needs DISPLAY_240x320"
+    #endif
+  #elif (DIY_PANEL_H == 240)
+    #if DIY_L_COUNT != 0
+      #error "DIY_PANEL_ST7789 240x240 must set NO dimensional DISPLAY_*"
+    #endif
+  #else
+    #error "DIY_PANEL_ST7789 supports DIY_PANEL_H of 240 or 320 only"
+  #endif
+#endif
+
+// --- Reserved display pins ---------------------------------------------------
+// The button / buzzer / LED sanitizers call this to refuse a pin (fresh default
+// OR persisted-from-another-board OR hand-typed) that would drive a display
+// line. Every candidate is guarded >= 0 so an unused -1 pin never matches.
+// BACKLIGHT_PIN is already resolved by config.h before this header is included.
+static inline bool isDiyReservedPin(int pin) {
+  if (pin < 0) return false;
+  if (pin == DIY_PIN_SCLK) return true;
+  if (pin == DIY_PIN_MOSI) return true;
+  if (pin == DIY_PIN_DC)   return true;
+  if (pin == DIY_PIN_CS)   return true;
+  if (DIY_PIN_MISO  >= 0 && pin == DIY_PIN_MISO)  return true;
+  if (DIY_PIN_RST   >= 0 && pin == DIY_PIN_RST)   return true;
+  if (BACKLIGHT_PIN >= 0 && pin == BACKLIGHT_PIN) return true;
+  return false;
+}
+
+#endif // BOARD_IS_DIY

--- a/include/diy_display_config.h
+++ b/include/diy_display_config.h
@@ -173,6 +173,19 @@
   #endif
 #endif
 
+// --- Visible geometry must match the chosen layout ---------------------------
+// The driver<->layout checks above fix the UI to SCREEN_W x SCREEN_H. A manual
+// DIY_PANEL_W/H override that disagrees (e.g. ILI9341 + DISPLAY_240x320 but
+// DIY_PANEL_H=240) compiles fine yet hands LovyanGFX a panel a different size
+// than the UI, silently clipping the bottom/right. Catch it at build time.
+// (Guarded on defined() so the header stays usable if ever included before the
+// layout; config.h defines SCREEN_W/H just before pulling this in.)
+#if defined(SCREEN_W) && defined(SCREEN_H)
+  #if (DIY_PANEL_W != SCREEN_W) || (DIY_PANEL_H != SCREEN_H)
+    #error "BOARD_IS_DIY: DIY_PANEL_W/H must equal the layout's SCREEN_W x SCREEN_H - drop the geometry override or pick the matching DISPLAY_* layout"
+  #endif
+#endif
+
 // --- Reserved display pins ---------------------------------------------------
 // The button / buzzer / LED sanitizers call this to refuse a pin (fresh default
 // OR persisted-from-another-board OR hand-typed) that would drive a display

--- a/include/diy_display_config.h
+++ b/include/diy_display_config.h
@@ -106,6 +106,21 @@
 #ifndef DIY_MEM_H
   #define DIY_MEM_H DIY_DEF_MH
 #endif
+// Where the visible glass starts inside the controller's GRAM, at rotation 0.
+// Needed when the panel is smaller than the GRAM and the glass is not wired to
+// its first row/column - a 240x280 ST7789 on a 240x320 die wants
+// DIY_OFFSET_Y=20, and a 240x240 module can want 80 depending on which end it
+// is bonded to (symptom: the image is shifted with a band of noise along one
+// edge). Only rotation 0 is configured here: LovyanGFX derives the flipped
+// rotations itself as memory - (panel + offset) (Panel_LCD::setRotation), so a
+// correct value at rotation 0 stays correct through the web UI's rotation
+// setting. Leave at 0 unless you actually see the shift.
+#ifndef DIY_OFFSET_X
+  #define DIY_OFFSET_X 0
+#endif
+#ifndef DIY_OFFSET_Y
+  #define DIY_OFFSET_Y 0
+#endif
 #ifndef DIY_INVERT
   #define DIY_INVERT DIY_DEF_INVERT
 #endif
@@ -184,6 +199,24 @@
   #if (DIY_PANEL_W != SCREEN_W) || (DIY_PANEL_H != SCREEN_H)
     #error "BOARD_IS_DIY: DIY_PANEL_W/H must equal the layout's SCREEN_W x SCREEN_H - drop the geometry override or pick the matching DISPLAY_* layout"
   #endif
+#endif
+
+// --- The offset window must fit inside the GRAM ------------------------------
+// LovyanGFX stores offset_x/y as uint16_t, so a negative silently wraps to a
+// huge column start, and an offset that pushes the visible area past the GRAM
+// edge shifts the image off-screen instead of correcting it. Both are the sort
+// of typo this target exists to make loud rather than mysterious. Note the
+// window has to fit at rotation 0 AND at the flipped rotations, but
+// Panel_LCD::setRotation derives those as memory - (panel + offset), which is
+// non-negative exactly when this check passes.
+#if (DIY_OFFSET_X) < 0 || (DIY_OFFSET_Y) < 0
+  #error "BOARD_IS_DIY: DIY_OFFSET_X/Y must be >= 0 (LovyanGFX stores them unsigned)"
+#endif
+#if ((DIY_OFFSET_X) + (DIY_PANEL_W)) > (DIY_MEM_W)
+  #error "BOARD_IS_DIY: DIY_OFFSET_X + DIY_PANEL_W exceeds DIY_MEM_W - raise DIY_MEM_W to the controller's real GRAM width or lower the offset"
+#endif
+#if ((DIY_OFFSET_Y) + (DIY_PANEL_H)) > (DIY_MEM_H)
+  #error "BOARD_IS_DIY: DIY_OFFSET_Y + DIY_PANEL_H exceeds DIY_MEM_H - raise DIY_MEM_H to the controller's real GRAM height or lower the offset"
 #endif
 
 // --- Reserved display pins ---------------------------------------------------

--- a/include/diy_display_config.h
+++ b/include/diy_display_config.h
@@ -17,6 +17,15 @@
 
 #if defined(BOARD_IS_DIY)
 
+// sdkconfig.h is what defines CONFIG_IDF_TARGET_*, and the reserved-pin helper
+// at the bottom keys its per-chip rules off those. config.h pulls this header in
+// before any Arduino/ESP header, so without this include the macros are simply
+// absent and every one of those rules compiles away to nothing - a silent no-op
+// that still builds clean. Verified: adding an #error on "no target visible"
+// here fails the build unless this include is present. It is a pure #define
+// header, so it does not break the "preprocessor only" rule stated above.
+#include <sdkconfig.h>
+
 // --- Exactly one panel driver -----------------------------------------------
 // Normalise to 0/1 first: `defined()` produced BY macro expansion is undefined
 // behaviour (GCC -Wexpansion-to-defined), so never `#define X (defined(A)+...)`.
@@ -219,11 +228,23 @@
   #error "BOARD_IS_DIY: DIY_OFFSET_Y + DIY_PANEL_H exceeds DIY_MEM_H - raise DIY_MEM_H to the controller's real GRAM height or lower the offset"
 #endif
 
-// --- Reserved display pins ---------------------------------------------------
+// --- Reserved pins -----------------------------------------------------------
 // The button / buzzer / LED sanitizers call this to refuse a pin (fresh default
-// OR persisted-from-another-board OR hand-typed) that would drive a display
-// line. Every candidate is guarded >= 0 so an unused -1 pin never matches.
-// BACKLIGHT_PIN is already resolved by config.h before this header is included.
+// OR persisted-from-another-board OR hand-typed) that must not be driven.
+//
+// Two groups. First this build's display lines - every candidate is guarded
+// >= 0 so an unused -1 pin never matches, and BACKLIGHT_PIN is already resolved
+// by config.h before this header is included.
+//
+// Then the pins the CHIP cannot lend out whatever the wiring: the SPI flash /
+// PSRAM bus, the native USB data lines, and anything past the last real GPIO.
+// The maintained boards get these from their BOARD_IS_* branch in led.cpp, but
+// a DIY env is allowed to name no chip target at all (diy_spi_template and the
+// classic-ESP32 starter do not), and those envs would otherwise reach the end
+// of that chain with nothing but the display pins denied - on a DevKitC header
+// GPIO 6-11 are silkscreened right next to the usable ones. Keyed off the IDF
+// target macros so it works with or without a BOARD_IS_* flag; a DIY env that
+// does set one (diy_round240 sets BOARD_IS_C3) just gets the same answer twice.
 static inline bool isDiyReservedPin(int pin) {
   if (pin < 0) return false;
   if (pin == DIY_PIN_SCLK) return true;
@@ -233,6 +254,19 @@ static inline bool isDiyReservedPin(int pin) {
   if (DIY_PIN_MISO  >= 0 && pin == DIY_PIN_MISO)  return true;
   if (DIY_PIN_RST   >= 0 && pin == DIY_PIN_RST)   return true;
   if (BACKLIGHT_PIN >= 0 && pin == BACKLIGHT_PIN) return true;
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+  if (pin >= 6 && pin <= 11) return true;    // SPI flash
+  if (pin > 39) return true;                 // no such GPIO
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  if (pin >= 26 && pin <= 37) return true;   // SPI flash + PSRAM
+  if (pin == 19 || pin == 20) return true;   // native USB D-/D+
+  if (pin > 48) return true;
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+  if (pin >= 11 && pin <= 17) return true;   // SPI flash
+  if (pin == 18 || pin == 19) return true;   // native USB D-/D+
+  if (pin > 21) return true;
+#endif
   return false;
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,6 +7,8 @@
 ;   wt32_sc01_plus, es3n28p (community, issue #125 - manual build, hw-unconfirmed),
 ;   sc05_x (ZX2D80CE02S experimental), esp32c3_round, esp32s3_round
 ;   (DIY GC9A01 1.28" round)
+; Generic DIY displays (hand-wired SPI panels, pins from build flags): diy_round240
+;   (GC9A01, issue #153) + diy_spi_template (copy/edit). See boards/*.ini + README.
 ;
 ; Plain `pio run` builds only the default env (default_envs below).
 ; Build a specific env with `pio run -e <env>`.

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,8 @@
 ;   sc05_x (ZX2D80CE02S experimental), esp32c3_round, esp32s3_round
 ;   (DIY GC9A01 1.28" round)
 ; Generic DIY displays (hand-wired SPI panels, pins from build flags): diy_round240
-;   (GC9A01, issue #153) + diy_spi_template (copy/edit). See boards/*.ini + README.
+;   (GC9A01 on C3, issue #153), diy_round240_esp32 (same panel on a classic ESP32,
+;   issue #151) + diy_spi_template (copy/edit). See boards/*.ini + README.
 ;
 ; Plain `pio run` builds only the default env (default_envs below).
 ; Build a specific env with `pio run -e <env>`.

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -170,6 +170,10 @@ void sanitizeButtonPin() {
     buttonPin = 0;
   };
 
+#if defined(BOARD_IS_DIY)
+  // A pin carried over from another board's config could drive a DIY display line.
+  if (isDiyReservedPin(buttonPin)) { clash("DIY display pin"); return; }
+#endif
 #if defined(BACKLIGHT_PIN) && BACKLIGHT_PIN >= 0
   if (buttonPin == BACKLIGHT_PIN) { clash("backlight"); return; }
 #endif

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -171,8 +171,9 @@ void sanitizeButtonPin() {
   };
 
 #if defined(BOARD_IS_DIY)
-  // A pin carried over from another board's config could drive a DIY display line.
-  if (isDiyReservedPin(buttonPin)) { clash("DIY display pin"); return; }
+  // A pin carried over from another board's config could drive a DIY display
+  // line, or one of the chip's flash / USB pins - see isDiyReservedPin().
+  if (isDiyReservedPin(buttonPin)) { clash("a reserved DIY pin"); return; }
 #endif
 #if defined(BACKLIGHT_PIN) && BACKLIGHT_PIN >= 0
   if (buttonPin == BACKLIGHT_PIN) { clash("backlight"); return; }

--- a/src/buzzer.cpp
+++ b/src/buzzer.cpp
@@ -85,6 +85,14 @@ void sanitizeBuzzerPin() {
     return;
   }
 #endif
+#if defined(BOARD_IS_DIY)
+  // A pin carried over from another board's config could drive a DIY display line.
+  if (isDiyReservedPin(buzzerSettings.pin)) {
+    Serial.printf("Buzzer: pin %d is a DIY display pin, disabling\n", buzzerSettings.pin);
+    buzzerSettings.pin = 0;
+    return;
+  }
+#endif
 #if defined(BACKLIGHT_PIN)
   if (buzzerSettings.pin == BACKLIGHT_PIN) {
     Serial.printf("Buzzer: pin %d conflicts with backlight, disabling\n", buzzerSettings.pin);

--- a/src/buzzer.cpp
+++ b/src/buzzer.cpp
@@ -86,9 +86,10 @@ void sanitizeBuzzerPin() {
   }
 #endif
 #if defined(BOARD_IS_DIY)
-  // A pin carried over from another board's config could drive a DIY display line.
+  // A pin carried over from another board's config could drive a DIY display
+  // line, or one of the chip's flash / USB pins - see isDiyReservedPin().
   if (isDiyReservedPin(buzzerSettings.pin)) {
-    Serial.printf("Buzzer: pin %d is a DIY display pin, disabling\n", buzzerSettings.pin);
+    Serial.printf("Buzzer: pin %d is reserved on this DIY build, disabling\n", buzzerSettings.pin);
     buzzerSettings.pin = 0;
     return;
   }

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -252,7 +252,12 @@ void setBacklight(uint8_t level) {
 }
 
 static void applyPanelInversion() {
-#if defined(DISPLAY_CYD)
+#if defined(BOARD_IS_DIY)
+  // DIY class sets cfg.invert = DIY_INVERT; LovyanGFX's setInvert() XORs its
+  // argument with cfg.invert, so pass the checkbox directly (checkbox off = the
+  // DIY_INVERT baseline, on = flipped). Do NOT XOR DIY_INVERT again here.
+  _tft_instance.invertDisplay(dispSettings.invertColors);
+#elif defined(DISPLAY_CYD)
   _tft_instance.invertDisplay(dispSettings.invertColors);
 #elif defined(BOARD_IS_SC05X) || defined(BOARD_IS_ES3N28P)
   // These panels set cfg.invert=true in LovyanGFX, so "false" is the native

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -66,6 +66,12 @@ bool isLedPinAllowed(uint8_t pin) {
   if (buzzerSettings.enabled && pin == buzzerSettings.pin) return false;
   if (buttonType != BTN_DISABLED && pin == buttonPin) return false;
 
+#if defined(BOARD_IS_DIY)
+  // Standalone (not part of the board #elif chain below): a DIY+C3 build must
+  // reject BOTH the DIY display pins here AND the C3 reserved pins in the chain.
+  if (isDiyReservedPin(pin)) return false;
+#endif
+
 #if defined(DISPLAY_CYD) || defined(BOARD_IS_TZT_2432)
   // CYD (ESP32-2432S028) and TZT L1435-2.4 - same ESP32 pinout, both esp32dev
   if (pin == 2 || pin == 12 || pin == 13 || pin == 14 || pin == 15) return false;  // display SPI

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -205,6 +205,17 @@ bool isLedPinAllowed(uint8_t pin) {
   // MISO not used but on SPI bus
   if (pin == 47) return false;
   if (pin > 48) return false;
+
+#elif defined(BOARD_IS_DIY)
+  // Last resort for a DIY env that named no chip target, so none of the
+  // BOARD_IS_* branches above matched. isDiyReservedPin() (checked near the top
+  // of this function) already covers the display lines plus the chip's flash /
+  // PSRAM / USB pins; what is left is output capability, which only matters
+  // here - GPIO 34-39 on a classic ESP32 are input-only, perfectly good as a
+  // button but unable to drive an LED at all.
+  #if defined(CONFIG_IDF_TARGET_ESP32)
+  if (pin >= 34 && pin <= 39) return false;
+  #endif
 #endif
 
   return true;

--- a/src/lgfx_boards.h
+++ b/src/lgfx_boards.h
@@ -18,7 +18,67 @@
 
 #include <LovyanGFX.hpp>
 
-#if defined(BOARD_IS_S3_ZERO)
+#if defined(BOARD_IS_DIY)
+// --- Generic DIY SPI display (issue #153/#151) -------------------------------
+// Pins/driver/geometry come from -D flags, resolved + validated in
+// diy_display_config.h (pulled in via config.h, re-included here for clarity;
+// #pragma once makes it a no-op the second time). This branch is FIRST in the
+// chain so a DIY env that also sets BOARD_IS_C3 (to keep the C3 WiFi/Improv
+// fixes) still gets the DIY panel class - specialized-first, same convention as
+// BOARD_IS_C3_ROUND preceding BOARD_IS_C3.
+#include "config.h"
+#if   defined(DIY_PANEL_GC9A01)
+  using DiyPanel = lgfx::Panel_GC9A01;
+#elif defined(DIY_PANEL_ST7789)
+  using DiyPanel = lgfx::Panel_ST7789;
+#elif defined(DIY_PANEL_ILI9341)
+  using DiyPanel = lgfx::Panel_ILI9341;
+#elif defined(DIY_PANEL_ST7796)
+  using DiyPanel = lgfx::Panel_ST7796;
+#endif
+
+class LGFX_DIY : public lgfx::LGFX_Device {
+  DiyPanel      _panel;
+  lgfx::Bus_SPI _bus;
+public:
+  LGFX_DIY() {
+    {
+      auto cfg = _bus.config();
+      cfg.spi_host   = DIY_SPI_HOST;
+      cfg.spi_mode   = 0;
+      cfg.freq_write = DIY_FREQ_WRITE;
+      cfg.freq_read  = 16000000;
+      cfg.pin_sclk   = DIY_PIN_SCLK;
+      cfg.pin_mosi   = DIY_PIN_MOSI;
+      cfg.pin_miso   = DIY_PIN_MISO;
+      cfg.pin_dc     = DIY_PIN_DC;
+      cfg.use_lock   = true;
+      _bus.config(cfg);
+      _panel.setBus(&_bus);
+    }
+    {
+      auto cfg = _panel.config();
+      cfg.pin_cs   = DIY_PIN_CS;
+      cfg.pin_rst  = DIY_PIN_RST;
+      cfg.pin_busy = -1;
+      cfg.memory_width  = DIY_MEM_W;
+      cfg.memory_height = DIY_MEM_H;
+      cfg.panel_width   = DIY_PANEL_W;
+      cfg.panel_height  = DIY_PANEL_H;
+      cfg.offset_x      = 0;
+      cfg.offset_y      = 0;
+      cfg.offset_rotation = DIY_OFFSET_ROTATION;
+      cfg.invert        = DIY_INVERT;
+      cfg.rgb_order     = DIY_RGB_ORDER;
+      cfg.readable      = false;
+      _panel.config(cfg);
+    }
+    setPanel(&_panel);
+  }
+};
+static LGFX_DIY _tft_instance;
+
+#elif defined(BOARD_IS_S3_ZERO)
 // --- Waveshare ESP32-S3-Zero + external ST7789 240x240 -----------------------
 class LGFX_S3Zero : public lgfx::LGFX_Device {
   lgfx::Panel_ST7789  _panel;

--- a/src/lgfx_boards.h
+++ b/src/lgfx_boards.h
@@ -65,8 +65,8 @@ public:
       cfg.memory_height = DIY_MEM_H;
       cfg.panel_width   = DIY_PANEL_W;
       cfg.panel_height  = DIY_PANEL_H;
-      cfg.offset_x      = 0;
-      cfg.offset_y      = 0;
+      cfg.offset_x      = DIY_OFFSET_X;
+      cfg.offset_y      = DIY_OFFSET_Y;
       cfg.offset_rotation = DIY_OFFSET_ROTATION;
       cfg.invert        = DIY_INVERT;
       cfg.rgb_order     = DIY_RGB_ORDER;


### PR DESCRIPTION
Adds a generic "DIY display" build target so a hand-wired SPI panel on a bare
ESP32 can be supported by editing a `boards/*.ini` file instead of the C++
sources. Ships in v3.7.7.

Closes #153

## Why

Two requests converge on the same gap - the display driver, pins, and
geometry were baked into `lgfx_boards.h`, so any wiring that did not match a
maintained board needed a source edit:

- **#153** (@Trotter73) - a C3 Super Mini + 1.28" round GC9A01 wired
  differently from the stock `esp32c3_round`, asking for pin configs to be
  accessible without forking the code.
- **#151** (@Arzamazz) - a classic ESP32 DevKitC + GC9A01 where hand-editing
  `lgfx_boards.h` compiled fine but the UI laid out as if the screen were
  square, so text was cut off by the round bezel (the round layout flag was
  never set).

## What it does

A new `BOARD_IS_DIY` target where the panel driver, SPI pins, geometry, and
colour tuning all come from `-D DIY_*` build flags. `BOARD_IS_DIY` is checked
first in every hardware selector (display, button, buzzer, LED, panel
inversion), so it can be combined with `BOARD_IS_C3` to keep the C3 radio
fixes while DIY wins the display config.

- **Drivers:** GC9A01 (round 240x240), ST7789 (240x240 / 240x320),
  ILI9341 (240x320), ST7796 (320x480).
- **Driver/layout safety:** the flags are resolved and validated at compile
  time in `include/diy_display_config.h`. The build refuses to compile if the
  driver and layout flag disagree - which is exactly the #151 failure mode,
  where a round panel silently ran the square layout and pushed text off the
  glass.
- **Pin-collision safety:** button, buzzer, and status-LED pins default to
  disabled on a DIY build (their normal defaults often collide with a custom
  panel's SPI pins), and the firmware refuses to assign any of them to a pin
  already driving the display. Configure them from the web UI after boot.
- The generic `LGFX_DIY` panel class is first in the `lgfx_boards.h` chain.

## Starter envs (in `boards/`, community tier, not in the web flasher)

- `boards/diy_round240.ini` - ready-to-use GC9A01 round on a C3 Super Mini,
  pre-filled with the #153 reporter's wiring. Edit five `DIY_PIN_*` lines and
  `pio run -e diy_round240`.
- `boards/diy_round240_esp32.ini` - the same round module on a classic ESP32
  DevKitC / WROOM, pre-filled with the #151 reporter's wiring. That board needs
  four things changed together (board, partition table, SPI host, printer
  count) and a wrong `DIY_SPI_HOST` fails unhelpfully, so it ships as its own
  env rather than a block of notes to apply by hand.
- `boards/diy_spi_template.ini` - fully commented ST7789 240x320 template to
  copy and adapt, including the same classic-ESP32 override block.

## Glass offset inside the GRAM

`DIY_OFFSET_X` / `DIY_OFFSET_Y` (default 0) set where the visible panel starts
in the controller's memory, for the common case of a 240x240 ST7789 bonded to
the far end of its 240x320 die - the symptom is a picture shifted by a fixed
number of pixels with a noise band along one edge. Only rotation 0 is
configured; LovyanGFX derives the flipped rotations itself. Validated like the
rest of the flags: it stores them unsigned, so a negative would wrap to a huge
column start, and an offset that pushes the window past the GRAM edge is
rejected with a message naming the flag to change.

## Reserved pins

`isDiyReservedPin()` also rejects what the chip cannot lend out at all - flash
/ PSRAM, native USB, out-of-range - keyed off `CONFIG_IDF_TARGET_*`. A DIY env
is allowed to name no chip target (neither template env does), and `led.cpp`
picks its deny-list from a `BOARD_IS_*` chain with no final `#else`, so those
envs previously reached the end of it with only the display pins denied and the
web UI would accept GPIO 6 as a status LED. It is shared by the button, buzzer
and LED sanitizers. Note `config.h` includes this header before any Arduino or
ESP header, so it now pulls in `sdkconfig.h` explicitly - without that the
target macros are absent and every per-chip rule compiles away to nothing while
still building clean.

## Docs

New "Custom-Wired Displays" section in the README, plus
`boards/DIY-DISPLAY-HOWTO.md` with the full flag list, the driver/layout
pairing table, and the classic-ESP32 overrides.

## Hardware status

- **GC9A01 round on a C3, confirmed.** @Trotter73 flashed `diy_round240` on the
  hardware from #153 and reports it working. I also ran a DIY build against my
  own round module - a different pin map (SCLK 21 / MOSI 20 / DC 7 / CS 6 /
  RST 10) fed through the same `LGFX_DIY` class - which boots, connects, and
  renders the round dashboard, so the flags really are what drives the wiring.
- **Classic ESP32 DevKitC (`diy_round240_esp32`) is build-verified only.** No
  panel of mine is wired that way yet, so #151 stays open until its reporter
  confirms.
