### PR TITLE
Fix screensaver wake with LED enabled on AXS15231B

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -492,13 +492,13 @@ static void handleWakeButton() {
   uint32_t boardHoldMs = boardButtonHoldDurationMs();
   uint32_t holdMs = (touchHoldMs > boardHoldMs) ? touchHoldMs : boardHoldMs;
   bool suppressDim = isBoardButton3Held();
-#if defined(USE_XPT2046)
+#if defined(USE_XPT2046) || defined(USE_AXS_TOUCH)
   // Resistive panels (CYD, TZT) register a wake touch as a long press that
   // easily crosses the 300ms hold threshold. That would ramp the LED (default
   // direction is up, toward max), save it, and consume the press so the screen
   // never wakes. Suppress dimming while asleep so the touch only wakes.
-  // Capacitive panels get crisp short taps and keep hold-to-dim on the
-  // screensaver, so this gate is XPT2046-only.
+  // Most capacitive panels get crisp short taps and keep hold-to-dim on the
+  // screensaver, but AXS15231B requires the same suppression as XPT2046.
   if (isSleepStickyScreen(getScreenState())) suppressDim = true;
 #endif
 


### PR DESCRIPTION
Hi Rafał,

I use BambuHelper with a JC3248W535 (AXS15231B) display and noticed an issue when LED control is enabled.

Once the display enters the screensaver, tapping the touchscreen produces the usual click sound, so the touch is clearly detected, but the display does not exit the screensaver and return to the normal screen. This happens whenever LED control is enabled, regardless of which LED pin I configure.

I tried to fix it by applying the existing XPT2046 suppressDim workaround to USE_AXS_TOUCH as well. With this change, waking from the screensaver works correctly on my JC3248W535.

My C++/embedded development knowledge is fairly basic, so please let me know if this is not the right way to fix the issue. I would appreciate any corrections or suggestions.

And thank you for creating this project in the first place. It's a really cool and useful!