### PR TITLE
v3.7.8: configurable Ready / Print complete gauges, completion time, Phoenix timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ The built-in configuration portal (open the device's IP in any browser) covers e
 
 | Sidebar section | What's inside |
 |---|---|
-| **Printer** | One tab per printer slot: LAN or Cloud connection (serial, access code / cloud token), live status readout, per-printer gauge layout and AMS view, chamber light control |
+| **Printer** | One tab per printer slot: LAN or Cloud connection (serial, access code / cloud token), live status readout, per-printer gauge layout for the print screen plus the Ready / Print complete pair, AMS view, chamber light control |
 | **Display** | Brightness and night mode, screen rotation, after-print behavior, clock screen, screensaver, and Gauge Appearance: theme presets, per-gauge colors, custom labels (accented European characters supported) |
 | **Hardware** | Printer rotation and split-screen mode, external button / TTP223, buzzer with quiet hours, status LED, detected-hardware readout |
 | **Advanced** | Gauge full-scale ranges and behavior (smoothing, warning color), clock-screen info footer, and the Danger zone: reboot, factory reset, experimental multi-printer opt-ins |

--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -227,6 +227,7 @@ struct PrinterConfig {
   uint8_t landscapeExtras[2];  // Col 4 (top, bot) - landscape 8-slot mode only.
   uint8_t portraitExtras[3];   // Row 3 (left, mid, right) - portrait 9-slot mode only.
   bool    amsView;             // 240x240: replace gauge row 2 with AMS strip (per-printer)
+  uint8_t idleSlots[2];        // Ready + Print Complete screens (left, right).
   uint8_t lightFlags;          // chamber-light automation bitmask (LIGHT_* flags), 0 = all off
   uint8_t lightOffDelayMin;    // minutes to wait before turning light off (0-60), default 5
 };

--- a/include/bambu_state.h
+++ b/include/bambu_state.h
@@ -109,6 +109,11 @@ struct BambuState {
   unsigned long lastUpdate;       // millis() of last MQTT message (any)
   unsigned long lastPrintDataMs;  // millis() of last core print data (temps, fans, progress, state)
   bool finishBuzzerPlayed;    // true after FINISH buzzer played (reset on next print)
+  uint32_t finishEpoch;       // wall-clock time the print finished (epoch secs), 0 = unknown
+  bool finishTimeLatched;     // true once this print's finish has been stamped. Starts SET
+                              // after a state wipe: the first FINISH report from a printer
+                              // that was already done reads as an edge, and stamping that
+                              // would record boot time. Armed by an observed print start.
   bool doorAcknowledged;      // true after door opened on FINISH screen (print removed)
   bool bedCooldownAlertArmed; // armed on FINISH transition, fired when bedTemp <= threshold
   int8_t lightState;          // chamber_light from lights_report: -1 unknown, 0 off, 1 on

--- a/include/config.h
+++ b/include/config.h
@@ -4,7 +4,7 @@
 // =============================================================================
 //  Firmware version
 // =============================================================================
-#define FW_VERSION          "v3.7.7"
+#define FW_VERSION          "v3.7.8"
 
 // Board variant — injected into the web UI for OTA asset filtering.
 // Normally set via build_flags in platformio.ini; this is a fallback.

--- a/include/config.h
+++ b/include/config.h
@@ -97,6 +97,10 @@
 // =============================================================================
 #define NVS_NAMESPACE       "bambu"
 
+// Any epoch below this means NTP has not answered yet and the RTC is still at
+// its power-on value, so a wall-clock reading must not be trusted or displayed.
+#define NTP_SYNCED_EPOCH    1704067200UL   // 2024-01-01 00:00:00 UTC
+
 // =============================================================================
 //  Multi-printer
 // =============================================================================

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -205,14 +205,29 @@
 #define LY_FIN_WIFI_Y   308
 // --- Finished screen (landscape overrides - fit within 240px height, full 320 wide) ---
 // Gauges side-by-side, centered cluster on x=160 (32px gap between R=32 gauges).
-// Vertical layout: gauges 18..82, "Print Complete!" centered at 118, file 150,
-// kWh 178 (clear band 169..187 — does NOT touch file at 142..158), bot 216..236.
+//
+// Every Y below is a center (MC datum), so the real ink extent is +/- half the
+// font height. Measured VLW metrics (ascent+descent from the font headers):
+// FONT_SMALL 15, FONT_BODY 20, FONT_LARGE 28.
+//
+// The header bar fills y=7..27 (LY_LAND_HDR_Y/H). GY used to be 50, which put
+// the R=32 arcs at y=18..82 - nine pixels up inside the header, slicing through
+// the printer name (#158). The whole block moved down to clear it:
+//
+//   gauges      30..94   (GY 62 -/+ R 32, so 3px below the header band)
+//   gauge label 83..103  (drawGaugeLabel centers at cy + R - 1, FONT_BODY)
+//   "Print Complete!" 110..138  (TEXT_Y 124, FONT_LARGE)
+//   file name        142..162  (FILE_Y 152, FONT_BODY)
+//   kWh clear band   167..201  (KWH_Y 176; the band is 34px tall, not 18, once
+//                               a Tasmota tariff turns on the second cost line,
+//                               whose ink runs to 202)
+//   bottom bar       216..236
 #define LY_LAND_FIN_GL       112   // left gauge center X (left edge x=80)
 #define LY_LAND_FIN_GR       208   // right gauge center X (right edge x=240)
-#define LY_LAND_FIN_GY        50   // gauge row center Y (R=32 → spans 18..82)
-#define LY_LAND_FIN_TEXT_Y   118   // "Print Complete!" (font 4 ~26px tall)
-#define LY_LAND_FIN_FILE_Y   150   // file name (font 2 ~16px tall, spans 142..158)
-#define LY_LAND_FIN_KWH_Y    178   // kWh row (font 2) — clear band kwhY-9..kwhY+9 = 169..187
+#define LY_LAND_FIN_GY        62   // gauge row center Y (R=32 → spans 30..94)
+#define LY_LAND_FIN_TEXT_Y   124   // "Print Complete!" (FONT_LARGE, 28px tall)
+#define LY_LAND_FIN_FILE_Y   152   // file name (FONT_BODY, 20px tall)
+#define LY_LAND_FIN_KWH_Y    176   // kWh row (FONT_BODY) — clear band kwhY-9 .. kwhY+25
 #define LY_LAND_FIN_BOT_Y    216
 #define LY_LAND_FIN_BOT_H    20
 #define LY_LAND_FIN_WIFI_Y   228

--- a/include/layout_240x320.h
+++ b/include/layout_240x320.h
@@ -227,7 +227,7 @@
 #define LY_LAND_FIN_GY        62   // gauge row center Y (R=32 → spans 30..94)
 #define LY_LAND_FIN_TEXT_Y   124   // "Print Complete!" (FONT_LARGE, 28px tall)
 #define LY_LAND_FIN_FILE_Y   152   // file name (FONT_BODY, 20px tall)
-#define LY_LAND_FIN_KWH_Y    176   // kWh row (FONT_BODY) — clear band kwhY-9 .. kwhY+25
+#define LY_LAND_FIN_KWH_Y    176   // kWh row (FONT_BODY) - clear band kwhY-9 .. kwhY+25
 #define LY_LAND_FIN_BOT_Y    216
 #define LY_LAND_FIN_BOT_H    20
 #define LY_LAND_FIN_WIFI_Y   228

--- a/include/layout_round240.h
+++ b/include/layout_round240.h
@@ -152,6 +152,12 @@
 #define LY_RND_FIN_CHK_Y     92    // checkmark circle center Y
 #define LY_RND_FIN_CHK_R     32
 #define LY_RND_FIN_TEXT_Y    156   // "Print Complete!" (center datum)
+// Rim-safe ink width for the headline. Derived, not guessed: the ring inner
+// edge is R - T = 111, the FONT_BODY line at y=156 reaches dy = 46 from the
+// center, so the usable chord is 2*sqrt(111^2 - 46^2) = 202. 190 keeps a
+// margin. The filename line below sits lower (dy = 68 -> chord 175) and uses
+// its own tighter 150.
+#define LY_RND_FIN_TEXT_MAXW 190
 #define LY_RND_FIN_FILE_Y    178   // filename (center datum)
 #define LY_RND_FIN_TIME_Y    198   // total time (center datum)
 

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -76,7 +76,7 @@ function saveWifi(){
 //    Printer:  pname, ip, serial, code, connmode, region, cl_token, cl_serial,
 //              cl_pname, dualp, gs0..gs5, lx0..lx1, px0..px2, is0..is1, amsv
 //    Display:  bright, nighten, nstart, nend, nbright, ssbright, afterprint,
-//              fmins, dack, kps, pong, abar, slbl, timem, fanmp, hidelp, invcol,
+//              fmins, dack, fintm, kps, pong, abar, slbl, timem, fanmp, hidelp, invcol,
 //              cydcls, cyd32e, rskin, rotation, tz, use24h, datefmt, clk_time, clk_date,
 //              clk_size, clk_dsize, clk_hidedate, noz_max, bed_max, cht_max, pwr_max,
 //              gsmooth, warn_thr, warn_clr,
@@ -830,7 +830,7 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       </div>
     </div>
 %EXTRAS_SECTIONS%
-    <div class="row-divider">&#9670; Ready / Print complete</div>
+    <div class="row-divider" id="idlePairDivider">&#9670; Ready / Print complete</div>
     <div class="gauge-grid">
       <div class="cell"><label>Left gauge</label><select id="is0" class="gauge-slot-sel"></select></div>
       <div class="cell"><label>Right gauge</label><select id="is1" class="gauge-slot-sel"></select></div>
@@ -973,6 +973,11 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       <input type="checkbox" id="dack" value="1" %DACK% onchange="toggleSetting('dack',this.checked)">
       <label for="dack">Wait for door open before timeout</label>
     </label>
+    <label class="check-row">
+      <input type="checkbox" id="fintm" value="1" %FINTM% onchange="toggleSetting('fintm',this.checked)">
+      <label for="fintm">Show the completion time on the finish screen</label>
+    </label>
+    <div class="help-text" style="padding-left:28px">Adds the clock time the print ended, e.g. <span class="mono">Print Complete! @ 14:32</span>. On 240 px wide screens the longer line is drawn in a smaller font - turn this off to keep the headline large.</div>
     <label class="check-row">
       <input type="checkbox" id="kps" value="1" %KPS% onchange="toggleSetting('kps',this.checked)">
       <label for="kps">Keep print status screen after completion</label>
@@ -1842,11 +1847,17 @@ rebuildGaugeOptions();
 /* Round boards (GC9A01): the printing dashboard has no 2x3 grid. Only the Rim
    skin renders gauges - three mini slots fed from gaugeSlots[0..2] - so the
    card re-labels itself and hides the bottom row. gs3-gs5 stay in the DOM
-   (hidden) so saveGaugeLayout keeps posting all six slots unchanged. */
+   (hidden) so saveGaugeLayout keeps posting all six slots unchanged.
+   The is0/is1 pair drives the round Ready screen only: the round Print
+   complete screen is a fixed layout (checkmark, headline, file name, energy)
+   with no room for the two gauges, so the divider says so rather than
+   promising a screen that ignores the setting. */
 var IS_ROUND = %ISROUND% === 1;
 if (IS_ROUND){
   var gd = document.getElementById('glDesc');
-  if (gd) gd.innerHTML = 'Per-printer mini gauges for the round <em>Rim</em> skin: left, center and right slot. The <em>Speedo</em> and <em>Rings</em> skins have fixed layouts. Set a slot to <em>Empty</em> to hide it.';
+  if (gd) gd.innerHTML = 'Per-printer mini gauges for the round <em>Rim</em> skin: left, center and right slot. The <em>Speedo</em> and <em>Rings</em> skins have fixed layouts. The last pair is the two gauges on the <em>Ready</em> screen - the round <em>Print complete</em> screen has a fixed layout and does not use them. Set a slot to <em>Empty</em> to hide it.';
+  var ipd = document.getElementById('idlePairDivider');
+  if (ipd) ipd.innerHTML = '&#9670; Ready screen';
   var roundLbls = ['Left gauge','Center gauge','Right gauge'];
   for (var ri = 0; ri < 3; ri++){
     var rsel = document.getElementById('gs' + ri);
@@ -2535,6 +2546,7 @@ function applyDisplay(){
   else if (ap === 'custom') { p.append('fmins', document.getElementById('fmins').value); if (afClock) p.append('clock', '1'); }
   else { p.append('fmins', ap); if (afClock) p.append('clock', '1'); }
   if (document.getElementById('dack').checked) p.append('dack', '1');
+  if (document.getElementById('fintm').checked) p.append('fintm', '1');
   if (document.getElementById('kps').checked) p.append('kps', '1');
   if (document.getElementById('abar').checked) p.append('abar', '1');
   if (document.getElementById('pong').checked) p.append('pong', '1');

--- a/include/web_pages.h
+++ b/include/web_pages.h
@@ -74,7 +74,7 @@ function saveWifi(){
 //
 //  Field IDs (audited against web_server.cpp, NOT the design handoff README):
 //    Printer:  pname, ip, serial, code, connmode, region, cl_token, cl_serial,
-//              cl_pname, dualp, gs0..gs5, amsv
+//              cl_pname, dualp, gs0..gs5, lx0..lx1, px0..px2, is0..is1, amsv
 //    Display:  bright, nighten, nstart, nend, nbright, ssbright, afterprint,
 //              fmins, dack, kps, pong, abar, slbl, timem, fanmp, hidelp, invcol,
 //              cydcls, cyd32e, rskin, rotation, tz, use24h, datefmt, clk_time, clk_date,
@@ -810,19 +810,19 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
     <div class="card-head">
       <div>
         <h3>Gauge Layout</h3>
-        <p id="glDesc">Per-printer display slots. The standard 2x3 grid is always shown. On 240x320 and 320x480 boards the extra rows below only render when the matching grid mode (<em>Landscape 8 slots</em> / <em>Portrait 9 slots</em>) is enabled under <strong>Advanced</strong>. Set any slot to <em>Empty</em> to hide it.</p>
+        <p id="glDesc">Per-printer display slots. The standard 2x3 grid is always shown while printing. On 240x320 and 320x480 boards the extra rows below only render when the matching grid mode (<em>Landscape 8 slots</em> / <em>Portrait 9 slots</em>) is enabled under <strong>Advanced</strong>. The last pair is the two gauges on the Ready and Print complete screens - handy for watching chamber temperature while a part cools. That pair is not used when <em>Keep print status screen after completion</em> is on, since the print grid stays up instead. Set any slot to <em>Empty</em> to hide it.</p>
       </div>
       <button type="button" class="btn btn-ghost btn-sm" style="white-space:nowrap" onclick="resetGaugeLayout()">Reset to default</button>
     </div>
 %AMSV_ROW%
-    <div class="row-divider" style="margin-top:var(--sp-3)" id="topRowDivider">&#9650; Top row</div>
+    <div class="row-divider" style="margin-top:var(--sp-3)" id="topRowDivider">&#9650; Print screen - top row</div>
     <div class="gauge-grid">
       <div class="cell"><label>Top-left</label><select id="gs0" class="gauge-slot-sel"></select></div>
       <div class="cell"><label>Top-center</label><select id="gs1" class="gauge-slot-sel"></select></div>
       <div class="cell"><label>Top-right</label><select id="gs2" class="gauge-slot-sel"></select></div>
     </div>
     <div id="bottomRowGroup">
-      <div class="row-divider">&#9660; Bottom row</div>
+      <div class="row-divider">&#9660; Print screen - bottom row</div>
       <div class="gauge-grid">
         <div class="cell"><label>Bot-left</label><select id="gs3" class="gauge-slot-sel"></select></div>
         <div class="cell"><label>Bot-center</label><select id="gs4" class="gauge-slot-sel"></select></div>
@@ -830,6 +830,11 @@ html[data-theme="dark"] .topbar::after { opacity: 0.5; }
       </div>
     </div>
 %EXTRAS_SECTIONS%
+    <div class="row-divider">&#9670; Ready / Print complete</div>
+    <div class="gauge-grid">
+      <div class="cell"><label>Left gauge</label><select id="is0" class="gauge-slot-sel"></select></div>
+      <div class="cell"><label>Right gauge</label><select id="is1" class="gauge-slot-sel"></select></div>
+    </div>
     <div class="action-bar">
       <button type="button" class="btn btn-primary" onclick="saveGaugeLayout()">Save Gauge Layout</button>
     </div>
@@ -1790,6 +1795,7 @@ function gaugeAllowed(idx){
   if (req) return !!gaugeCaps[req];
   return true;
 }
+var GAUGE_CAMERA_ID = 32;  // keep in sync with GAUGE_CAMERA in settings.h
 function rebuildGaugeOptions(){
   // Build ungrouped + groups once, then clone into each <select>.
   // groups[] preserves first-seen order; groupMembers[g] is a list of {i, name}.
@@ -1804,9 +1810,15 @@ function rebuildGaugeOptions(){
   });
   var sels = document.querySelectorAll('.gauge-slot-sel');
   sels.forEach(function(sel){
+    // Ready / Print complete slots cannot host the camera: that tile paints on
+    // its own cadence and the stream only starts for a print-grid slot, so it
+    // would sit frozen. Filtered here because this runs again on every capability
+    // refresh and tab switch - removing the option once would not stick.
+    var isIdleSel = (sel.id === 'is0' || sel.id === 'is1');
     var cur = sel.value;
     sel.innerHTML = '';
     ungrouped.forEach(function(e){
+      if (isIdleSel && e.i === GAUGE_CAMERA_ID) return;
       var o = document.createElement('option');
       o.value = e.i; o.textContent = e.name;
       sel.appendChild(o);
@@ -1815,11 +1827,12 @@ function rebuildGaugeOptions(){
       var og = document.createElement('optgroup');
       og.label = g;
       groupMembers[g].forEach(function(e){
+        if (isIdleSel && e.i === GAUGE_CAMERA_ID) return;
         var o = document.createElement('option');
         o.value = e.i; o.textContent = e.name;
         og.appendChild(o);
       });
-      sel.appendChild(og);
+      if (og.children.length) sel.appendChild(og);
     });
     if (cur !== '') sel.value = cur;
   });
@@ -1855,7 +1868,7 @@ function refreshGaugeCaps(){
     });
     arr.forEach(function(d){
       if (!d) return;
-      ['gaugeSlots','landscapeExtras','portraitExtras'].forEach(function(key){
+      ['gaugeSlots','landscapeExtras','portraitExtras','idleSlots'].forEach(function(key){
         if (!Array.isArray(d[key])) return;
         d[key].forEach(function(v){
           if (!persistedGauges[v]) { persistedGauges[v] = true; changed = true; }
@@ -1876,6 +1889,9 @@ function resetGaugeLayout(){
   var lx = ['lx0','lx1'], px = ['px0','px1','px2'];
   lx.forEach(function(id){ var s = document.getElementById(id); if (s) s.value = 0; });
   px.forEach(function(id){ var s = document.getElementById(id); if (s) s.value = 0; });
+  // Ready / Print complete -> Nozzle/Bed, what those screens always drew.
+  var di = [2,3];
+  for (var i = 0; i < 2; i++) { var s = document.getElementById('is' + i); if (s) s.value = di[i]; }
   showToast('Restored layout defaults');
 }
 function saveGaugeLayout(){
@@ -1884,6 +1900,7 @@ function saveGaugeLayout(){
   for (var g = 0; g < 6; g++) { var s = document.getElementById('gs' + g); if (s) p.append('gs' + g, s.value); }
   for (var g = 0; g < 2; g++) { var s = document.getElementById('lx' + g); if (s) p.append('lx' + g, s.value); }
   for (var g = 0; g < 3; g++) { var s = document.getElementById('px' + g); if (s) p.append('px' + g, s.value); }
+  for (var g = 0; g < 2; g++) { var s = document.getElementById('is' + g); if (s) p.append('is' + g, s.value); }
   var av = document.getElementById('amsv');
   if (av && av.checked) p.append('amsv', '1');
   fetch('/save/gaugelayout',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:p.toString()})
@@ -1954,15 +1971,20 @@ function selectPrinterTab(slot){
       var capName = GAUGE_REQUIRES[idx];
       if (d[capName] && !gaugeCaps[capName]){ gaugeCaps[capName] = true; capsChanged = true; }
     });
-    if (d.gaugeSlots){
-      d.gaugeSlots.forEach(function(v){
+    // Keep options for gauges this printer has saved even when it is offline and
+    // its capability flags say otherwise - otherwise the select renders empty and
+    // the next save silently downgrades the slot to Empty.
+    ['gaugeSlots','idleSlots'].forEach(function(key){
+      if (!d[key]) return;
+      d[key].forEach(function(v){
         if (!persistedGauges[v]){ persistedGauges[v] = true; capsChanged = true; }
       });
-    }
+    });
     if (capsChanged) rebuildGaugeOptions();
     if (d.gaugeSlots) { for (var g = 0; g < 6; g++) { var sel = document.getElementById('gs' + g); if (sel) sel.value = d.gaugeSlots[g] || 0; } }
     if (d.landscapeExtras) { for (var g = 0; g < 2; g++) { var sel = document.getElementById('lx' + g); if (sel) sel.value = d.landscapeExtras[g] || 0; } }
     if (d.portraitExtras)  { for (var g = 0; g < 3; g++) { var sel = document.getElementById('px' + g); if (sel) sel.value = d.portraitExtras[g] || 0; } }
+    if (d.idleSlots)       { for (var g = 0; g < 2; g++) { var sel = document.getElementById('is' + g); if (sel) sel.value = d.idleSlots[g] || 0; } }
     var av = document.getElementById('amsv');
     if (av) { av.checked = !!d.amsView; syncAmsView(); }
     var lf = d.lightFlags || 0;

--- a/src/bambu_mqtt.cpp
+++ b/src/bambu_mqtt.cpp
@@ -1678,6 +1678,7 @@ static void initConnSlot(uint8_t i) {
   BambuState& s = printers[i].state;
   memset(&s, 0, sizeof(BambuState));
   s.lightState = -1;  // unknown until lights_report arrives (memset would read as "off")
+  s.finishTimeLatched = true;  // see settings.cpp: only an observed print start arms it
   setPrinterGcodeStateCanonical(s, GCODE_UNKNOWN);
 
   if (isPrinterConfigured(i)) {

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1478,6 +1478,49 @@ static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
   #define LAYOUT_240x240_AMS_VIEW 1
 #endif
 
+// Renders the print completion time into buf, "" when there is nothing to show
+// (the user turned the timestamp off, or the print finished before NTP had a
+// valid clock). Shared by the finished-screen headline and the idle status
+// badge so both agree on the 12h/24h wording.
+static bool formatFinishClock(char* buf, size_t n, const BambuState& s) {
+  buf[0] = '\0';
+  if (!dpSettings.finishShowTime || s.finishEpoch == 0) return false;
+  // localtime_r needs a real time_t; finishEpoch is stored as uint32_t so its
+  // width does not depend on the toolchain.
+  time_t stamp = (time_t)s.finishEpoch;
+  struct tm ft;
+  localtime_r(&stamp, &ft);
+  int hour = ft.tm_hour;
+  if (netSettings.use24h) {
+    snprintf(buf, n, "%02d:%02d", hour, ft.tm_min);
+  } else {
+    // Uppercase AM/PM to match every other 12h renderer (clock screen, ETA line)
+    const char* ampm = hour < 12 ? "AM" : "PM";
+    hour %= 12;
+    if (hour == 0) hour = 12;
+    snprintf(buf, n, "%d:%02d %s", hour, ft.tm_min, ampm);
+  }
+  return true;
+}
+
+// Idle-screen wording for a printer still sitting in GCODE_FINISH. Steps down
+// until it fits maxW: full wording with the time -> short wording with the time
+// -> wording alone. The caller has already selected the badge font.
+static const char* formatIdleFinishBadge(char* buf, size_t n, const BambuState& s,
+                                         int16_t maxW) {
+  char clock[16];
+  if (!formatFinishClock(clock, sizeof(clock), s)) {
+    strlcpy(buf, "Print Complete", n);
+    return buf;
+  }
+  snprintf(buf, n, "Print Complete @ %s", clock);
+  if (maxW > 0 && tft.textWidth(buf) > maxW) {
+    snprintf(buf, n, "Complete @ %s", clock);
+    if (tft.textWidth(buf) > maxW) strlcpy(buf, "Print Complete", n);
+  }
+  return buf;
+}
+
 static void drawIdle() {
   if (!isAnyPrinterConfigured()) {
     wasNoPrinter = true;
@@ -1572,7 +1615,10 @@ static void drawIdle() {
   tickGaugeSmooth(s, forceRedraw);
   bool stateChanged = forceRedraw ||
                       (s.gcodeStateId != prevState.gcodeStateId) ||
-                      (strcmp(s.gcodeState, prevState.gcodeState) != 0);
+                      (strcmp(s.gcodeState, prevState.gcodeState) != 0) ||
+                      // The completion stamp lands a loop iteration after the
+                      // FINISH edge, so the badge has to repaint on it too.
+                      (s.finishEpoch != prevState.finishEpoch);
   bool connChanged = forceRedraw || (s.connected != prevState.connected);
   bool wifiChanged = forceRedraw || (s.wifiSignal != prevState.wifiSignal);
 
@@ -1606,9 +1652,23 @@ static void drawIdle() {
     setFont(tft, FONT_BODY);
     uint16_t stateColor = CLR_TEXT_DIM;
     const char* stateStr = s.gcodeState;
+    char finishBadge[40];
     if (s.gcodeStateId == GCODE_IDLE) {
       stateColor = CLR_GREEN;
       stateStr = "Ready";
+    } else if (s.gcodeStateId == GCODE_FINISH) {
+      // The finished screen is one-shot: waking a slept display dismisses it
+      // (finishDismissedByWake in main.cpp) and lands here instead. Carry the
+      // completion wording and time on the badge so a print that finished while
+      // nobody was watching is still readable on wake, rather than the raw
+      // "FINISH" state word (#158).
+      stateColor = CLR_GREEN;
+#if defined(DISPLAY_ROUND_240)
+      const int16_t badgeMaxW = 200;   // rim-safe chord at the badge row
+#else
+      const int16_t badgeMaxW = scrW - 8;
+#endif
+      stateStr = formatIdleFinishBadge(finishBadge, sizeof(finishBadge), s, badgeMaxW);
     } else if (s.gcodeStateId == GCODE_FAILED) {
       stateColor = CLR_RED;
       stateStr = "ERROR";
@@ -3000,24 +3060,8 @@ void drawFinishHeadline(int16_t cx, int16_t y, int16_t maxW, const BambuState& s
 
   // Empty when the user turned the timestamp off, or when the print finished
   // before NTP had a valid clock.
-  char clock[16] = "";
-  if (dpSettings.finishShowTime && s.finishEpoch != 0) {
-    // localtime_r needs a real time_t; finishEpoch is stored as uint32_t so its
-    // width does not depend on the toolchain.
-    time_t stamp = (time_t)s.finishEpoch;
-    struct tm ft;
-    localtime_r(&stamp, &ft);
-    int hour = ft.tm_hour;
-    if (netSettings.use24h) {
-      snprintf(clock, sizeof(clock), "%02d:%02d", hour, ft.tm_min);
-    } else {
-      // Uppercase AM/PM to match every other 12h renderer (clock screen, ETA line)
-      const char* ampm = hour < 12 ? "AM" : "PM";
-      hour %= 12;
-      if (hour == 0) hour = 12;
-      snprintf(clock, sizeof(clock), "%d:%02d %s", hour, ft.tm_min, ampm);
-    }
-  }
+  char clock[16];
+  formatFinishClock(clock, sizeof(clock), s);
 
   char buf[40];
   if (clock[0] == '\0') {

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -2894,6 +2894,49 @@ uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
   return clr;
 }
 
+// ---------------------------------------------------------------------------
+//  Finished screen headline
+// ---------------------------------------------------------------------------
+//  Sits beside formatEtaLine() - outside the DISPLAY_ROUND_240 block below - so
+//  the round finished screen links against it too.
+// ---------------------------------------------------------------------------
+void drawFinishHeadline(int16_t cx, int16_t y, int16_t maxW, const BambuState& s) {
+  static const char* kMsg = "Print Complete!";
+
+  char buf[40];
+  if (s.finishEpoch != 0) {
+    // localtime_r needs a real time_t; finishEpoch is stored as uint32_t so its
+    // width does not depend on the toolchain.
+    time_t stamp = (time_t)s.finishEpoch;
+    struct tm ft;
+    localtime_r(&stamp, &ft);
+    int hour = ft.tm_hour;
+    if (netSettings.use24h) {
+      snprintf(buf, sizeof(buf), "%s @ %02d:%02d", kMsg, hour, ft.tm_min);
+    } else {
+      // Uppercase AM/PM to match every other 12h renderer (clock screen, ETA line)
+      const char* ampm = hour < 12 ? "AM" : "PM";
+      hour %= 12;
+      if (hour == 0) hour = 12;
+      snprintf(buf, sizeof(buf), "%s @ %d:%02d %s", kMsg, hour, ft.tm_min, ampm);
+    }
+  } else {
+    strlcpy(buf, kMsg, sizeof(buf));
+  }
+
+  // Largest font that fits. The time is the first thing sacrificed - the
+  // message itself always renders at full size on every layout profile.
+  setFont(tft, FONT_LARGE);
+  if (maxW > 0 && tft.textWidth(buf) > maxW) {
+    setFont(tft, FONT_BODY);
+    if (tft.textWidth(buf) > maxW) {
+      strlcpy(buf, kMsg, sizeof(buf));
+      setFont(tft, FONT_LARGE);
+    }
+  }
+  tft.drawString(buf, cx, y);
+}
+
 #if defined(DISPLAY_ROUND_240)
 // ===========================================================================
 //  Round display (GC9A01): printing screen. Three skins selectable from the
@@ -4310,9 +4353,9 @@ static void drawFinishedRound() {
     }
 
     tft.setTextDatum(MC_DATUM);
-    setFont(tft, FONT_LARGE);
     tft.setTextColor(CLR_GREEN, CLR_BG);
-    tft.drawString("Print Complete!", cx, LY_RND_FIN_TEXT_Y);
+    // 150 is the same rim-safe width the file name below uses
+    drawFinishHeadline(cx, LY_RND_FIN_TEXT_Y, 150, s);
 
     const char* rndFinName = jobDisplayName(s);
     if (rndFinName[0] != '\0') {
@@ -4481,8 +4524,7 @@ static void drawFinished() {
     markFrameDirty();
     tft.setTextDatum(MC_DATUM);
     tft.setTextColor(CLR_GREEN, CLR_BG);
-    setFont(tft, FONT_LARGE);
-    tft.drawString("Print Complete!", cx, finTextY);
+    drawFinishHeadline(cx, finTextY, scrW - 12, s);
   }
 
   // === File name ===

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1463,6 +1463,11 @@ static bool useEnhancedPortraitAms(const AmsState& ams);
 #if defined(LAYOUT_HAS_AMS_STRIP)
 static void drawAmsZone(const BambuState& s, bool force);
 #endif
+// Defined next to drawGaugeTile(), used by both the Ready and Print Complete
+// screens - so it must sit outside every layout guard.
+static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
+                              int16_t leftX, int16_t rightX, int16_t cy, int16_t r,
+                              uint8_t* prevTypes, bool fr, bool* animatingOut);
 
 // Helper macro for the 240x240-only AMS-view feature (replaces gauge row 2
 // with an AMS strip). The HTML row, gauge gating, and dispatch are gated by
@@ -1561,16 +1566,12 @@ static void drawIdle() {
   const int16_t lyIdleGOffset   = LY_IDLE_G_OFFSET;
 #endif
 
-  bool animating = tickGaugeSmooth(s, forceRedraw);
-  gaugesAnimating = animating;
+  // Advances every smoother, which other screens rely on. gaugesAnimating is set
+  // further down from the two slots actually on screen.
+  tickGaugeSmooth(s, forceRedraw);
   bool stateChanged = forceRedraw ||
                       (s.gcodeStateId != prevState.gcodeStateId) ||
                       (strcmp(s.gcodeState, prevState.gcodeState) != 0);
-  bool tempChanged = forceRedraw || animating ||
-                     (s.nozzleTemp != prevState.nozzleTemp) ||
-                     (s.nozzleTarget != prevState.nozzleTarget) ||
-                     (s.bedTemp != prevState.bedTemp) ||
-                     (s.bedTarget != prevState.bedTarget);
   bool connChanged = forceRedraw || (s.connected != prevState.connected);
   bool wifiChanged = forceRedraw || (s.wifiSignal != prevState.wifiSignal);
 
@@ -1649,19 +1650,16 @@ static void drawIdle() {
     }
   }
 
-  // Nozzle temp gauge
-  if (tempChanged) {
-    markFrameDirty();
-    drawTempGauge(tft, cx - lyIdleGOffset, lyIdleGaugeY, lyIdleGaugeR,
-                  s.nozzleTemp, s.nozzleTarget, (float)dispSettings.nozzleScaleMax,
-                  dispSettings.nozzle.arc, nozzleLabel(s), nullptr, forceRedraw,
-                  &dispSettings.nozzle, smoothNozzleTemp);
-
-    // Bed temp gauge
-    drawTempGauge(tft, cx + lyIdleGOffset, lyIdleGaugeY, lyIdleGaugeR,
-                  s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                  dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, forceRedraw,
-                  &dispSettings.bed, smoothBedTemp);
+  // The two configurable gauges (#158). Same pair as the Print Complete screen.
+  {
+    static uint8_t prevIdleTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    bool slotsAnim = false;
+    if (drawIdlePairSlots(p.config, s, cx - lyIdleGOffset, cx + lyIdleGOffset,
+                          lyIdleGaugeY, lyIdleGaugeR, prevIdleTypes, forceRedraw,
+                          &slotsAnim)) {
+      markFrameDirty();
+    }
+    gaugesAnimating = slotsAnim;  // only the two shown gauges drive the tick rate
   }
 
   // AMS on idle (boards with permanent AMS strip)
@@ -2642,7 +2640,10 @@ void drawCameraGauge(int16_t, int16_t, int16_t, bool) {}
 bool gaugeTileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p) {
   switch (gt) {
     case GAUGE_PROGRESS:      return s.progress != p.progress || s.remainingMinutes != p.remainingMinutes;
-    case GAUGE_NOZZLE:        return s.nozzleTemp != p.nozzleTemp || s.nozzleTarget != p.nozzleTarget;
+    // Dual nozzle also flips this tile's label between "Nozzle R" and "Nozzle L",
+    // so a side switch at a steady temperature still needs a repaint.
+    case GAUGE_NOZZLE:        return s.nozzleTemp != p.nozzleTemp || s.nozzleTarget != p.nozzleTarget ||
+                                     s.dualNozzle != p.dualNozzle || s.activeNozzle != p.activeNozzle;
     case GAUGE_NOZZLE_RIGHT:  return s.nozzleTempN[0] != p.nozzleTempN[0] || s.nozzleTargetN[0] != p.nozzleTargetN[0];
     case GAUGE_NOZZLE_LEFT:   return s.nozzleTempN[1] != p.nozzleTempN[1] || s.nozzleTargetN[1] != p.nozzleTargetN[1];
     case GAUGE_BED:           return s.bedTemp != p.bedTemp || s.bedTarget != p.bedTarget;
@@ -2687,6 +2688,69 @@ bool gaugeTileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p)
     return false;
   }
   return false;
+}
+
+// True while this gauge type's own smoother is still interpolating. The Ready
+// and Print Complete screens need this rather than tickGaugeSmooth()'s return
+// value: that one aggregates every smoother, so a settling hidden fan would
+// repaint a steady slot - and repaint an AMS bars tile at the animation tick.
+static bool gaugeTypeAnimating(uint8_t gt, const BambuState& s) {
+  // Not named EPS: xtensa's specreg.h defines that as a register number.
+  const float ANIM_EPS = 0.01f;
+  switch (gt) {
+    case GAUGE_NOZZLE:        return fabsf(smoothNozzleTemp    - s.nozzleTemp)            > ANIM_EPS;
+    case GAUGE_NOZZLE_RIGHT:  return fabsf(smoothNozzleTempN[0] - s.nozzleTempN[0])       > ANIM_EPS;
+    case GAUGE_NOZZLE_LEFT:   return fabsf(smoothNozzleTempN[1] - s.nozzleTempN[1])       > ANIM_EPS;
+    case GAUGE_BED:           return fabsf(smoothBedTemp       - s.bedTemp)               > ANIM_EPS;
+    case GAUGE_CHAMBER_TEMP:  return fabsf(smoothChamberTemp   - s.chamberTemp)           > ANIM_EPS;
+    case GAUGE_PART_FAN:      return fabsf(smoothPartFan     - (float)s.coolingFanPct)    > ANIM_EPS;
+    case GAUGE_AUX_FAN:       return fabsf(smoothAuxFan      - (float)s.auxFanPct)        > ANIM_EPS;
+    case GAUGE_AUX_FAN_RIGHT: return fabsf(smoothAuxRightFan - (float)s.auxFanRightPct)   > ANIM_EPS;
+    case GAUGE_CHAMBER_FAN:   return fabsf(smoothChamberFan  - (float)s.chamberFanPct)    > ANIM_EPS;
+    case GAUGE_EXHAUST_FAN:   return fabsf(smoothExhaustFan  - (float)s.exhaustFanPct)    > ANIM_EPS;
+    case GAUGE_HEATBREAK:     return fabsf(smoothHeatbreakFan - (float)s.heatbreakFanPct) > ANIM_EPS;
+    default: return false;   // every other type renders straight from the value
+  }
+}
+
+// Draws the two configurable slots the Ready and Print Complete screens share.
+// Handles the type-change wipe: a layout saved from the web UI does not force a
+// redraw, so each screen keeps its own cache (0xFF = draw everything first time).
+// The clear is a square plus the label band, not a circle - AMS bars and
+// filament tiles paint into the corners of the slot box.
+// Returns true when anything was painted, and reports through animatingOut
+// whether either slot still needs the fast animation tick.
+static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
+                              int16_t leftX, int16_t rightX, int16_t cy, int16_t r,
+                              uint8_t* prevTypes, bool fr, bool* animatingOut) {
+  const int16_t xs[IDLE_SLOT_COUNT] = { leftX, rightX };
+  bool drew = false, anim = false;
+  for (uint8_t i = 0; i < IDLE_SLOT_COUNT; i++) {
+    uint8_t gt = cfg.idleSlots[i];
+    if (gt >= GAUGE_TYPE_COUNT) gt = GAUGE_EMPTY;
+    const bool typeChanged = (gt != prevTypes[i]);
+    if (typeChanged) {
+      if (!fr) {
+        const int16_t clearSz = r * 2 + 4;
+        tft.fillRect(xs[i] - r - 2, cy - r - 2, clearSz, clearSz, dispSettings.bgColor);
+        const bool sm = dispSettings.smallLabels;
+        const int16_t labelY = cy + r + (sm ? 3 : -1);
+        const int16_t lh = sm ? 18 : 24;
+        tft.fillRect(xs[i] - r - 2, labelY - lh / 2, clearSz, lh, dispSettings.bgColor);
+      }
+      prevTypes[i] = gt;
+      drew = true;
+    }
+    const bool slotAnim = gaugeTypeAnimating(gt, s);
+    if (slotAnim) anim = true;
+    if (fr || typeChanged || slotAnim || gaugeTileValueChanged(gt, s, prevState)) {
+      drawGaugeTile(gt, s, rotState.displayIndex, xs[i], cy, r, LY_GAUGE_T,
+                    fr || typeChanged, true);
+      drew = true;
+    }
+  }
+  if (animatingOut) *animatingOut = anim;
+  return drew;
 }
 
 // Reuses the shared gauge primitives. smooth=false: arcs snap to value (split -
@@ -4454,15 +4518,10 @@ static void drawFinished() {
 #endif
   const int16_t cx = scrW / 2;
 
-  bool animating = tickGaugeSmooth(s, forceRedraw);
-  gaugesAnimating = animating;  // finished screen was the only gauge screen not
-                                // reporting this, so its arcs settled at the slow
-                                // DISPLAY_UPDATE_MS tick instead of GAUGE_ANIM_MS
-  bool tempChanged = forceRedraw || animating ||
-                     (s.nozzleTemp != prevState.nozzleTemp) ||
-                     (s.nozzleTarget != prevState.nozzleTarget) ||
-                     (s.bedTemp != prevState.bedTemp) ||
-                     (s.bedTarget != prevState.bedTarget);
+  // Advances every smoother, which other screens rely on. gaugesAnimating is set
+  // further down from the two slots actually on screen - this screen used not to
+  // report it at all, so its arcs settled at the slow DISPLAY_UPDATE_MS tick.
+  tickGaugeSmooth(s, forceRedraw);
 
   // === H2-style LED progress bar at 100% (y=0-5) ===
   if (forceRedraw) {
@@ -4505,18 +4564,15 @@ static void drawFinished() {
     if (getActiveConnCount() > 1) drawPrinterDots(cx, finHdrDotCY);
   }
 
-  // === Row 1: Nozzle | Bed (two gauges centered) ===
-  if (tempChanged) {
-    markFrameDirty();
-    drawTempGauge(tft, gaugeLeft, gaugeY, gR,
-                  s.nozzleTemp, s.nozzleTarget, (float)dispSettings.nozzleScaleMax,
-                  dispSettings.nozzle.arc, nozzleLabel(s), nullptr, forceRedraw,
-                  &dispSettings.nozzle, smoothNozzleTemp);
-
-    drawTempGauge(tft, gaugeRight, gaugeY, gR,
-                  s.bedTemp, s.bedTarget, (float)dispSettings.bedScaleMax,
-                  dispSettings.bed.arc, gaugeLabelOr(gaugeLabels.bed, "Bed"), nullptr, forceRedraw,
-                  &dispSettings.bed, smoothBedTemp);
+  // === Row 1: the two configurable gauges (#158), shared with the Ready screen ===
+  {
+    static uint8_t prevFinTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    bool slotsAnim = false;
+    if (drawIdlePairSlots(p.config, s, gaugeLeft, gaugeRight, gaugeY, gR,
+                          prevFinTypes, forceRedraw, &slotsAnim)) {
+      markFrameDirty();
+    }
+    gaugesAnimating = slotsAnim;  // only the two shown gauges drive the tick rate
   }
 
   // === "Print Complete!" status ===

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -4412,6 +4412,9 @@ static void drawFinished() {
   const int16_t cx = scrW / 2;
 
   bool animating = tickGaugeSmooth(s, forceRedraw);
+  gaugesAnimating = animating;  // finished screen was the only gauge screen not
+                                // reporting this, so its arcs settled at the slow
+                                // DISPLAY_UPDATE_MS tick instead of GAUGE_ANIM_MS
   bool tempChanged = forceRedraw || animating ||
                      (s.nozzleTemp != prevState.nozzleTemp) ||
                      (s.nozzleTarget != prevState.nozzleTarget) ||

--- a/src/display_ui.cpp
+++ b/src/display_ui.cpp
@@ -1467,7 +1467,8 @@ static void drawAmsZone(const BambuState& s, bool force);
 // screens - so it must sit outside every layout guard.
 static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
                               int16_t leftX, int16_t rightX, int16_t cy, int16_t r,
-                              uint8_t* prevTypes, bool fr, bool* animatingOut);
+                              uint8_t* prevTypes, uint32_t* prevAirduct, bool fr,
+                              bool* animatingOut);
 
 // Helper macro for the 240x240-only AMS-view feature (replaces gauge row 2
 // with an AMS strip). The HTML row, gauge gating, and dispatch are gated by
@@ -1652,11 +1653,12 @@ static void drawIdle() {
 
   // The two configurable gauges (#158). Same pair as the Print Complete screen.
   {
-    static uint8_t prevIdleTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    static uint8_t  prevIdleTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    static uint32_t prevIdleAirduct = 0;
     bool slotsAnim = false;
     if (drawIdlePairSlots(p.config, s, cx - lyIdleGOffset, cx + lyIdleGOffset,
-                          lyIdleGaugeY, lyIdleGaugeR, prevIdleTypes, forceRedraw,
-                          &slotsAnim)) {
+                          lyIdleGaugeY, lyIdleGaugeR, prevIdleTypes,
+                          &prevIdleAirduct, forceRedraw, &slotsAnim)) {
       markFrameDirty();
     }
     gaugesAnimating = slotsAnim;  // only the two shown gauges drive the tick rate
@@ -2676,7 +2678,12 @@ bool gaugeTileValueChanged(uint8_t gt, const BambuState& s, const BambuState& p)
     uint8_t ui = isBars ? (gt - GAUGE_AMS_BARS_1) : (gt - GAUGE_AMS_FILAMENT_1);
     if (s.ams.present != p.ams.present || s.ams.unitCount != p.ams.unitCount) return true;
     const AmsUnit& cu = s.ams.units[ui]; const AmsUnit& pu = p.ams.units[ui];
-    if (cu.present != pu.present || (!isBars && cu.humidity != pu.humidity) ||
+    // humidityRaw as well as the legacy level: the filament tile tints its
+    // humidity dot through amsHumidityColor(), which prefers the raw RH when
+    // it is 1..100. A drift across a threshold (35/50/65) recolors the tile
+    // while the coarse level stays put.
+    if (cu.present != pu.present ||
+        (!isBars && (cu.humidity != pu.humidity || cu.humidityRaw != pu.humidityRaw)) ||
         cu.trayCount != pu.trayCount) return true;
     if (isBars && s.ams.activeTray != p.ams.activeTray) return true;
     for (int tr = 0; tr < AMS_TRAYS_PER_UNIT; tr++) {
@@ -2720,14 +2727,30 @@ static bool gaugeTypeAnimating(uint8_t gt, const BambuState& s) {
 // filament tiles paint into the corners of the slot box.
 // Returns true when anything was painted, and reports through animatingOut
 // whether either slot still needs the fast animation tick.
+// prevAirduct is caller-owned for the same reason prevTypes is: the Ready and
+// Print Complete screens each keep their own cache, and a file-scope static
+// would let whichever screen ran first swallow the change.
 static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
                               int16_t leftX, int16_t rightX, int16_t cy, int16_t r,
-                              uint8_t* prevTypes, bool fr, bool* animatingOut) {
+                              uint8_t* prevTypes, uint32_t* prevAirduct, bool fr,
+                              bool* animatingOut) {
   const int16_t xs[IDLE_SLOT_COUNT] = { leftX, rightX };
   bool drew = false, anim = false;
+  // GAUGE_AUX_FAN and GAUGE_CHAMBER_FAN pick their default label from
+  // s.airductFuncs (Aux vs L.Aux, Chamber vs Exhaust). The mask starts at 0 and
+  // only fills in on the first pushall carrying device.airduct.parts, so a
+  // label drawn on boot would stick: drawFanGauge repaints the label only
+  // inside its gaugeTextChanged() guard, which watches the percentage, and an
+  // idle chamber fan sits at 0 forever. Force those tiles through a full
+  // redraw when the mask moves (once per session in practice). Mirrors the
+  // printing grid's own invalidation.
+  const bool airductChanged = (*prevAirduct != s.airductFuncs);
+  *prevAirduct = s.airductFuncs;
   for (uint8_t i = 0; i < IDLE_SLOT_COUNT; i++) {
     uint8_t gt = cfg.idleSlots[i];
     if (gt >= GAUGE_TYPE_COUNT) gt = GAUGE_EMPTY;
+    const bool labelStale = airductChanged &&
+                            (gt == GAUGE_AUX_FAN || gt == GAUGE_CHAMBER_FAN);
     const bool typeChanged = (gt != prevTypes[i]);
     if (typeChanged) {
       if (!fr) {
@@ -2743,9 +2766,12 @@ static bool drawIdlePairSlots(const PrinterConfig& cfg, const BambuState& s,
     }
     const bool slotAnim = gaugeTypeAnimating(gt, s);
     if (slotAnim) anim = true;
-    if (fr || typeChanged || slotAnim || gaugeTileValueChanged(gt, s, prevState)) {
+    if (fr || typeChanged || labelStale || slotAnim ||
+        gaugeTileValueChanged(gt, s, prevState)) {
+      // labelStale forces the full-redraw path: drawGaugeLabel() clears its own
+      // band, so no separate wipe is needed for the wider replacement string.
       drawGaugeTile(gt, s, rotState.displayIndex, xs[i], cy, r, LY_GAUGE_T,
-                    fr || typeChanged, true);
+                    fr || typeChanged || labelStale, true);
       drew = true;
     }
   }
@@ -2966,9 +2992,16 @@ uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
 // ---------------------------------------------------------------------------
 void drawFinishHeadline(int16_t cx, int16_t y, int16_t maxW, const BambuState& s) {
   static const char* kMsg = "Print Complete!";
+  // Shorter wording, used only when the full headline plus the timestamp still
+  // overflows the budget at the small font (the round 240 screen in 12h mode:
+  // 213 px vs a 190 px rim-safe span). Keeping the time is worth more there
+  // than the longer phrasing, and it is the last step before the time is cut.
+  static const char* kMsgShort = "Completed";
 
-  char buf[40];
-  if (s.finishEpoch != 0) {
+  // Empty when the user turned the timestamp off, or when the print finished
+  // before NTP had a valid clock.
+  char clock[16] = "";
+  if (dpSettings.finishShowTime && s.finishEpoch != 0) {
     // localtime_r needs a real time_t; finishEpoch is stored as uint32_t so its
     // width does not depend on the toolchain.
     time_t stamp = (time_t)s.finishEpoch;
@@ -2976,26 +3009,36 @@ void drawFinishHeadline(int16_t cx, int16_t y, int16_t maxW, const BambuState& s
     localtime_r(&stamp, &ft);
     int hour = ft.tm_hour;
     if (netSettings.use24h) {
-      snprintf(buf, sizeof(buf), "%s @ %02d:%02d", kMsg, hour, ft.tm_min);
+      snprintf(clock, sizeof(clock), "%02d:%02d", hour, ft.tm_min);
     } else {
       // Uppercase AM/PM to match every other 12h renderer (clock screen, ETA line)
       const char* ampm = hour < 12 ? "AM" : "PM";
       hour %= 12;
       if (hour == 0) hour = 12;
-      snprintf(buf, sizeof(buf), "%s @ %d:%02d %s", kMsg, hour, ft.tm_min, ampm);
+      snprintf(clock, sizeof(clock), "%d:%02d %s", hour, ft.tm_min, ampm);
     }
-  } else {
-    strlcpy(buf, kMsg, sizeof(buf));
   }
 
-  // Largest font that fits. The time is the first thing sacrificed - the
-  // message itself always renders at full size on every layout profile.
+  char buf[40];
+  if (clock[0] == '\0') {
+    setFont(tft, FONT_LARGE);
+    tft.drawString(kMsg, cx, y);
+    return;
+  }
+
+  // Step down until it fits: full wording large -> full wording small ->
+  // short wording small -> no time, back to the full wording at full size.
+  // The message itself always renders on every layout profile.
+  snprintf(buf, sizeof(buf), "%s @ %s", kMsg, clock);
   setFont(tft, FONT_LARGE);
   if (maxW > 0 && tft.textWidth(buf) > maxW) {
     setFont(tft, FONT_BODY);
     if (tft.textWidth(buf) > maxW) {
-      strlcpy(buf, kMsg, sizeof(buf));
-      setFont(tft, FONT_LARGE);
+      snprintf(buf, sizeof(buf), "%s @ %s", kMsgShort, clock);
+      if (tft.textWidth(buf) > maxW) {
+        strlcpy(buf, kMsg, sizeof(buf));
+        setFont(tft, FONT_LARGE);
+      }
     }
   }
   tft.drawString(buf, cx, y);
@@ -3970,9 +4013,11 @@ static void drawPrinting() {
               if (!needDraw) {
                 const AmsUnit &cu = s.ams.units[ui], &pu = prevState.ams.units[ui];
                 // Bars gauge does not show humidity, so skip the humidity diff
-                // to avoid redundant redraws.
+                // to avoid redundant redraws. The filament tile needs the raw
+                // RH too - its humidity dot is colored by amsHumidityColor(),
+                // which prefers humidityRaw over the coarse level.
                 if (cu.present != pu.present
-                    || (!isBars && cu.humidity != pu.humidity)
+                    || (!isBars && (cu.humidity != pu.humidity || cu.humidityRaw != pu.humidityRaw))
                     || cu.trayCount != pu.trayCount) needDraw = true;
               }
               if (!needDraw && isBars && s.ams.activeTray != prevState.ams.activeTray) {
@@ -4418,8 +4463,7 @@ static void drawFinishedRound() {
 
     tft.setTextDatum(MC_DATUM);
     tft.setTextColor(CLR_GREEN, CLR_BG);
-    // 150 is the same rim-safe width the file name below uses
-    drawFinishHeadline(cx, LY_RND_FIN_TEXT_Y, 150, s);
+    drawFinishHeadline(cx, LY_RND_FIN_TEXT_Y, LY_RND_FIN_TEXT_MAXW, s);
 
     const char* rndFinName = jobDisplayName(s);
     if (rndFinName[0] != '\0') {
@@ -4566,10 +4610,11 @@ static void drawFinished() {
 
   // === Row 1: the two configurable gauges (#158), shared with the Ready screen ===
   {
-    static uint8_t prevFinTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    static uint8_t  prevFinTypes[IDLE_SLOT_COUNT] = { 0xFF, 0xFF };
+    static uint32_t prevFinAirduct = 0;
     bool slotsAnim = false;
     if (drawIdlePairSlots(p.config, s, gaugeLeft, gaugeRight, gaugeY, gR,
-                          prevFinTypes, forceRedraw, &slotsAnim)) {
+                          prevFinTypes, &prevFinAirduct, forceRedraw, &slotsAnim)) {
       markFrameDirty();
     }
     gaugesAnimating = slotsAnim;  // only the two shown gauges drive the tick rate

--- a/src/display_ui.h
+++ b/src/display_ui.h
@@ -158,4 +158,10 @@ void formatAmsDryName(char* out, size_t len, bool isHT, uint8_t displayNum,
 uint16_t formatEtaLine(uint16_t remainingMin, uint8_t mode, bool labelRemaining,
                        int16_t maxW, char* buf, size_t n);
 
+// Draws the finished screen's headline, centered on (cx, y): "Print Complete!"
+// on its own, or with the completion time appended when the finish was dated
+// (#158). Picks the largest font that fits maxW, dropping the time before it
+// gives up the message. The caller has already cleared the band.
+void drawFinishHeadline(int16_t cx, int16_t y, int16_t maxW, const BambuState& s);
+
 #endif // DISPLAY_UI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "camera_client.h"
 #include <esp_sleep.h>
 #include <driver/gpio.h>
+#include <time.h>
 
 static unsigned long splashEnd = 0;
 static unsigned long finishScreenStart = 0;
@@ -924,6 +925,21 @@ static void handleGcodeStateTransitions() {
         if (buzzerSettings.bedCooldownAlert) {
           ps.bedCooldownAlertArmed = true;
         }
+        // Completion time (#158). Only stamp a finish whose print start we
+        // actually saw - otherwise this edge could be a reconnect re-reporting
+        // an old FINISH, or the first report from a printer that was already
+        // done, and we would record "now" as the completion time. When we
+        // cannot date a finish, show nothing rather than the previous print's
+        // time. Deliberately not folded into the finishBuzzerPlayed latch
+        // below: updateDisplayedPrinterScreenState() runs earlier in the loop
+        // and has already set that flag for the printer that is on screen.
+        if (!ps.finishTimeLatched) {
+          time_t nowEpoch = time(nullptr);
+          ps.finishEpoch = (nowEpoch > NTP_SYNCED_EPOCH) ? (uint32_t)nowEpoch : 0;
+          ps.finishTimeLatched = true;
+        } else {
+          ps.finishEpoch = 0;
+        }
         // Announce the finish even if this slot is not the one on screen: fire the
         // one-shot per-slot alert, snap the display to the finished slot, and hold
         // it there for one rotation interval so the finish screen is seen. The
@@ -961,6 +977,8 @@ static void handleGcodeStateTransitions() {
           !isPrintingGcodeState(prevGcodeStateId[i])) {
         ps.bedCooldownAlertArmed = false;
         ps.finishBuzzerPlayed = false;  // per-slot reset so a hidden printer's next finish still beeps
+        ps.finishEpoch = 0;
+        ps.finishTimeLatched = false;   // arm: this print's finish is ours to stamp
         if (printers[i].config.lightFlags & LIGHT_ON_AT_START)
           requestLightCommand(i, true);  // also cancels any pending auto-off
       }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -461,6 +461,9 @@ void loadSettings() {
     // Zero out state
     memset(&printers[i].state, 0, sizeof(BambuState));
     printers[i].state.lightState = -1;  // unknown until lights_report arrives
+    // Latched, not armed: a printer that is already FINISH when we connect must
+    // not have the connection time recorded as its completion time
+    printers[i].state.finishTimeLatched = true;
     // 0 is a valid tray index (AMS 1 slot 1) - if the active tray is never
     // resolved the filament swatch would show that tray's data
     printers[i].state.ams.activeTray = 255;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -661,6 +661,7 @@ void loadSettings() {
   dpSettings.showClockAfterFinish = prefs.getBool("dp_clock", true);
   dpSettings.doorAckEnabled = prefs.getBool("dp_dack", false);
   dpSettings.keepPrintScreen = prefs.getBool("dp_kps", false);
+  dpSettings.finishShowTime = prefs.getBool("dp_fintm", true);
   dpSettings.nightModeEnabled = prefs.getBool("dp_night", false);
   dpSettings.nightStartHour = prefs.getUChar("dp_nstart", 22);
   dpSettings.nightEndHour = prefs.getUChar("dp_nend", 7);
@@ -918,6 +919,7 @@ void saveSettings() {
   prefs.putBool("dp_clock", dpSettings.showClockAfterFinish);
   prefs.putBool("dp_dack", dpSettings.doorAckEnabled);
   prefs.putBool("dp_kps", dpSettings.keepPrintScreen);
+  prefs.putBool("dp_fintm", dpSettings.finishShowTime);
   prefs.putBool("dp_night", dpSettings.nightModeEnabled);
   prefs.putUChar("dp_nstart", dpSettings.nightStartHour);
   prefs.putUChar("dp_nend", dpSettings.nightEndHour);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -626,17 +626,7 @@ void loadSettings() {
 
   // Re-resolve the index from the POSIX string (handles database reordering
   // across firmware updates without relying on a stored index value).
-  {
-    size_t cnt;
-    const TimezoneRegion* regions = getSupportedTimezones(&cnt);
-    netSettings.timezoneIndex = 14;  // default: CET (Amsterdam, Berlin, Rome)
-    for (size_t i = 0; i < cnt; i++) {
-      if (strcmp(regions[i].posixString, netSettings.timezoneStr) == 0) {
-        netSettings.timezoneIndex = (uint8_t)i;
-        break;
-      }
-    }
-  }
+  netSettings.timezoneIndex = resolveTimezoneIndex(netSettings.timezoneStr);
 
   netSettings.use24h = prefs.getBool("net_24h", true);
   netSettings.dateFormat = prefs.getUChar("net_datefmt", 0);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -243,6 +243,13 @@ static void defaultGaugeSlots(uint8_t* slots) {
 #endif
 }
 
+// Default Ready / Print Complete pair: the nozzle and bed gauges those screens
+// drew before the slots became configurable.
+static void defaultIdleSlots(uint8_t* slots) {
+  slots[0] = GAUGE_NOZZLE;
+  slots[1] = GAUGE_BED;
+}
+
 // ---------------------------------------------------------------------------
 //  Save/load a single GaugeColors struct
 // ---------------------------------------------------------------------------
@@ -446,6 +453,20 @@ void loadSettings() {
     prefs.getBytes(key, cfg.portraitExtras, sizeof(cfg.portraitExtras));
     for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT; g++) {
       if (cfg.portraitExtras[g] >= GAUGE_TYPE_COUNT) cfg.portraitExtras[g] = GAUGE_EMPTY;
+    }
+
+    // Ready / Print Complete pair. A missing key means a config written before
+    // these were configurable, so fall back to the nozzle+bed those screens
+    // always drew.
+    snprintf(key, sizeof(key), "p%d_islot", i);
+    defaultIdleSlots(cfg.idleSlots);
+    prefs.getBytes(key, cfg.idleSlots, sizeof(cfg.idleSlots));
+    for (uint8_t g = 0; g < IDLE_SLOT_COUNT; g++) {
+      // GAUGE_CAMERA is rejected, not just range-checked: the camera tile
+      // renders on its own cadence and camera_client only starts a stream for
+      // types parked in gaugeSlots, so it would freeze as a stale still here.
+      if (cfg.idleSlots[g] >= GAUGE_TYPE_COUNT || cfg.idleSlots[g] == GAUGE_CAMERA)
+        cfg.idleSlots[g] = GAUGE_EMPTY;
     }
 
     // AMS view (per-printer): 240x240 only, replaces gauge row 2 with AMS strip
@@ -982,6 +1003,8 @@ void savePrinterConfig(uint8_t index) {
   prefs.putBytes(key, cfg.landscapeExtras, sizeof(cfg.landscapeExtras));
   snprintf(key, sizeof(key), "p%d_pext", index);
   prefs.putBytes(key, cfg.portraitExtras, sizeof(cfg.portraitExtras));
+  snprintf(key, sizeof(key), "p%d_islot", index);
+  prefs.putBytes(key, cfg.idleSlots, sizeof(cfg.idleSlots));
 
   snprintf(key, sizeof(key), "p%d_amsv", index);
   prefs.putBool(key, cfg.amsView);
@@ -1002,6 +1025,7 @@ void clearPrinterConfig(uint8_t index) {
   cfg.region = REGION_US;
   cfg.lightOffDelayMin = 5;  // sensible default after a slot is cleared
   defaultGaugeSlots(cfg.gaugeSlots);
+  defaultIdleSlots(cfg.idleSlots);
   memset(cfg.landscapeExtras, GAUGE_EMPTY, sizeof(cfg.landscapeExtras));
   memset(cfg.portraitExtras, GAUGE_EMPTY, sizeof(cfg.portraitExtras));
   savePrinterConfig(index);

--- a/src/settings.h
+++ b/src/settings.h
@@ -196,6 +196,8 @@ struct DisplayPowerSettings {
   bool showClockAfterFinish;   // show clock instead of turning display off
   bool doorAckEnabled;         // wait for door open after print finish before timeout
   bool keepPrintScreen;        // show printing screen instead of finish screen after print
+  bool finishShowTime;         // append the completion clock time to the finish headline
+                               // (costs the large font on 240 px wide layouts)
   // Night mode (scheduled dimming)
   bool nightModeEnabled;       // enable time-based dimming
   uint8_t nightStartHour;      // dim start hour (0-23)

--- a/src/settings.h
+++ b/src/settings.h
@@ -49,6 +49,10 @@ static const uint8_t GAUGE_SLOT_COUNT = 6;
 // type for "col 4 row 1" and "row 3 col 1" can be set independently.
 static const uint8_t LANDSCAPE_EXTRA_COUNT = 2;  // col 4 top, col 4 bot
 static const uint8_t PORTRAIT_EXTRA_COUNT  = 3;  // row 3 left, mid, right
+// The Ready and Print Complete screens show two gauges side by side, in their
+// own slots so they can differ from the print-screen grid (e.g. chamber temp
+// while a part cools). Shared by both screens - they never appear together.
+static const uint8_t IDLE_SLOT_COUNT = 2;        // left, right
 // Max slots displayed by any mode at once. Used to size per-frame slot caches
 // in display_ui.cpp (prevSlotTypes, SlotGrid arrays).
 static const uint8_t GAUGE_SLOT_MAX = GAUGE_SLOT_COUNT + PORTRAIT_EXTRA_COUNT;  // 9

--- a/src/timezones.cpp
+++ b/src/timezones.cpp
@@ -13,6 +13,7 @@ static const TimezoneRegion timezoneDatabase[] = {
   {"(UTC-09:00) Alaska",                                         "AKST9AKDT,M3.2.0/02:00,M11.1.0/02:00"},
   {"(UTC-08:00) Pacific Time (Los Angeles, Vancouver)",          "PST8PDT,M3.2.0/02:00,M11.1.0/02:00"},
   {"(UTC-07:00) Mountain Time (Denver, Edmonton)",               "MST7MDT,M3.2.0/02:00,M11.1.0/02:00"},
+  {"(UTC-07:00) Arizona (Phoenix)",                              "MST7"},
   {"(UTC-06:00) Central Time (Chicago, Winnipeg)",               "CST6CDT,M3.2.0/02:00,M11.1.0/02:00"},
   {"(UTC-06:00) Mexico City",                                    "CST6CDT,M4.1.0/02:00,M10.5.0/02:00"},
   {"(UTC-05:00) Eastern Time (New York, Toronto)",               "EST5EDT,M3.2.0/02:00,M11.1.0/02:00"},
@@ -57,6 +58,22 @@ static const size_t TIMEZONE_COUNT = sizeof(timezoneDatabase) / sizeof(TimezoneR
 const TimezoneRegion* getSupportedTimezones(size_t* count) {
   if (count) *count = TIMEZONE_COUNT;
   return timezoneDatabase;
+}
+
+uint8_t resolveTimezoneIndex(const char* posixString) {
+  if (posixString && posixString[0] != '\0') {
+    for (size_t i = 0; i < TIMEZONE_COUNT; i++) {
+      if (strcmp(timezoneDatabase[i].posixString, posixString) == 0) return (uint8_t)i;
+    }
+  }
+  // No match (empty value, or a string from a newer firmware). Fall back to CET
+  // by looking the entry up rather than hardcoding its position - the database
+  // is ordered by UTC offset, so any inserted region shifts every index after it.
+  for (size_t i = 0; i < TIMEZONE_COUNT; i++) {
+    if (strcmp(timezoneDatabase[i].posixString, "CET-1CEST,M3.5.0/02:00,M10.5.0/03:00") == 0)
+      return (uint8_t)i;
+  }
+  return 0;
 }
 
 const char* getDefaultTimezoneForOffset(int gmtOffsetMinutes) {

--- a/src/timezones.h
+++ b/src/timezones.h
@@ -14,4 +14,9 @@ const TimezoneRegion* getSupportedTimezones(size_t* count);
 // Get default POSIX TZ string for old gmtOffsetMin value (migration)
 const char* getDefaultTimezoneForOffset(int gmtOffsetMinutes);
 
+// Resolve a POSIX TZ string back to its database index. Falls back to CET when
+// the string is unknown. Never rely on a stored index - the database is sorted
+// by UTC offset, so adding a region renumbers everything after it.
+uint8_t resolveTimezoneIndex(const char* posixString);
+
 #endif // TIMEZONES_H

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -159,6 +159,7 @@ static void readDisplayFromForm() {
     dpSettings.showClockAfterFinish = server.hasArg("clock");
   dpSettings.doorAckEnabled = server.hasArg("dack");
   dpSettings.keepPrintScreen = server.hasArg("kps");
+  dpSettings.finishShowTime = server.hasArg("fintm");
   dispSettings.animatedBar = server.hasArg("abar");
   dispSettings.pongClock = server.hasArg("pong");
   dispSettings.smallLabels = server.hasArg("slbl");
@@ -577,6 +578,7 @@ static void handleToggleSetting() {
   else if (key == "clock")   dpSettings.showClockAfterFinish = on;
   else if (key == "dack")    dpSettings.doorAckEnabled = on;
   else if (key == "kps")     dpSettings.keepPrintScreen = on;
+  else if (key == "fintm")   dpSettings.finishShowTime = on;
   else if (key == "abar")    dispSettings.animatedBar = on;
   else if (key == "pong")    dispSettings.pongClock = on;
   else if (key == "slbl")    dispSettings.smallLabels = on;
@@ -610,7 +612,11 @@ static void handleToggleSetting() {
   }
 
   saveSettings();
-  if (key == "invcol" || key == "slbl" || key == "abar" || key == "timem") applyDisplaySettings();
+  // "fintm" joins these because it rewrites text already on screen: the finish
+  // headline is painted only under forceRedraw, so without a re-render the
+  // toggle would appear to do nothing until the next print.
+  if (key == "invcol" || key == "slbl" || key == "abar" || key == "timem" ||
+      key == "fintm") applyDisplaySettings();
   if (key == "cydcls") scheduleRestart(800);  // panel swap needs a fresh init
   if (key == "cyd32e") scheduleRestart(800);  // re-init amp enable + RGB pins cleanly
   if (key == "rskin") triggerDisplayTransition();  // repaint print dashboard with the new skin
@@ -1213,6 +1219,7 @@ static void handleSettingsExport() {
   dp["keepDisplayOn"] = dpSettings.keepDisplayOn;
   dp["showClockAfterFinish"] = dpSettings.showClockAfterFinish;
   dp["doorAckEnabled"] = dpSettings.doorAckEnabled;
+  dp["finishShowTime"] = dpSettings.finishShowTime;
   dp["nightModeEnabled"] = dpSettings.nightModeEnabled;
   dp["nightStartHour"] = dpSettings.nightStartHour;
   dp["nightEndHour"] = dpSettings.nightEndHour;
@@ -1570,6 +1577,7 @@ static void handleSettingsImportFinish() {
     if (dp["keepDisplayOn"].is<bool>())         dpSettings.keepDisplayOn = dp["keepDisplayOn"].as<bool>();
     if (dp["showClockAfterFinish"].is<bool>())  dpSettings.showClockAfterFinish = dp["showClockAfterFinish"].as<bool>();
     if (dp["doorAckEnabled"].is<bool>())        dpSettings.doorAckEnabled = dp["doorAckEnabled"].as<bool>();
+    if (dp["finishShowTime"].is<bool>())        dpSettings.finishShowTime = dp["finishShowTime"].as<bool>();
     if (dp["nightModeEnabled"].is<bool>())      dpSettings.nightModeEnabled = dp["nightModeEnabled"].as<bool>();
     if (dp["nightStartHour"].is<uint8_t>())     dpSettings.nightStartHour = dp["nightStartHour"].as<uint8_t>();
     if (dp["nightEndHour"].is<uint8_t>())       dpSettings.nightEndHour = dp["nightEndHour"].as<uint8_t>();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1561,12 +1561,17 @@ static void handleSettingsImportFinish() {
     if (net["dns"].is<const char*>())         strlcpy(netSettings.dns, net["dns"], sizeof(netSettings.dns));
     if (net["timezoneStr"].is<const char*>()) {
       strlcpy(netSettings.timezoneStr, net["timezoneStr"], sizeof(netSettings.timezoneStr));
-      netSettings.timezoneIndex = net["timezoneIndex"] | (uint8_t)3;
+      // Derive the index from the string, never from the backup's stored index:
+      // a backup taken on an older firmware numbered the database differently.
+      netSettings.timezoneIndex = resolveTimezoneIndex(netSettings.timezoneStr);
     } else if (net["gmtOffsetMin"].is<int16_t>()) {
       // Backward compat: import from old format
       int16_t oldOffset = net["gmtOffsetMin"].as<int16_t>();
       const char* migrated = getDefaultTimezoneForOffset(oldOffset);
-      if (migrated) strlcpy(netSettings.timezoneStr, migrated, sizeof(netSettings.timezoneStr));
+      if (migrated) {
+        strlcpy(netSettings.timezoneStr, migrated, sizeof(netSettings.timezoneStr));
+        netSettings.timezoneIndex = resolveTimezoneIndex(netSettings.timezoneStr);
+      }
     }
     if (net["use24h"].is<bool>())             netSettings.use24h = net["use24h"].as<bool>();
     if (net["dateFormat"].is<uint8_t>())     netSettings.dateFormat = net["dateFormat"].as<uint8_t>();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -349,6 +349,13 @@ static void handleSaveGaugeLayout() {
   for (uint8_t g = 0; g < GAUGE_SLOT_COUNT;       g++) readSlotArg("gs", g, cfg.gaugeSlots[g]);
   for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT;  g++) readSlotArg("lx", g, cfg.landscapeExtras[g]);
   for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;   g++) readSlotArg("px", g, cfg.portraitExtras[g]);
+  for (uint8_t g = 0; g < IDLE_SLOT_COUNT;        g++) {
+    readSlotArg("is", g, cfg.idleSlots[g]);
+    // The Ready / Print Complete screens redraw only on change, while the
+    // camera tile paints on its own cadence and camera_client only streams for
+    // a type parked in gaugeSlots - it would sit there as a stale frame.
+    if (cfg.idleSlots[g] == GAUGE_CAMERA) cfg.idleSlots[g] = GAUGE_EMPTY;
+  }
   cfg.amsView = server.hasArg("amsv");
 
   savePrinterConfig(slot);
@@ -725,6 +732,8 @@ static void handlePrinterConfig() {
   for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT; g++) lext.add(cfg.landscapeExtras[g]);
   JsonArray pext = doc["portraitExtras"].to<JsonArray>();
   for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
+  JsonArray islot = doc["idleSlots"].to<JsonArray>();
+  for (uint8_t g = 0; g < IDLE_SLOT_COUNT;       g++) islot.add(cfg.idleSlots[g]);
   doc["amsView"] = cfg.amsView;
   doc["lightFlags"] = cfg.lightFlags;       // chamber-light automation bitmask
   doc["lightDelay"] = cfg.lightOffDelayMin; // off delay (minutes)
@@ -1122,6 +1131,8 @@ static void handleSettingsExport() {
     for (uint8_t g = 0; g < LANDSCAPE_EXTRA_COUNT; g++) lext.add(cfg.landscapeExtras[g]);
     JsonArray pext = p["portraitExtras"].to<JsonArray>();
     for (uint8_t g = 0; g < PORTRAIT_EXTRA_COUNT;  g++) pext.add(cfg.portraitExtras[g]);
+    JsonArray islot = p["idleSlots"].to<JsonArray>();
+    for (uint8_t g = 0; g < IDLE_SLOT_COUNT;       g++) islot.add(cfg.idleSlots[g]);
     p["amsView"] = cfg.amsView;
     p["lightFlags"] = cfg.lightFlags;       // chamber-light automation bitmask
     p["lightDelay"] = cfg.lightOffDelayMin; // off delay (minutes)
@@ -1437,6 +1448,21 @@ static void handleSettingsImportFinish() {
       };
       importExtras(p["landscapeExtras"].as<JsonArray>(), cfg.landscapeExtras, LANDSCAPE_EXTRA_COUNT);
       importExtras(p["portraitExtras"].as<JsonArray>(),  cfg.portraitExtras,  PORTRAIT_EXTRA_COUNT);
+      // Ready / Print Complete pair. Backups predating it have no field, so
+      // restore the nozzle+bed those screens used to draw rather than blanking
+      // them. Camera is refused here too - see handleSaveGaugeLayout.
+      {
+        JsonArray islot = p["idleSlots"].as<JsonArray>();
+        static const uint8_t defIdle[IDLE_SLOT_COUNT] = { GAUGE_NOZZLE, GAUGE_BED };
+        for (uint8_t g = 0; g < IDLE_SLOT_COUNT; g++) {
+          if (islot && g < islot.size()) {
+            uint8_t v = islot[g].as<uint8_t>();
+            cfg.idleSlots[g] = (v < GAUGE_TYPE_COUNT && v != GAUGE_CAMERA) ? v : GAUGE_EMPTY;
+          } else {
+            cfg.idleSlots[g] = defIdle[g];
+          }
+        }
+      }
       if (p["amsView"].is<bool>()) {
         cfg.amsView = p["amsView"].as<bool>();
       } else if (legacyAmsViewPresent) {

--- a/src/web_template.cpp
+++ b/src/web_template.cpp
@@ -227,6 +227,7 @@ static bool resolvePlaceholder(const char* name, String& out) {
   // --- Display options ---
   if (strcmp(name, "DACK") == 0)   { out = dpSettings.doorAckEnabled ? "checked" : ""; return true; }
   if (strcmp(name, "KPS") == 0)    { out = dpSettings.keepPrintScreen ? "checked" : ""; return true; }
+  if (strcmp(name, "FINTM") == 0)  { out = dpSettings.finishShowTime ? "checked" : ""; return true; }
   if (strcmp(name, "ABAR") == 0)   { out = dispSettings.animatedBar ? "checked" : ""; return true; }
   if (strcmp(name, "PONG") == 0)   { out = dispSettings.pongClock ? "checked" : ""; return true; }
   if (strcmp(name, "SLBL") == 0)   { out = dispSettings.smallLabels ? "checked" : ""; return true; }


### PR DESCRIPTION
Two requested features plus the fixes that came out of reviewing them. Addresses #157 and #158.

## Phoenix timezone (#157)

Arizona does not observe DST, so none of the existing US entries fit. Added a dedicated `MST7` entry to the timezone database.

## Print complete screen (#158)

**Completion time in the headline.** The finish screen now shows the wall-clock time the print ended, e.g. `Print Complete! @ 14:32`, in whichever 12h/24h format the clock screen is set to.

Only a finish whose print start was actually observed gets stamped. A reconnect re-reporting an old FINISH, or the first report from a printer that was already done when the device booted, would otherwise record "now" as the completion time. When a finish cannot be dated, nothing is shown rather than the previous print's time. NTP is checked too: an epoch below 2024-01-01 means the RTC never synced, so the reading is discarded.

**Configurable gauges on the Ready and Print complete screens.** Those two screens always drew Nozzle and Bed. They now take a per-printer pair from the Gauge Layout card, so you can watch chamber temperature while a part cools, or park an AMS humidity tile there. Defaults to Nozzle/Bed, which is what they always drew.

The camera tile is excluded from this pair: it paints on its own cadence and the stream only starts for a slot in the print grid, so it would sit there as a frozen frame. Filtered in the web UI and clamped server-side on both the form and the JSON import path.

**Landscape gauge clearance.** On 240x320 in landscape the finished-screen gauges were centered at y=50, which put the R=32 arcs at y=18..82 - nine pixels up inside the header bar, slicing through the printer name. The whole block moved down to y=62. The layout header now records the real measured VLW font extents instead of the nominal "font 4 ~26px" estimates, so the next person editing those constants has the actual numbers.

**Animation rate.** The finished screen ran at the slow tick, so a settling gauge stepped visibly. It now runs at the gauge animation rate while either of its two slots is still interpolating, and drops back when they settle.

## Fixes from review

**The round display discarded the completion time entirely.** The headline had a 150 px budget, but `Print Complete! @ HH:MM` measures 187 px at FONT_BODY in 24h mode and 213 px in 12h, so it always fell through to the untimed fallback. Widths measured by summing xAdvance out of the VLW blobs, not estimated.

The real rim-safe span at that line is 202 px (ring inner edge 111, the FONT_BODY line reaches dy 46 from center, chord = 2*sqrt(111^2 - 46^2)), so the budget is now a derived constant with the arithmetic written down. The ladder also gains a shorter `Completed @ HH:MM` step (179 px) before it gives up on the time. Layouts that already fit the full wording are untouched.

**Stale Aux and Chamber labels on the new gauge pair.** Those tiles pick their label from the airduct bitmask, which starts empty and only fills in on the first pushall carrying `device.airduct.parts`. A value diff is not enough to refresh them: the fan gauge repaints its label only inside the guard that watches the percentage, and an idle chamber fan sits at zero forever. Those tiles now take the full-redraw path when the mask moves. Tracked per screen, since Ready and Print complete share the renderer and a shared latch would let whichever ran first swallow the change. The printing grid already had this invalidation; the new shared path did not.

**AMS filament tile ignored the raw humidity.** Its indicator color comes from `amsHumidityColor()`, which prefers the raw RH when it is 1..100, but change detection only compared the coarse level. A drift across a threshold (35/50/65) recolored nothing. Fixed in the shared helper and in the printing grid it was extracted from, which had the same omission.

## New setting

**"Show the completion time on the finish screen"**, under *After a print completes*. Default on.

This is not cosmetic preference. The headline picks the largest font that fits, and on every 240 px wide board the timed line does not fit at FONT_LARGE, so switching the time on drops the headline to FONT_BODY:

| screen width | `Print Complete! @ 02:34` at FONT_LARGE | result |
|---|---|---|
| 240 (esp32s3, cyd portrait, esp32c3, ws_lcd_200 portrait) | 264 px vs 228 budget | falls back to FONT_BODY |
| 320 and wider (jc3248w535, landscape, 480x480) | 264 px vs 308 budget | stays FONT_LARGE |

Turning it off keeps the headline large. Persisted to NVS and carried in settings export/import.

## Round display caveat

The round Print complete screen is a fixed layout - gold rim ring, checkmark, headline, file name, energy line - with no room for two R=30 gauges without dropping the checkmark. The round Ready screen does honour the pair. Rather than ship a setting that half works, the Gauge Layout card relabels that section to "Ready screen" on round builds and says so in the description.

## Testing

Built clean on `esp32c3_round`, `ws_lcd_200`, and `cyd` - covering the round profile, 240x320 with the landscape and AMS sidebar paths, and the low-RAM classic ESP32. `esp32c3_round` is now the tightest board at 93.8% flash.

Flashed over OTA and running on the round GC9A01 unit and the Waveshare 2.0" unit.
